### PR TITLE
Updated admin labels in EG

### DIFF
--- a/data/109/201/400/5/1092014005.geojson
+++ b/data/109/201/400/5/1092014005.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":30.317323,
     "geom:longitude":31.697321,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "10th Ramadan City Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "10th Ramadan City Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":30.317905,
     "lbl:longitude":31.697321,
     "meso:admin_1":"Sharkia",
@@ -54,7 +69,7 @@
         }
     ],
     "wof:id":1092014005,
-    "wof:lastmodified":1536615081,
+    "wof:lastmodified":1560969123,
     "wof:name":"10th Ramadan City",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/201/400/7/1092014007.geojson
+++ b/data/109/201/400/7/1092014007.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":29.845635,
     "geom:longitude":31.357065,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "15 Mayo Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "15 Mayo Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092014007,
-    "wof:lastmodified":1553718032,
+    "wof:lastmodified":1560969123,
     "wof:name":"15 Mayo",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/400/9/1092014009.geojson
+++ b/data/109/201/400/9/1092014009.geojson
@@ -10,8 +10,17 @@
     "geom:latitude":29.965614,
     "geom:longitude":30.899814,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "6th October City Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
-        "6th October City"
+        "6th October City Kism"
     ],
     "label:eng_x_preferred_placetype":[
         "kism"
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092014009,
-    "wof:lastmodified":1555092024,
+    "wof:lastmodified":1560969122,
     "wof:name":"6th October City",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/201/401/1/1092014011.geojson
+++ b/data/109/201/401/1/1092014011.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.045936,
     "geom:longitude":31.244268,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Abdeen Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Abdeen Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092014011,
-    "wof:lastmodified":1553718030,
+    "wof:lastmodified":1560969122,
     "wof:name":"Abdeen",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/404/3/1092014043.geojson
+++ b/data/109/201/404/3/1092014043.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":27.281233,
     "geom:longitude":31.0897,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Abnoob Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Abnoob District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":27.286063,
     "lbl:longitude":31.089675,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092014043,
-    "wof:lastmodified":1553718030,
+    "wof:lastmodified":1560969126,
     "wof:name":"Abnoob",
     "wof:parent_id":85671069,
     "wof:placetype":"county",

--- a/data/109/201/406/1/1092014061.geojson
+++ b/data/109/201/406/1/1092014061.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.804931,
     "geom:longitude":30.100623,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Abu El-Matameer Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Abu El-Matameer District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.806953,
     "lbl:longitude":30.096741,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092014061,
-    "wof:lastmodified":1553718030,
+    "wof:lastmodified":1560969122,
     "wof:name":"Abu El-Matameer",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/201/410/3/1092014103.geojson
+++ b/data/109/201/410/3/1092014103.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.533564,
     "geom:longitude":31.689563,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Abu Hammad Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Abu Hammad District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.525574,
     "lbl:longitude":31.656831,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092014103,
-    "wof:lastmodified":1553718030,
+    "wof:lastmodified":1560969124,
     "wof:name":"Abu Hammad",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/201/413/3/1092014133.geojson
+++ b/data/109/201/413/3/1092014133.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.106127,
     "geom:longitude":30.310873,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Abu Homos Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Abu Homos District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.106968,
     "lbl:longitude":30.313635,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092014133,
-    "wof:lastmodified":1553718030,
+    "wof:lastmodified":1560969121,
     "wof:name":"Abu Homos",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/201/417/5/1092014175.geojson
+++ b/data/109/201/417/5/1092014175.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.736363,
     "geom:longitude":31.701558,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Abu Kebeer Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Abu Kebeer District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.726973,
     "lbl:longitude":31.695005,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092014175,
-    "wof:lastmodified":1553718030,
+    "wof:lastmodified":1560969124,
     "wof:name":"Abu Kebeer",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/201/422/1/1092014221.geojson
+++ b/data/109/201/422/1/1092014221.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":27.929599,
     "geom:longitude":30.769992,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Abu Qorqas Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Abu Qorqas District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":27.925517,
     "lbl:longitude":30.788382,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092014221,
-    "wof:lastmodified":1553718031,
+    "wof:lastmodified":1560969121,
     "wof:name":"Abu Qorqas",
     "wof:parent_id":85671049,
     "wof:placetype":"county",

--- a/data/109/201/426/7/1092014267.geojson
+++ b/data/109/201/426/7/1092014267.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":28.740967,
     "geom:longitude":33.489884,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Abu Redeis Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Abu Redeis Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092014267,
-    "wof:lastmodified":1553718030,
+    "wof:lastmodified":1560969124,
     "wof:name":"Abu Redeis",
     "wof:parent_id":85671089,
     "wof:placetype":"county",

--- a/data/109/201/431/3/1092014313.geojson
+++ b/data/109/201/431/3/1092014313.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":27.025213,
     "geom:longitude":31.280538,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Abu Teeg Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Abu Teeg District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":27.019936,
     "lbl:longitude":31.275813,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092014313,
-    "wof:lastmodified":1553718030,
+    "wof:lastmodified":1560969122,
     "wof:name":"Abu Teeg",
     "wof:parent_id":85671069,
     "wof:placetype":"county",

--- a/data/109/201/435/7/1092014357.geojson
+++ b/data/109/201/435/7/1092014357.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":26.128177,
     "geom:longitude":32.084324,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Abu Tesht Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Abu Tesht District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":26.130058,
     "lbl:longitude":32.082808,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092014357,
-    "wof:lastmodified":1553718032,
+    "wof:lastmodified":1560969125,
     "wof:name":"Abu Tesht",
     "wof:parent_id":85671075,
     "wof:placetype":"county",

--- a/data/109/201/440/3/1092014403.geojson
+++ b/data/109/201/440/3/1092014403.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":29.194804,
     "geom:longitude":33.34349,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Abu Zeneimah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Abu Zeneimah Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":29.176642,
     "lbl:longitude":33.304332,
     "meso:admin_1":"South Sinai",
@@ -53,7 +68,7 @@
         }
     ],
     "wof:id":1092014403,
-    "wof:lastmodified":1536615082,
+    "wof:lastmodified":1560969121,
     "wof:name":"Abu Zeneimah",
     "wof:parent_id":85671089,
     "wof:placetype":"county",

--- a/data/109/201/443/9/1092014439.geojson
+++ b/data/109/201/443/9/1092014439.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.898516,
     "geom:longitude":31.311788,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Aga Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Aga District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.901371,
     "lbl:longitude":31.313477,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092014439,
-    "wof:lastmodified":1553718030,
+    "wof:lastmodified":1560969124,
     "wof:name":"Aga",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/201/448/1/1092014481.geojson
+++ b/data/109/201/448/1/1092014481.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":29.088008,
     "geom:longitude":30.936695,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Ahnasya Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Ahnasya District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":29.08905,
     "lbl:longitude":30.936693,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092014481,
-    "wof:lastmodified":1553718031,
+    "wof:lastmodified":1560969122,
     "wof:name":"Ahnasya",
     "wof:parent_id":85671053,
     "wof:placetype":"county",

--- a/data/109/201/452/7/1092014527.geojson
+++ b/data/109/201/452/7/1092014527.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.128233,
     "geom:longitude":31.337587,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Ain Shams Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Ain Shams Kism"
     ],
@@ -109,7 +118,7 @@
         }
     ],
     "wof:id":1092014527,
-    "wof:lastmodified":1553718033,
+    "wof:lastmodified":1560969122,
     "wof:name":"Ain Shams",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/455/7/1092014557.geojson
+++ b/data/109/201/455/7/1092014557.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":26.570908,
     "geom:longitude":31.752702,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Akhmeem Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Akhmeem District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":26.582146,
     "lbl:longitude":31.735527,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092014557,
-    "wof:lastmodified":1553718032,
+    "wof:lastmodified":1560969122,
     "wof:name":"Akhmeem",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/201/457/3/1092014573.geojson
+++ b/data/109/201/457/3/1092014573.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":25.625841,
     "geom:longitude":32.503418,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Armant Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Armant District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":25.63434,
     "lbl:longitude":32.498181,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092014573,
-    "wof:lastmodified":1553718033,
+    "wof:lastmodified":1560969125,
     "wof:name":"Armant",
     "wof:parent_id":85671075,
     "wof:placetype":"county",

--- a/data/109/201/462/1/1092014621.geojson
+++ b/data/109/201/462/1/1092014621.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.302495,
     "geom:longitude":30.993887,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Ashmoon Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Ashmoon District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.274336,
     "lbl:longitude":31.028506,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092014621,
-    "wof:lastmodified":1553718035,
+    "wof:lastmodified":1560969123,
     "wof:name":"Ashmoon",
     "wof:parent_id":85670995,
     "wof:placetype":"county",

--- a/data/109/201/463/3/1092014633.geojson
+++ b/data/109/201/463/3/1092014633.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":27.154458,
     "geom:longitude":31.156959,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Asiut Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Asiut District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":27.115817,
     "lbl:longitude":31.214729,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092014633,
-    "wof:lastmodified":1553718033,
+    "wof:lastmodified":1560969122,
     "wof:name":"Asiut",
     "wof:parent_id":85671069,
     "wof:placetype":"county",

--- a/data/109/201/463/5/1092014635.geojson
+++ b/data/109/201/463/5/1092014635.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":24.029509,
     "geom:longitude":32.827799,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Aswan Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Aswan District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":24.071677,
     "lbl:longitude":32.881367,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092014635,
-    "wof:lastmodified":1553718035,
+    "wof:lastmodified":1560969122,
     "wof:name":"Aswan",
     "wof:parent_id":85671061,
     "wof:placetype":"county",

--- a/data/109/201/463/7/1092014637.geojson
+++ b/data/109/201/463/7/1092014637.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":29.805891,
     "geom:longitude":32.43323,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Ataqah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Ataqah Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092014637,
-    "wof:lastmodified":1553718036,
+    "wof:lastmodified":1560969122,
     "wof:name":"Ataqah",
     "wof:parent_id":85671013,
     "wof:placetype":"county",

--- a/data/109/201/465/3/1092014653.geojson
+++ b/data/109/201/465/3/1092014653.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":29.371349,
     "geom:longitude":31.245467,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Atfeeh Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Atfeeh District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":29.428463,
     "lbl:longitude":31.248918,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092014653,
-    "wof:lastmodified":1553718036,
+    "wof:lastmodified":1560969123,
     "wof:name":"Atfeeh",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/201/468/3/1092014683.geojson
+++ b/data/109/201/468/3/1092014683.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":29.181336,
     "geom:longitude":30.71936,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Atsa Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Atsa District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":29.191195,
     "lbl:longitude":30.747888,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092014683,
-    "wof:lastmodified":1553718036,
+    "wof:lastmodified":1560969125,
     "wof:name":"Atsa",
     "wof:parent_id":85671037,
     "wof:placetype":"county",

--- a/data/109/201/472/7/1092014727.geojson
+++ b/data/109/201/472/7/1092014727.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.127714,
     "geom:longitude":31.249974,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Awal Shobra El-Kheimah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Awal Shobra El-Kheimah Kism"
     ],
@@ -76,7 +85,7 @@
         }
     ],
     "wof:id":1092014727,
-    "wof:lastmodified":1553718035,
+    "wof:lastmodified":1560969125,
     "wof:name":"Awal Shobra El-Kheimah",
     "wof:parent_id":85671003,
     "wof:placetype":"county",

--- a/data/109/201/477/3/1092014773.geojson
+++ b/data/109/201/477/3/1092014773.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":27.181795,
     "geom:longitude":31.148069,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Awel Asiut Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Awel Asiut Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":27.186102,
     "lbl:longitude":31.147324,
     "meso:admin_1":"Assiut",
@@ -57,7 +72,7 @@
         }
     ],
     "wof:id":1092014773,
-    "wof:lastmodified":1555047464,
+    "wof:lastmodified":1560969122,
     "wof:name":"Awel Asiut",
     "wof:parent_id":85671069,
     "wof:placetype":"county",

--- a/data/109/201/481/5/1092014815.geojson
+++ b/data/109/201/481/5/1092014815.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":31.015848,
     "geom:longitude":33.550796,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Awel El-Areesh Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Awel El-Areesh Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":31.014867,
     "lbl:longitude":33.55182,
     "meso:admin_1":"North Sinai",
@@ -57,7 +72,7 @@
         }
     ],
     "wof:id":1092014815,
-    "wof:lastmodified":1555047464,
+    "wof:lastmodified":1560969124,
     "wof:name":"Awel El-Areesh",
     "wof:parent_id":85671093,
     "wof:placetype":"county",

--- a/data/109/201/484/5/1092014845.geojson
+++ b/data/109/201/484/5/1092014845.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.596605,
     "geom:longitude":32.280793,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Awel El-Esmailiah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Awel El-Esmailiah Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092014845,
-    "wof:lastmodified":1553718039,
+    "wof:lastmodified":1560969122,
     "wof:name":"Awel El-Esmailiah",
     "wof:parent_id":85670989,
     "wof:placetype":"county",

--- a/data/109/201/489/1/1092014891.geojson
+++ b/data/109/201/489/1/1092014891.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.95985,
     "geom:longitude":31.160757,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Awel El-Mahallah El-Kobra Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Awel El-Mahallah El-Kobra Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092014891,
-    "wof:lastmodified":1553718036,
+    "wof:lastmodified":1560969125,
     "wof:name":"Awel El-Mahallah El-Kobra",
     "wof:parent_id":85670985,
     "wof:placetype":"county",

--- a/data/109/201/493/5/1092014935.geojson
+++ b/data/109/201/493/5/1092014935.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":31.068148,
     "geom:longitude":31.423514,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Awel El-Mansourah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Awel El-Mansourah Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":31.070114,
     "lbl:longitude":31.42317,
     "meso:admin_1":"Dakahlia",
@@ -57,7 +72,7 @@
         }
     ],
     "wof:id":1092014935,
-    "wof:lastmodified":1555047464,
+    "wof:lastmodified":1560969125,
     "wof:name":"Awel El-Mansourah",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/201/497/1/1092014971.geojson
+++ b/data/109/201/497/1/1092014971.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.593069,
     "geom:longitude":31.505801,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Awel El-Zaqazeeq Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Awel El-Zaqazeeq Kism"
     ],
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092014971,
-    "wof:lastmodified":1553718037,
+    "wof:lastmodified":1560969122,
     "wof:name":"Awel El-Zaqazeeq",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/201/501/3/1092015013.geojson
+++ b/data/109/201/501/3/1092015013.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":26.543732,
     "geom:longitude":31.691322,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Awel Sohag Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Awel Sohag Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092015013,
-    "wof:lastmodified":1553718036,
+    "wof:lastmodified":1560969124,
     "wof:name":"Awel Sohag",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/201/505/7/1092015057.geojson
+++ b/data/109/201/505/7/1092015057.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.802032,
     "geom:longitude":31.002561,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Awel Tanta Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Awel Tanta Kism"
     ],
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092015057,
-    "wof:lastmodified":1553718036,
+    "wof:lastmodified":1560969121,
     "wof:name":"Awel Tanta",
     "wof:parent_id":85670985,
     "wof:placetype":"county",

--- a/data/109/201/510/5/1092015105.geojson
+++ b/data/109/201/510/5/1092015105.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.977627,
     "geom:longitude":31.786194,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Awlad Saqr Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Awlad Saqr District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.981639,
     "lbl:longitude":31.784097,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092015105,
-    "wof:lastmodified":1553718035,
+    "wof:lastmodified":1560969123,
     "wof:name":"Awlad Saqr",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/201/514/3/1092015143.geojson
+++ b/data/109/201/514/3/1092015143.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.059705,
     "geom:longitude":31.259136,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Bab El-Sha'reyah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Bab El-Sha'reyah Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092015143,
-    "wof:lastmodified":1553718035,
+    "wof:lastmodified":1560969126,
     "wof:name":"Bab El-Sha'reyah",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/518/3/1092015183.geojson
+++ b/data/109/201/518/3/1092015183.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":31.197271,
     "geom:longitude":29.918233,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Bab Sharqy Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Bab Sharqy Kism"
     ],
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092015183,
-    "wof:lastmodified":1553718035,
+    "wof:lastmodified":1560969123,
     "wof:name":"Bab Sharqy",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/201/522/9/1092015229.geojson
+++ b/data/109/201/522/9/1092015229.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":30.132249,
     "geom:longitude":31.733954,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Badr City Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Badr City Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":30.132437,
     "lbl:longitude":31.733734,
     "meso:admin_1":"Helwan",
@@ -56,7 +71,7 @@
         }
     ],
     "wof:id":1092015229,
-    "wof:lastmodified":1555047464,
+    "wof:lastmodified":1560969126,
     "wof:name":"Badr City",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/525/3/1092015253.geojson
+++ b/data/109/201/525/3/1092015253.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.449201,
     "geom:longitude":31.20466,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Banha Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
     "label:eng_x_preferred_longname":[
-        "Banha Kism"
+        "Banha District"
     ],
     "label:eng_x_preferred_placetype":[
-        "kism"
+        "district"
     ],
     "lbl:latitude":30.45481,
     "lbl:longitude":31.212021,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092015253,
-    "wof:lastmodified":1553718035,
+    "wof:lastmodified":1560969126,
     "wof:name":"Banha",
     "wof:parent_id":85671003,
     "wof:placetype":"county",

--- a/data/109/201/529/5/1092015295.geojson
+++ b/data/109/201/529/5/1092015295.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":28.5052,
     "geom:longitude":30.751507,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Bany Mazar Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Bany Mazar District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":28.502609,
     "lbl:longitude":30.724553,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092015295,
-    "wof:lastmodified":1553718035,
+    "wof:lastmodified":1560969123,
     "wof:name":"Bany Mazar",
     "wof:parent_id":85671049,
     "wof:placetype":"county",

--- a/data/109/201/534/1/1092015341.geojson
+++ b/data/109/201/534/1/1092015341.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":29.083635,
     "geom:longitude":31.07332,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Bany Sweif Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Bany Sweif District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":29.072643,
     "lbl:longitude":31.047083,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092015341,
-    "wof:lastmodified":1553718037,
+    "wof:lastmodified":1560969121,
     "wof:name":"Bany Sweif",
     "wof:parent_id":85671053,
     "wof:placetype":"county",

--- a/data/109/201/537/5/1092015375.geojson
+++ b/data/109/201/537/5/1092015375.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.954593,
     "geom:longitude":30.829974,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Basyoun Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Basyoun District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.949481,
     "lbl:longitude":30.836315,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092015375,
-    "wof:lastmodified":1553718036,
+    "wof:lastmodified":1560969124,
     "wof:name":"Basyoun",
     "wof:parent_id":85670985,
     "wof:placetype":"county",

--- a/data/109/201/541/5/1092015415.geojson
+++ b/data/109/201/541/5/1092015415.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":28.949885,
     "geom:longitude":30.963044,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Beba Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Beba District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":28.9495,
     "lbl:longitude":30.961557,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092015415,
-    "wof:lastmodified":1553718037,
+    "wof:lastmodified":1560969126,
     "wof:name":"Beba",
     "wof:parent_id":85671053,
     "wof:placetype":"county",

--- a/data/109/201/546/3/1092015463.geojson
+++ b/data/109/201/546/3/1092015463.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.274618,
     "geom:longitude":31.20423,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Beela Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Beela District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.21273,
     "lbl:longitude":31.205971,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092015463,
-    "wof:lastmodified":1553718035,
+    "wof:lastmodified":1560969126,
     "wof:name":"Beela",
     "wof:parent_id":85671057,
     "wof:placetype":"county",

--- a/data/109/201/552/1/1092015521.geojson
+++ b/data/109/201/552/1/1092015521.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":30.930647,
     "geom:longitude":33.090041,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Beer El-Abd Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Beer El-Abd Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":30.885135,
     "lbl:longitude":33.02004,
     "meso:admin_1":"North Sinai",
@@ -57,7 +72,7 @@
         }
     ],
     "wof:id":1092015521,
-    "wof:lastmodified":1555047464,
+    "wof:lastmodified":1560969124,
     "wof:name":"Beer El-Abd",
     "wof:parent_id":85671093,
     "wof:placetype":"county",

--- a/data/109/201/556/9/1092015569.geojson
+++ b/data/109/201/556/9/1092015569.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.414979,
     "geom:longitude":31.534847,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Belbeis Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Belbeis District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.422791,
     "lbl:longitude":31.521225,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092015569,
-    "wof:lastmodified":1553718036,
+    "wof:lastmodified":1560969120,
     "wof:name":"Belbeis",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/201/561/1/1092015611.geojson
+++ b/data/109/201/561/1/1092015611.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.350063,
     "geom:longitude":31.386203,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Belqas Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Belqas District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.355935,
     "lbl:longitude":31.383239,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092015611,
-    "wof:lastmodified":1553718035,
+    "wof:lastmodified":1560969121,
     "wof:name":"Belqas",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/201/565/3/1092015653.geojson
+++ b/data/109/201/565/3/1092015653.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.64787,
     "geom:longitude":31.089353,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Berket El-Sab' Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Berket El-Sab' District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.636226,
     "lbl:longitude":31.09569,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092015653,
-    "wof:lastmodified":1553718036,
+    "wof:lastmodified":1560969124,
     "wof:name":"Berket El-Sab'",
     "wof:parent_id":85670995,
     "wof:placetype":"county",

--- a/data/109/201/569/5/1092015695.geojson
+++ b/data/109/201/569/5/1092015695.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":30.701775,
     "geom:longitude":29.751977,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Borg El-Arab City Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Borg El-Arab City Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":30.693029,
     "lbl:longitude":29.77473,
     "meso:admin_1":"Alexandria",
@@ -57,7 +72,7 @@
         }
     ],
     "wof:id":1092015695,
-    "wof:lastmodified":1555047464,
+    "wof:lastmodified":1560969120,
     "wof:name":"Borg El-Arab City",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/201/573/9/1092015739.geojson
+++ b/data/109/201/573/9/1092015739.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.893316,
     "geom:longitude":29.536286,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Borg El-Arab Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Borg El-Arab Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092015739,
-    "wof:lastmodified":1553718035,
+    "wof:lastmodified":1560969123,
     "wof:name":"Borg El-Arab",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/201/578/7/1092015787.geojson
+++ b/data/109/201/578/7/1092015787.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.027488,
     "geom:longitude":31.187715,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Boulaq El-Dakroor Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Boulaq El-Dakroor Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092015787,
-    "wof:lastmodified":1553718036,
+    "wof:lastmodified":1560969126,
     "wof:name":"Boulaq El-Dakroor",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/201/583/9/1092015839.geojson
+++ b/data/109/201/583/9/1092015839.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.062133,
     "geom:longitude":31.232214,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Boulaq Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Boulaq Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092015839,
-    "wof:lastmodified":1553718040,
+    "wof:lastmodified":1560969126,
     "wof:name":"Boulaq",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/588/1/1092015881.geojson
+++ b/data/109/201/588/1/1092015881.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":28.490199,
     "geom:longitude":34.38647,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Dahab Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Dahab Kism"
     ],
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092015881,
-    "wof:lastmodified":1553718035,
+    "wof:lastmodified":1560969123,
     "wof:name":"Dahab",
     "wof:parent_id":85671089,
     "wof:placetype":"county",

--- a/data/109/201/592/1/1092015921.geojson
+++ b/data/109/201/592/1/1092015921.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.010805,
     "geom:longitude":30.455626,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Damanhoor Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Damanhoor District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.009324,
     "lbl:longitude":30.457885,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092015921,
-    "wof:lastmodified":1553718035,
+    "wof:lastmodified":1560969121,
     "wof:name":"Damanhoor",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/201/594/7/1092015947.geojson
+++ b/data/109/201/594/7/1092015947.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":26.255728,
     "geom:longitude":32.030645,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Dar El-Salam Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Dar El-Salam District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":26.229621,
     "lbl:longitude":32.05045,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092015947,
-    "wof:lastmodified":1553718039,
+    "wof:lastmodified":1560969120,
     "wof:name":"Dar El-Salam",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/201/598/7/1092015987.geojson
+++ b/data/109/201/598/7/1092015987.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":27.527725,
     "geom:longitude":30.77573,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Dayroot Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Dayroot District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":27.520351,
     "lbl:longitude":30.774226,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092015987,
-    "wof:lastmodified":1553718036,
+    "wof:lastmodified":1560969124,
     "wof:name":"Dayroot",
     "wof:parent_id":85671069,
     "wof:placetype":"county",

--- a/data/109/201/603/3/1092016033.geojson
+++ b/data/109/201/603/3/1092016033.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":27.636314,
     "geom:longitude":30.781715,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Deir Mowas Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Deir Mowas District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":27.631482,
     "lbl:longitude":30.814542,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092016033,
-    "wof:lastmodified":1553718036,
+    "wof:lastmodified":1560969122,
     "wof:name":"Deir Mowas",
     "wof:parent_id":85671049,
     "wof:placetype":"county",

--- a/data/109/201/607/9/1092016079.geojson
+++ b/data/109/201/607/9/1092016079.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.762427,
     "geom:longitude":31.458327,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Deirab Negm Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Deirab Negm District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.75851,
     "lbl:longitude":31.456323,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092016079,
-    "wof:lastmodified":1553718037,
+    "wof:lastmodified":1560969125,
     "wof:name":"Deirab Negm",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/201/611/5/1092016115.geojson
+++ b/data/109/201/611/5/1092016115.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":24.413086,
     "geom:longitude":32.903741,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Deraw Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Deraw District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":24.433589,
     "lbl:longitude":32.903178,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092016115,
-    "wof:lastmodified":1553718035,
+    "wof:lastmodified":1560969122,
     "wof:name":"Deraw",
     "wof:parent_id":85671061,
     "wof:placetype":"county",

--- a/data/109/201/615/7/1092016157.geojson
+++ b/data/109/201/615/7/1092016157.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":26.140785,
     "geom:longitude":32.447878,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Deshna Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
     "label:eng_x_preferred_longname":[
-        "Deshna New City"
+        "Deshna District"
     ],
     "label:eng_x_preferred_placetype":[
-        "new city"
+        "district"
     ],
     "lbl:latitude":26.147675,
     "lbl:longitude":32.486341,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092016157,
-    "wof:lastmodified":1553718035,
+    "wof:lastmodified":1560969125,
     "wof:name":"Deshna",
     "wof:parent_id":85671075,
     "wof:placetype":"county",

--- a/data/109/201/620/3/1092016203.geojson
+++ b/data/109/201/620/3/1092016203.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.162997,
     "geom:longitude":30.718588,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Desooq Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
-        "Desooq Markaz"
+        "Desooq Kism"
     ],
     "label:eng_x_preferred_placetype":[
-        "markaz"
+        "kism"
     ],
     "lbl:latitude":31.166605,
     "lbl:longitude":30.700337,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092016203,
-    "wof:lastmodified":1553718035,
+    "wof:lastmodified":1560969122,
     "wof:name":"Desooq",
     "wof:parent_id":85671057,
     "wof:placetype":"county",

--- a/data/109/201/622/7/1092016227.geojson
+++ b/data/109/201/622/7/1092016227.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.081417,
     "geom:longitude":31.67273,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Dokornos Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Dokornos District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.048848,
     "lbl:longitude":31.657463,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092016227,
-    "wof:lastmodified":1553718036,
+    "wof:lastmodified":1560969124,
     "wof:name":"Dokornos",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/201/627/1/1092016271.geojson
+++ b/data/109/201/627/1/1092016271.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":31.440419,
     "geom:longitude":31.706088,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Domiat El-Gedidah City Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Domiat El-Gedidah City Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092016271,
-    "wof:lastmodified":1553718036,
+    "wof:lastmodified":1560969122,
     "wof:name":"Domiat El-Gedidah City",
     "wof:parent_id":85671025,
     "wof:placetype":"county",

--- a/data/109/201/631/9/1092016319.geojson
+++ b/data/109/201/631/9/1092016319.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":31.472174,
     "geom:longitude":31.773473,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Domiat El-Gedidah Port Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Domiat El-Gedidah Port Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":31.459963,
     "lbl:longitude":31.769991,
     "meso:admin_1":"Domiat",
@@ -55,7 +70,7 @@
         }
     ],
     "wof:id":1092016319,
-    "wof:lastmodified":1555047464,
+    "wof:lastmodified":1560969125,
     "wof:name":"Domiat El-Gedidah Port",
     "wof:parent_id":85671025,
     "wof:placetype":"county",

--- a/data/109/201/634/9/1092016349.geojson
+++ b/data/109/201/634/9/1092016349.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":31.446564,
     "geom:longitude":31.869672,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Domiat Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Domiat District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
+    ],
     "lbl:latitude":31.459666,
     "lbl:longitude":31.832704,
     "meso:admin_1":"Domiat",
@@ -57,7 +72,7 @@
         }
     ],
     "wof:id":1092016349,
-    "wof:lastmodified":1555047464,
+    "wof:lastmodified":1560969122,
     "wof:name":"Domiat",
     "wof:parent_id":85671025,
     "wof:placetype":"county",

--- a/data/109/201/639/1/1092016391.geojson
+++ b/data/109/201/639/1/1092016391.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":29.359091,
     "geom:longitude":30.620337,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Ebshoway Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Ebshoway District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":29.342637,
     "lbl:longitude":30.633827,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092016391,
-    "wof:lastmodified":1553718039,
+    "wof:lastmodified":1560969125,
     "wof:name":"Ebshoway",
     "wof:parent_id":85671037,
     "wof:placetype":"county",

--- a/data/109/201/643/7/1092016437.geojson
+++ b/data/109/201/643/7/1092016437.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":25.015708,
     "geom:longitude":32.828234,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Edfu Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Edfu District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":24.969102,
     "lbl:longitude":32.879258,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092016437,
-    "wof:lastmodified":1553718036,
+    "wof:lastmodified":1560969121,
     "wof:name":"Edfu",
     "wof:parent_id":85671061,
     "wof:placetype":"county",

--- a/data/109/201/648/1/1092016481.geojson
+++ b/data/109/201/648/1/1092016481.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.287393,
     "geom:longitude":30.331298,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Edku Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Edku District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.297177,
     "lbl:longitude":30.352833,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092016481,
-    "wof:lastmodified":1553718037,
+    "wof:lastmodified":1560969125,
     "wof:name":"Edku",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/201/650/5/1092016505.geojson
+++ b/data/109/201/650/5/1092016505.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":28.689577,
     "geom:longitude":30.738757,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Adwah Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Adwah District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":28.694904,
     "lbl:longitude":30.746767,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092016505,
-    "wof:lastmodified":1553718037,
+    "wof:lastmodified":1560969123,
     "wof:name":"El-Adwah",
     "wof:parent_id":85671049,
     "wof:placetype":"county",

--- a/data/109/201/654/5/1092016545.geojson
+++ b/data/109/201/654/5/1092016545.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.059846,
     "geom:longitude":31.203534,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Agouzah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Agouzah Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092016545,
-    "wof:lastmodified":1553718037,
+    "wof:lastmodified":1560969125,
     "wof:name":"El-Agouzah",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/201/659/1/1092016591.geojson
+++ b/data/109/201/659/1/1092016591.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":29.991069,
     "geom:longitude":31.14241,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Ahram Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Ahram Kism"
     ],
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092016591,
-    "wof:lastmodified":1553718037,
+    "wof:lastmodified":1560969123,
     "wof:name":"El-Ahram",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/201/662/3/1092016623.geojson
+++ b/data/109/201/662/3/1092016623.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":29.553279,
     "geom:longitude":28.67505,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "El-Alamein Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Alamein District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
+    ],
     "lbl:latitude":29.166664,
     "lbl:longitude":28.713095,
     "meso:admin_1":"Marsa Matrooh",
@@ -56,7 +71,7 @@
         }
     ],
     "wof:id":1092016623,
-    "wof:lastmodified":1555047464,
+    "wof:lastmodified":1560969125,
     "wof:name":"El-Alamein",
     "wof:parent_id":85671031,
     "wof:placetype":"county",

--- a/data/109/201/666/7/1092016667.geojson
+++ b/data/109/201/666/7/1092016667.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":30.001637,
     "geom:longitude":31.781454,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Amal Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Amal Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":30.001825,
     "lbl:longitude":31.781234,
     "meso:admin_1":"Helwan",
@@ -57,7 +72,7 @@
         }
     ],
     "wof:id":1092016667,
-    "wof:lastmodified":1555047464,
+    "wof:lastmodified":1560969123,
     "wof:name":"El-Amal",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/671/5/1092016715.geojson
+++ b/data/109/201/671/5/1092016715.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":31.040795,
     "geom:longitude":29.826741,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Amreyah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Amreyah Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":31.039272,
     "lbl:longitude":29.854239,
     "meso:admin_1":"Alexandria",
@@ -57,7 +72,7 @@
         }
     ],
     "wof:id":1092016715,
-    "wof:lastmodified":1555047464,
+    "wof:lastmodified":1560969124,
     "wof:name":"El-Amreyah",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/201/676/7/1092016767.geojson
+++ b/data/109/201/676/7/1092016767.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":31.262796,
     "geom:longitude":32.293802,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Arab Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Arab Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092016767,
-    "wof:lastmodified":1553718037,
+    "wof:lastmodified":1560969124,
     "wof:name":"El-Arab",
     "wof:parent_id":85671021,
     "wof:placetype":"county",

--- a/data/109/201/680/3/1092016803.geojson
+++ b/data/109/201/680/3/1092016803.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":29.981265,
     "geom:longitude":32.519101,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Arbe'in Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Arbe'in Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092016803,
-    "wof:lastmodified":1553718037,
+    "wof:lastmodified":1560969122,
     "wof:name":"El-Arbe'in",
     "wof:parent_id":85671013,
     "wof:placetype":"county",

--- a/data/109/201/685/1/1092016851.geojson
+++ b/data/109/201/685/1/1092016851.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":31.188648,
     "geom:longitude":29.898336,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Atareen Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Atareen Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092016851,
-    "wof:lastmodified":1553718037,
+    "wof:lastmodified":1560969124,
     "wof:name":"El-Atareen",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/201/689/3/1092016893.geojson
+++ b/data/109/201/689/3/1092016893.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":29.574227,
     "geom:longitude":31.238195,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Ayyat Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Ayyat District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":29.672642,
     "lbl:longitude":31.258412,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092016893,
-    "wof:lastmodified":1553718038,
+    "wof:lastmodified":1560969122,
     "wof:name":"El-Ayyat",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/201/692/9/1092016929.geojson
+++ b/data/109/201/692/9/1092016929.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.060072,
     "geom:longitude":31.246331,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Azbakeyah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Azbakeyah Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092016929,
-    "wof:lastmodified":1553718038,
+    "wof:lastmodified":1560969123,
     "wof:name":"El-Azbakeyah",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/697/5/1092016975.geojson
+++ b/data/109/201/697/5/1092016975.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":26.959476,
     "geom:longitude":31.423994,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Badary Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Badary District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":26.979725,
     "lbl:longitude":31.41101,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092016975,
-    "wof:lastmodified":1553718038,
+    "wof:lastmodified":1560969125,
     "wof:name":"El-Badary",
     "wof:parent_id":85671069,
     "wof:placetype":"county",

--- a/data/109/201/701/9/1092017019.geojson
+++ b/data/109/201/701/9/1092017019.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":29.819135,
     "geom:longitude":31.249472,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Badrashein Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Badrashein District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":29.827293,
     "lbl:longitude":31.259673,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092017019,
-    "wof:lastmodified":1553718038,
+    "wof:lastmodified":1560969121,
     "wof:name":"El-Badrashein",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/201/706/5/1092017065.geojson
+++ b/data/109/201/706/5/1092017065.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.420252,
     "geom:longitude":31.056637,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Bagoor Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Bagoor District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.420664,
     "lbl:longitude":31.046141,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092017065,
-    "wof:lastmodified":1553718038,
+    "wof:lastmodified":1560969121,
     "wof:name":"El-Bagoor",
     "wof:parent_id":85670995,
     "wof:placetype":"county",

--- a/data/109/201/710/1/1092017101.geojson
+++ b/data/109/201/710/1/1092017101.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":29.980556,
     "geom:longitude":31.257976,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Basateen Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Basateen Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092017101,
-    "wof:lastmodified":1553718041,
+    "wof:lastmodified":1560969126,
     "wof:name":"El-Basateen",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/714/3/1092017143.geojson
+++ b/data/109/201/714/3/1092017143.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":26.229771,
     "geom:longitude":31.948163,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Beleena Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Beleena District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":26.228511,
     "lbl:longitude":31.948166,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092017143,
-    "wof:lastmodified":1553718039,
+    "wof:lastmodified":1560969123,
     "wof:name":"El-Beleena",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/201/718/9/1092017189.geojson
+++ b/data/109/201/718/9/1092017189.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.539541,
     "geom:longitude":31.160262,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Borolos Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Borolos District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.532964,
     "lbl:longitude":31.219121,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092017189,
-    "wof:lastmodified":1553718039,
+    "wof:lastmodified":1560969126,
     "wof:name":"El-Borolos",
     "wof:parent_id":85671057,
     "wof:placetype":"county",

--- a/data/109/201/722/7/1092017227.geojson
+++ b/data/109/201/722/7/1092017227.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.007993,
     "geom:longitude":28.089028,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "El-Dab'ah Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
     "label:eng_x_preferred_longname":[
-        "El-Dab'ah Kism"
+        "El-Dab'ah District"
     ],
     "label:eng_x_preferred_placetype":[
-        "kism"
+        "district"
     ],
     "lbl:latitude":30.01652,
     "lbl:longitude":28.079876,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092017227,
-    "wof:lastmodified":1553718039,
+    "wof:lastmodified":1560969123,
     "wof:name":"El-Dab'ah",
     "wof:parent_id":85671031,
     "wof:placetype":"county",

--- a/data/109/201/727/3/1092017273.geojson
+++ b/data/109/201/727/3/1092017273.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.063654,
     "geom:longitude":31.267804,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Daher Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Daher Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092017273,
-    "wof:lastmodified":1553718039,
+    "wof:lastmodified":1560969126,
     "wof:name":"El-Daher",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/731/7/1092017317.geojson
+++ b/data/109/201/731/7/1092017317.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.828442,
     "geom:longitude":30.496163,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Dalangat Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Dalangat District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.821639,
     "lbl:longitude":30.508945,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092017317,
-    "wof:lastmodified":1553718040,
+    "wof:lastmodified":1560969121,
     "wof:name":"El-Dalangat",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/201/735/9/1092017359.geojson
+++ b/data/109/201/735/9/1092017359.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.042426,
     "geom:longitude":31.258862,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Darb El-Ahmar Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Darb El-Ahmar Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092017359,
-    "wof:lastmodified":1553718039,
+    "wof:lastmodified":1560969124,
     "wof:name":"El-Darb El-Ahmar",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/739/7/1092017397.geojson
+++ b/data/109/201/739/7/1092017397.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":31.102808,
     "geom:longitude":32.22294,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Dawahy Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Dawahy Kism"
     ],
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092017397,
-    "wof:lastmodified":1553718040,
+    "wof:lastmodified":1560969121,
     "wof:name":"El-Dawahy",
     "wof:parent_id":85671021,
     "wof:placetype":"county",

--- a/data/109/201/744/1/1092017441.geojson
+++ b/data/109/201/744/1/1092017441.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":31.110857,
     "geom:longitude":29.78988,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Dekheilah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Dekheilah Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092017441,
-    "wof:lastmodified":1553718042,
+    "wof:lastmodified":1560969126,
     "wof:name":"El-Dekheilah",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/201/748/9/1092017489.geojson
+++ b/data/109/201/748/9/1092017489.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.040674,
     "geom:longitude":31.208173,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Dokky Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Dokky Kism"
     ],
@@ -76,7 +85,7 @@
         }
     ],
     "wof:id":1092017489,
-    "wof:lastmodified":1553718041,
+    "wof:lastmodified":1560969123,
     "wof:name":"El-Dokky",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/201/753/5/1092017535.geojson
+++ b/data/109/201/753/5/1092017535.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.538725,
     "geom:longitude":32.196912,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Esmailiah Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Esmailiah District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.542746,
     "lbl:longitude":32.185827,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092017535,
-    "wof:lastmodified":1553718040,
+    "wof:lastmodified":1560969121,
     "wof:name":"El-Esmailiah",
     "wof:parent_id":85670989,
     "wof:placetype":"county",

--- a/data/109/201/758/5/1092017585.geojson
+++ b/data/109/201/758/5/1092017585.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":26.983504,
     "geom:longitude":27.767309,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Farafrah Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Farafrah District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":26.969359,
     "lbl:longitude":27.767323,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092017585,
-    "wof:lastmodified":1553718039,
+    "wof:lastmodified":1560969124,
     "wof:name":"El-Farafrah",
     "wof:parent_id":85671071,
     "wof:placetype":"county",

--- a/data/109/201/762/7/1092017627.geojson
+++ b/data/109/201/762/7/1092017627.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":28.799146,
     "geom:longitude":30.839068,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Fashn Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Fashn District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":28.808909,
     "lbl:longitude":30.846803,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092017627,
-    "wof:lastmodified":1553718039,
+    "wof:lastmodified":1560969121,
     "wof:name":"El-Fashn",
     "wof:parent_id":85671053,
     "wof:placetype":"county",

--- a/data/109/201/766/9/1092017669.geojson
+++ b/data/109/201/766/9/1092017669.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":27.201769,
     "geom:longitude":31.198892,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Fath Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Fath District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":27.204901,
     "lbl:longitude":31.208418,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092017669,
-    "wof:lastmodified":1553718040,
+    "wof:lastmodified":1560969124,
     "wof:name":"El-Fath",
     "wof:parent_id":85671069,
     "wof:placetype":"county",

--- a/data/109/201/770/5/1092017705.geojson
+++ b/data/109/201/770/5/1092017705.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":29.303423,
     "geom:longitude":30.908368,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Fayoum Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Fayoum District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":29.291877,
     "lbl:longitude":30.939269,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092017705,
-    "wof:lastmodified":1553718040,
+    "wof:lastmodified":1560969123,
     "wof:name":"El-Fayoum",
     "wof:parent_id":85671037,
     "wof:placetype":"county",

--- a/data/109/201/775/5/1092017755.geojson
+++ b/data/109/201/775/5/1092017755.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.052868,
     "geom:longitude":31.266264,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Gamaleyah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
-        "El-Gamaleyah Markaz"
+        "El-Gamaleyah Kism"
     ],
     "label:eng_x_preferred_placetype":[
-        "markaz"
+        "kism"
     ],
     "lbl:latitude":30.051726,
     "lbl:longitude":31.266429,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092017755,
-    "wof:lastmodified":1553718040,
+    "wof:lastmodified":1560969126,
     "wof:name":"El-Gamaleyah",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/779/7/1092017797.geojson
+++ b/data/109/201/779/7/1092017797.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.221402,
     "geom:longitude":31.852625,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "El-Gamaleyah Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
     "label:eng_x_preferred_longname":[
-        "El-Gamaleyah Kism"
+        "El-Gamaleyah District"
     ],
     "label:eng_x_preferred_placetype":[
-        "kism"
+        "district"
     ],
     "lbl:latitude":31.222258,
     "lbl:longitude":31.853218,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092017797,
-    "wof:lastmodified":1553718040,
+    "wof:lastmodified":1560969123,
     "wof:name":"El-Gamaleyah",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/201/782/7/1092017827.geojson
+++ b/data/109/201/782/7/1092017827.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.149408,
     "geom:longitude":32.526451,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Ganayen Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Ganayen Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092017827,
-    "wof:lastmodified":1553718041,
+    "wof:lastmodified":1560969123,
     "wof:name":"El-Ganayen",
     "wof:parent_id":85671013,
     "wof:placetype":"county",

--- a/data/109/201/787/3/1092017873.geojson
+++ b/data/109/201/787/3/1092017873.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":26.902105,
     "geom:longitude":31.321459,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Ghanayem Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Ghanayem District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":26.895938,
     "lbl:longitude":31.322161,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092017873,
-    "wof:lastmodified":1553718037,
+    "wof:lastmodified":1560969126,
     "wof:name":"El-Ghanayem",
     "wof:parent_id":85671069,
     "wof:placetype":"county",

--- a/data/109/201/791/7/1092017917.geojson
+++ b/data/109/201/791/7/1092017917.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":31.19905,
     "geom:longitude":29.875414,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Gomrok Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Gomrok Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":31.202204,
     "lbl:longitude":29.880121,
     "meso:admin_1":"Alexandria",
@@ -56,7 +71,7 @@
         }
     ],
     "wof:id":1092017917,
-    "wof:lastmodified":1555047464,
+    "wof:lastmodified":1560969121,
     "wof:name":"El-Gomrok",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/201/795/3/1092017953.geojson
+++ b/data/109/201/795/3/1092017953.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.05044,
     "geom:longitude":29.263291,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "El-Hamam Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
     "label:eng_x_preferred_longname":[
-        "El-Hamam Kism"
+        "El-Hamam District"
     ],
     "label:eng_x_preferred_placetype":[
-        "kism"
+        "district"
     ],
     "lbl:latitude":29.986882,
     "lbl:longitude":29.172774,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092017953,
-    "wof:lastmodified":1553718037,
+    "wof:lastmodified":1560969124,
     "wof:name":"El-Hamam",
     "wof:parent_id":85671031,
     "wof:placetype":"county",

--- a/data/109/201/799/3/1092017993.geojson
+++ b/data/109/201/799/3/1092017993.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.387455,
     "geom:longitude":31.099857,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Hamool Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Hamool District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.396844,
     "lbl:longitude":31.102607,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092017993,
-    "wof:lastmodified":1553718038,
+    "wof:lastmodified":1560969120,
     "wof:name":"El-Hamool",
     "wof:parent_id":85671057,
     "wof:placetype":"county",

--- a/data/109/201/804/1/1092018041.geojson
+++ b/data/109/201/804/1/1092018041.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.524266,
     "geom:longitude":33.535633,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "El-Hasanah Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
     "label:eng_x_preferred_longname":[
-        "El-Hasanah Kism"
+        "El-Hasanah District"
     ],
     "label:eng_x_preferred_placetype":[
-        "kism"
+        "district"
     ],
     "lbl:latitude":30.528831,
     "lbl:longitude":33.447305,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092018041,
-    "wof:lastmodified":1553718037,
+    "wof:lastmodified":1560969122,
     "wof:name":"El-Hasanah",
     "wof:parent_id":85671093,
     "wof:placetype":"county",

--- a/data/109/201/806/5/1092018065.geojson
+++ b/data/109/201/806/5/1092018065.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":29.903596,
     "geom:longitude":31.25964,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Hawamdeyah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Hawamdeyah Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092018065,
-    "wof:lastmodified":1553718037,
+    "wof:lastmodified":1560969125,
     "wof:name":"El-Hawamdeyah",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/201/809/1/1092018091.geojson
+++ b/data/109/201/809/1/1092018091.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.850183,
     "geom:longitude":32.019378,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Hoseineyah Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Hoseineyah District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.946357,
     "lbl:longitude":32.023341,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092018091,
-    "wof:lastmodified":1553718037,
+    "wof:lastmodified":1560969125,
     "wof:name":"El-Hoseineyah",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/201/810/7/1092018107.geojson
+++ b/data/109/201/810/7/1092018107.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.738985,
     "geom:longitude":31.563393,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Ibrahimeyah Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Ibrahimeyah District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.732788,
     "lbl:longitude":31.551111,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092018107,
-    "wof:lastmodified":1553718037,
+    "wof:lastmodified":1560969122,
     "wof:name":"El-Ibrahimeyah",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/201/812/7/1092018127.geojson
+++ b/data/109/201/812/7/1092018127.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.017398,
     "geom:longitude":31.267711,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Khalifah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Khalifah Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092018127,
-    "wof:lastmodified":1553718037,
+    "wof:lastmodified":1560969124,
     "wof:name":"El-Khalifah",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/814/3/1092018143.geojson
+++ b/data/109/201/814/3/1092018143.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.228919,
     "geom:longitude":31.4287,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "El-Khankah Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
     "label:eng_x_preferred_longname":[
-        "El-Khankah Kism"
+        "El-Khankah District"
     ],
     "label:eng_x_preferred_placetype":[
-        "kism"
+        "district"
     ],
     "lbl:latitude":30.243072,
     "lbl:longitude":31.401996,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092018143,
-    "wof:lastmodified":1553718037,
+    "wof:lastmodified":1560969125,
     "wof:name":"El-Khankah",
     "wof:parent_id":85671003,
     "wof:placetype":"county",

--- a/data/109/201/816/1/1092018161.geojson
+++ b/data/109/201/816/1/1092018161.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":31.183494,
     "geom:longitude":29.887399,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Labban Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Labban Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":31.18336,
     "lbl:longitude":29.886286,
     "meso:admin_1":"Alexandria",
@@ -57,7 +72,7 @@
         }
     ],
     "wof:id":1092018161,
-    "wof:lastmodified":1555047464,
+    "wof:lastmodified":1560969121,
     "wof:name":"El-Labban",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/201/820/3/1092018203.geojson
+++ b/data/109/201/820/3/1092018203.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":29.960627,
     "geom:longitude":31.263377,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Maadi Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Maadi Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092018203,
-    "wof:lastmodified":1553718037,
+    "wof:lastmodified":1560969121,
     "wof:name":"El-Maadi",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/824/5/1092018245.geojson
+++ b/data/109/201/824/5/1092018245.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.029903,
     "geom:longitude":31.134865,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Mahallah El-Kobra Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Mahallah El-Kobra District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.070553,
     "lbl:longitude":31.127031,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092018245,
-    "wof:lastmodified":1553718038,
+    "wof:lastmodified":1560969124,
     "wof:name":"El-Mahallah El-Kobra",
     "wof:parent_id":85670985,
     "wof:placetype":"county",

--- a/data/109/201/827/7/1092018277.geojson
+++ b/data/109/201/827/7/1092018277.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.178652,
     "geom:longitude":30.500119,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Mahmoudeyah Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Mahmoudeyah District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.168011,
     "lbl:longitude":30.485611,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092018277,
-    "wof:lastmodified":1553718038,
+    "wof:lastmodified":1560969121,
     "wof:name":"El-Mahmoudeyah",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/201/832/5/1092018325.geojson
+++ b/data/109/201/832/5/1092018325.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":31.293465,
     "geom:longitude":32.197106,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Manakh Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Manakh Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092018325,
-    "wof:lastmodified":1553718038,
+    "wof:lastmodified":1560969122,
     "wof:name":"El-Manakh",
     "wof:parent_id":85671021,
     "wof:placetype":"county",

--- a/data/109/201/836/9/1092018369.geojson
+++ b/data/109/201/836/9/1092018369.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":31.196061,
     "geom:longitude":29.889006,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Mansheyah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Mansheyah Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092018369,
-    "wof:lastmodified":1553718038,
+    "wof:lastmodified":1560969125,
     "wof:name":"El-Mansheyah",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/201/839/5/1092018395.geojson
+++ b/data/109/201/839/5/1092018395.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.043659,
     "geom:longitude":31.475518,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Mansourah Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Mansourah District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.038018,
     "lbl:longitude":31.490373,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092018395,
-    "wof:lastmodified":1553718041,
+    "wof:lastmodified":1560969125,
     "wof:name":"El-Mansourah",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/201/839/7/1092018397.geojson
+++ b/data/109/201/839/7/1092018397.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.164819,
     "geom:longitude":31.943438,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Manzalah Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Manzalah District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.160145,
     "lbl:longitude":31.924457,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092018397,
-    "wof:lastmodified":1553718041,
+    "wof:lastmodified":1560969125,
     "wof:name":"El-Manzalah",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/201/839/9/1092018399.geojson
+++ b/data/109/201/839/9/1092018399.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":26.655786,
     "geom:longitude":31.56954,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Maraghah Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Maraghah District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":26.667819,
     "lbl:longitude":31.584647,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092018399,
-    "wof:lastmodified":1553718038,
+    "wof:lastmodified":1560969125,
     "wof:name":"El-Maraghah",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/201/840/1/1092018401.geojson
+++ b/data/109/201/840/1/1092018401.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.151653,
     "geom:longitude":31.345717,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Marg Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Marg Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092018401,
-    "wof:lastmodified":1553718038,
+    "wof:lastmodified":1560969125,
     "wof:name":"El-Marg",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/843/3/1092018433.geojson
+++ b/data/109/201/843/3/1092018433.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.126761,
     "geom:longitude":31.304097,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Matareyah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Matareyah Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092018433,
-    "wof:lastmodified":1553718038,
+    "wof:lastmodified":1560969122,
     "wof:name":"El-Matareyah",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/847/9/1092018479.geojson
+++ b/data/109/201/847/9/1092018479.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.200333,
     "geom:longitude":32.01655,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Matareyah Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Matareyah District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.205855,
     "lbl:longitude":32.013756,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092018479,
-    "wof:lastmodified":1553718038,
+    "wof:lastmodified":1560969125,
     "wof:name":"El-Matareyah",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/201/851/3/1092018513.geojson
+++ b/data/109/201/851/3/1092018513.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":28.112037,
     "geom:longitude":30.806798,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "El-Menya El-Gedidah Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Menya El-Gedidah District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
+    ],
     "lbl:latitude":28.112124,
     "lbl:longitude":30.806798,
     "meso:admin_1":"Menia",
@@ -57,7 +72,7 @@
         }
     ],
     "wof:id":1092018513,
-    "wof:lastmodified":1555047464,
+    "wof:lastmodified":1560969122,
     "wof:name":"El-Menya El-Gedidah",
     "wof:parent_id":85671085,
     "wof:placetype":"county",

--- a/data/109/201/855/7/1092018557.geojson
+++ b/data/109/201/855/7/1092018557.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":28.083561,
     "geom:longitude":30.705901,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Menya Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Menya District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":28.076932,
     "lbl:longitude":30.704177,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092018557,
-    "wof:lastmodified":1553718038,
+    "wof:lastmodified":1560969125,
     "wof:name":"El-Menya",
     "wof:parent_id":85671049,
     "wof:placetype":"county",

--- a/data/109/201/859/9/1092018599.geojson
+++ b/data/109/201/859/9/1092018599.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":26.44031,
     "geom:longitude":31.772766,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Monshaeh Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Monshaeh District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":26.434696,
     "lbl:longitude":31.758885,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092018599,
-    "wof:lastmodified":1553718038,
+    "wof:lastmodified":1560969122,
     "wof:name":"El-Monshaeh",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/201/864/9/1092018649.geojson
+++ b/data/109/201/864/9/1092018649.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":31.256006,
     "geom:longitude":30.03214,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Montazah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Montazah Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092018649,
-    "wof:lastmodified":1553718041,
+    "wof:lastmodified":1560969126,
     "wof:name":"El-Montazah",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/201/867/9/1092018679.geojson
+++ b/data/109/201/867/9/1092018679.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.052232,
     "geom:longitude":31.252342,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Mosky Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Mosky Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092018679,
-    "wof:lastmodified":1553718038,
+    "wof:lastmodified":1560969123,
     "wof:name":"El-Mosky",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/872/5/1092018725.geojson
+++ b/data/109/201/872/5/1092018725.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":31.458023,
     "geom:longitude":26.164093,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "El-Negielah Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Negielah District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
+    ],
     "lbl:latitude":31.44146,
     "lbl:longitude":26.164093,
     "meso:admin_1":"Marsa Matrooh",
@@ -57,7 +72,7 @@
         }
     ],
     "wof:id":1092018725,
-    "wof:lastmodified":1555047464,
+    "wof:lastmodified":1560969122,
     "wof:name":"El-Negielah",
     "wof:parent_id":85671031,
     "wof:placetype":"county",

--- a/data/109/201/876/3/1092018763.geojson
+++ b/data/109/201/876/3/1092018763.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":30.478702,
     "geom:longitude":30.459406,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Nobareyah City Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Nobareyah City Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":30.482077,
     "lbl:longitude":30.462729,
     "meso:admin_1":"Behera",
@@ -57,7 +72,7 @@
         }
     ],
     "wof:id":1092018763,
-    "wof:lastmodified":1555047464,
+    "wof:lastmodified":1560969125,
     "wof:name":"El-Nobareyah City",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/201/879/5/1092018795.geojson
+++ b/data/109/201/879/5/1092018795.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.114816,
     "geom:longitude":31.365242,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Nozhah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Nozhah Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092018795,
-    "wof:lastmodified":1553718038,
+    "wof:lastmodified":1560969124,
     "wof:name":"El-Nozhah",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/883/9/1092018839.geojson
+++ b/data/109/201/883/9/1092018839.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":25.687654,
     "geom:longitude":32.625967,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Oksor Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Oksor District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":25.695627,
     "lbl:longitude":32.635288,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092018839,
-    "wof:lastmodified":1553718038,
+    "wof:lastmodified":1560969124,
     "wof:name":"El-Oksor",
     "wof:parent_id":85671097,
     "wof:placetype":"county",

--- a/data/109/201/889/1/1092018891.geojson
+++ b/data/109/201/889/1/1092018891.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":29.993369,
     "geom:longitude":31.180647,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Omraneyah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Omraneyah Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092018891,
-    "wof:lastmodified":1553718039,
+    "wof:lastmodified":1560969121,
     "wof:name":"El-Omraneyah",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/201/893/5/1092018935.geojson
+++ b/data/109/201/893/5/1092018935.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.218425,
     "geom:longitude":31.149799,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Qanater El-Khaireyah Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Qanater El-Khaireyah District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.250985,
     "lbl:longitude":31.143709,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092018935,
-    "wof:lastmodified":1553718039,
+    "wof:lastmodified":1560969123,
     "wof:name":"El-Qanater El-Khaireyah",
     "wof:parent_id":85671003,
     "wof:placetype":"county",

--- a/data/109/201/897/9/1092018979.geojson
+++ b/data/109/201/897/9/1092018979.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.635853,
     "geom:longitude":31.469554,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Qanayat Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Qanayat Kism"
     ],
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092018979,
-    "wof:lastmodified":1553718039,
+    "wof:lastmodified":1560969126,
     "wof:name":"El-Qanayat",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/201/902/7/1092019027.geojson
+++ b/data/109/201/902/7/1092019027.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.520818,
     "geom:longitude":32.381917,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Qantarah Sharq Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Qantarah Sharq Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092019027,
-    "wof:lastmodified":1553718039,
+    "wof:lastmodified":1560969124,
     "wof:name":"El-Qantarah Sharq",
     "wof:parent_id":85670989,
     "wof:placetype":"county",

--- a/data/109/201/907/1/1092019071.geojson
+++ b/data/109/201/907/1/1092019071.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.756638,
     "geom:longitude":32.244893,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Qantarah Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Qantarah District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.756927,
     "lbl:longitude":32.244883,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092019071,
-    "wof:lastmodified":1553718040,
+    "wof:lastmodified":1560969120,
     "wof:name":"El-Qantarah",
     "wof:parent_id":85670989,
     "wof:placetype":"county",

--- a/data/109/201/910/5/1092019105.geojson
+++ b/data/109/201/910/5/1092019105.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.622642,
     "geom:longitude":31.747594,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Qareen Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Qareen Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092019105,
-    "wof:lastmodified":1553718040,
+    "wof:lastmodified":1560969126,
     "wof:name":"El-Qareen",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/201/914/7/1092019147.geojson
+++ b/data/109/201/914/7/1092019147.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":30.673578,
     "geom:longitude":34.325429,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Qaseemah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Qaseemah Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":30.808131,
     "lbl:longitude":34.263156,
     "meso:admin_1":"North Sinai",
@@ -56,7 +71,7 @@
         }
     ],
     "wof:id":1092019147,
-    "wof:lastmodified":1555047464,
+    "wof:lastmodified":1560969123,
     "wof:name":"El-Qaseemah",
     "wof:parent_id":85671093,
     "wof:placetype":"county",

--- a/data/109/201/919/3/1092019193.geojson
+++ b/data/109/201/919/3/1092019193.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":25.598524,
     "geom:longitude":34.016486,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Qoseir Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Qoseir Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092019193,
-    "wof:lastmodified":1553718039,
+    "wof:lastmodified":1560969126,
     "wof:name":"El-Qoseir",
     "wof:parent_id":85671085,
     "wof:placetype":"county",

--- a/data/109/201/922/9/1092019229.geojson
+++ b/data/109/201/922/9/1092019229.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":27.39727,
     "geom:longitude":30.807666,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Qoweisah Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Qoweisah District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":27.391986,
     "lbl:longitude":30.801515,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092019229,
-    "wof:lastmodified":1553718040,
+    "wof:lastmodified":1560969123,
     "wof:name":"El-Qoweisah",
     "wof:parent_id":85671069,
     "wof:placetype":"county",

--- a/data/109/201/927/3/1092019273.geojson
+++ b/data/109/201/927/3/1092019273.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.092582,
     "geom:longitude":30.599887,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Rahmaneyah Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Rahmaneyah District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.092943,
     "lbl:longitude":30.623199,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092019273,
-    "wof:lastmodified":1553718040,
+    "wof:lastmodified":1560969126,
     "wof:name":"El-Rahmaneyah",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/201/931/5/1092019315.geojson
+++ b/data/109/201/931/5/1092019315.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":31.203223,
     "geom:longitude":29.992125,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Raml Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Raml Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092019315,
-    "wof:lastmodified":1553718039,
+    "wof:lastmodified":1560969120,
     "wof:name":"El-Raml",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/201/936/1/1092019361.geojson
+++ b/data/109/201/936/1/1092019361.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.320672,
     "geom:longitude":30.925639,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Reyad Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Reyad District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.354912,
     "lbl:longitude":30.904597,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092019361,
-    "wof:lastmodified":1553718039,
+    "wof:lastmodified":1560969120,
     "wof:name":"El-Reyad",
     "wof:parent_id":85671057,
     "wof:placetype":"county",

--- a/data/109/201/940/5/1092019405.geojson
+++ b/data/109/201/940/5/1092019405.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.370796,
     "geom:longitude":30.703079,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Sadat City Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Sadat City District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.382223,
     "lbl:longitude":30.755883,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092019405,
-    "wof:lastmodified":1553718039,
+    "wof:lastmodified":1560969123,
     "wof:name":"El-Sadat City",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/201/945/3/1092019453.geojson
+++ b/data/109/201/945/3/1092019453.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":29.625433,
     "geom:longitude":31.294391,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Saf Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Saf District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":29.621095,
     "lbl:longitude":31.298663,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092019453,
-    "wof:lastmodified":1553718041,
+    "wof:lastmodified":1560969126,
     "wof:name":"El-Saf",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/201/949/9/1092019499.geojson
+++ b/data/109/201/949/9/1092019499.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.093245,
     "geom:longitude":31.246187,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Sahel Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Sahel Kism"
     ],
@@ -76,7 +85,7 @@
         }
     ],
     "wof:id":1092019499,
-    "wof:lastmodified":1553718039,
+    "wof:lastmodified":1560969123,
     "wof:name":"El-Sahel",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/953/5/1092019535.geojson
+++ b/data/109/201/953/5/1092019535.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.167781,
     "geom:longitude":31.415219,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Salam Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Salam Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092019535,
-    "wof:lastmodified":1553718039,
+    "wof:lastmodified":1560969121,
     "wof:name":"El-Salam",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/957/7/1092019577.geojson
+++ b/data/109/201/957/7/1092019577.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.676383,
     "geom:longitude":31.884338,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Salheyah El-Gedidah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Salheyah El-Gedidah Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092019577,
-    "wof:lastmodified":1553718039,
+    "wof:lastmodified":1560969124,
     "wof:name":"El-Salheyah El-Gedidah",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/201/962/1/1092019621.geojson
+++ b/data/109/201/962/1/1092019621.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.499252,
     "geom:longitude":25.194534,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "El-Saloom Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
     "label:eng_x_preferred_longname":[
-        "El-Saloom Kism"
+        "El-Saloom District"
     ],
     "label:eng_x_preferred_placetype":[
-        "kism"
+        "district"
     ],
     "lbl:latitude":30.177982,
     "lbl:longitude":25.140316,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092019621,
-    "wof:lastmodified":1553718039,
+    "wof:lastmodified":1560969121,
     "wof:name":"El-Saloom",
     "wof:parent_id":85671031,
     "wof:placetype":"county",

--- a/data/109/201/964/9/1092019649.geojson
+++ b/data/109/201/964/9/1092019649.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.76843,
     "geom:longitude":31.114099,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Santah Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Santah District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.769457,
     "lbl:longitude":31.119982,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092019649,
-    "wof:lastmodified":1553718041,
+    "wof:lastmodified":1560969121,
     "wof:name":"El-Santah",
     "wof:parent_id":85670985,
     "wof:placetype":"county",

--- a/data/109/201/969/3/1092019693.geojson
+++ b/data/109/201/969/3/1092019693.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.031076,
     "geom:longitude":31.241919,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Sayedah Zeinab Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Sayedah Zeinab Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092019693,
-    "wof:lastmodified":1553718040,
+    "wof:lastmodified":1560969124,
     "wof:name":"El-Sayedah Zeinab",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/974/1/1092019741.geojson
+++ b/data/109/201/974/1/1092019741.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.880406,
     "geom:longitude":31.488339,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Senbelawein Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Senbelawein District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.888338,
     "lbl:longitude":31.461076,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092019741,
-    "wof:lastmodified":1553718040,
+    "wof:lastmodified":1560969126,
     "wof:name":"El-Senbelawein",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/201/978/7/1092019787.geojson
+++ b/data/109/201/978/7/1092019787.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":22.931636,
     "geom:longitude":34.719853,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Shalateen Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Shalateen Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092019787,
-    "wof:lastmodified":1553718041,
+    "wof:lastmodified":1560969123,
     "wof:name":"El-Shalateen",
     "wof:parent_id":85671085,
     "wof:placetype":"county",

--- a/data/109/201/983/1/1092019831.geojson
+++ b/data/109/201/983/1/1092019831.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.080711,
     "geom:longitude":31.261695,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Sharabeyah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Sharabeyah Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092019831,
-    "wof:lastmodified":1553718040,
+    "wof:lastmodified":1560969123,
     "wof:name":"El-Sharabeyah",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/987/7/1092019877.geojson
+++ b/data/109/201/987/7/1092019877.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":31.26112,
     "geom:longitude":32.301958,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Sharq Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Sharq Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":31.266797,
     "lbl:longitude":32.307779,
     "meso:admin_1":"Port Said",
@@ -57,7 +72,7 @@
         }
     ],
     "wof:id":1092019877,
-    "wof:lastmodified":1555047465,
+    "wof:lastmodified":1560969126,
     "wof:name":"El-Sharq",
     "wof:parent_id":85671021,
     "wof:placetype":"county",

--- a/data/109/201/992/1/1092019921.geojson
+++ b/data/109/201/992/1/1092019921.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":31.074969,
     "geom:longitude":34.064049,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "El-Sheikh Zoweid Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Sheikh Zoweid District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
+    ],
     "lbl:latitude":31.073081,
     "lbl:longitude":34.076401,
     "meso:admin_1":"North Sinai",
@@ -57,7 +72,7 @@
         }
     ],
     "wof:id":1092019921,
-    "wof:lastmodified":1555047465,
+    "wof:lastmodified":1560969124,
     "wof:name":"El-Sheikh Zoweid",
     "wof:parent_id":85671093,
     "wof:placetype":"county",

--- a/data/109/201/994/9/1092019949.geojson
+++ b/data/109/201/994/9/1092019949.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.598084,
     "geom:longitude":30.864176,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Shohada Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Shohada District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.59651,
     "lbl:longitude":30.876804,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092019949,
-    "wof:lastmodified":1553718040,
+    "wof:lastmodified":1560969124,
     "wof:name":"El-Shohada",
     "wof:parent_id":85670995,
     "wof:placetype":"county",

--- a/data/109/201/999/7/1092019997.geojson
+++ b/data/109/201/999/7/1092019997.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":30.00917,
     "geom:longitude":32.557886,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Suez Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Suez Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":30.016229,
     "lbl:longitude":32.559446,
     "meso:admin_1":"Suez",
@@ -57,7 +72,7 @@
         }
     ],
     "wof:id":1092019997,
-    "wof:lastmodified":1555047465,
+    "wof:lastmodified":1560969121,
     "wof:name":"El-Suez",
     "wof:parent_id":85671013,
     "wof:placetype":"county",

--- a/data/109/202/003/9/1092020039.geojson
+++ b/data/109/202/003/9/1092020039.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.535693,
     "geom:longitude":31.896974,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Tal El-Kebeer Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Tal El-Kebeer District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.514654,
     "lbl:longitude":31.872797,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092020039,
-    "wof:lastmodified":1553718040,
+    "wof:lastmodified":1560969119,
     "wof:name":"El-Tal El-Kebeer",
     "wof:parent_id":85670989,
     "wof:placetype":"county",

--- a/data/109/202/007/5/1092020075.geojson
+++ b/data/109/202/007/5/1092020075.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":29.78017,
     "geom:longitude":31.305594,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Tebeen Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Tebeen Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092020075,
-    "wof:lastmodified":1553718040,
+    "wof:lastmodified":1560969116,
     "wof:name":"El-Tebeen",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/011/3/1092020113.geojson
+++ b/data/109/202/011/3/1092020113.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":28.224736,
     "geom:longitude":33.841252,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Tour Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Tour Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":28.203373,
     "lbl:longitude":33.882356,
     "meso:admin_1":"South Sinai",
@@ -57,7 +72,7 @@
         }
     ],
     "wof:id":1092020113,
-    "wof:lastmodified":1555047465,
+    "wof:lastmodified":1560969118,
     "wof:name":"El-Tour",
     "wof:parent_id":85671089,
     "wof:placetype":"county",

--- a/data/109/202/015/5/1092020155.geojson
+++ b/data/109/202/015/5/1092020155.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":28.442395,
     "geom:longitude":28.856477,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "El-Wahat El-Bahareyah Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
     "label:eng_x_preferred_longname":[
-        "El-Wahat El-Bahareyah Kism"
+        "El-Wahat El-Bahareyah District"
     ],
     "label:eng_x_preferred_placetype":[
-        "kism"
+        "district"
     ],
     "lbl:latitude":28.407211,
     "lbl:longitude":28.805362,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092020155,
-    "wof:lastmodified":1553718040,
+    "wof:lastmodified":1560969115,
     "wof:name":"El-Wahat El-Bahareyah",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/202/020/1/1092020201.geojson
+++ b/data/109/202/020/1/1092020201.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":24.153939,
     "geom:longitude":27.455035,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Wahat El-Dakhlah Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Wahat El-Dakhlah District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":24.14366,
     "lbl:longitude":27.455545,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092020201,
-    "wof:lastmodified":1553718040,
+    "wof:lastmodified":1560969118,
     "wof:name":"El-Wahat El-Dakhlah",
     "wof:parent_id":85671071,
     "wof:placetype":"county",

--- a/data/109/202/022/3/1092020223.geojson
+++ b/data/109/202/022/3/1092020223.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":24.405636,
     "geom:longitude":31.13675,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "El-Wahat El-Khargah Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
     "label:eng_x_preferred_longname":[
-        "El-Wahat El-Khargah Kism"
+        "El-Wahat El-Khargah District"
     ],
     "label:eng_x_preferred_placetype":[
-        "kism"
+        "district"
     ],
     "lbl:latitude":24.445214,
     "lbl:longitude":31.164193,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092020223,
-    "wof:lastmodified":1553718042,
+    "wof:lastmodified":1560969116,
     "wof:name":"El-Wahat El-Khargah",
     "wof:parent_id":85671071,
     "wof:placetype":"county",

--- a/data/109/202/027/3/1092020273.geojson
+++ b/data/109/202/027/3/1092020273.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.073497,
     "geom:longitude":31.285654,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Waily Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Waily Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092020273,
-    "wof:lastmodified":1553718040,
+    "wof:lastmodified":1560969118,
     "wof:name":"El-Waily",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/031/5/1092020315.geojson
+++ b/data/109/202/031/5/1092020315.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":26.089199,
     "geom:longitude":32.447891,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Waqf Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Waqf District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":26.092324,
     "lbl:longitude":32.449403,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092020315,
-    "wof:lastmodified":1553718041,
+    "wof:lastmodified":1560969116,
     "wof:name":"El-Waqf",
     "wof:parent_id":85671075,
     "wof:placetype":"county",

--- a/data/109/202/034/9/1092020349.geojson
+++ b/data/109/202/034/9/1092020349.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.101892,
     "geom:longitude":31.199889,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Warraq Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Warraq Kism"
     ],
@@ -76,7 +85,7 @@
         }
     ],
     "wof:id":1092020349,
-    "wof:lastmodified":1553718040,
+    "wof:lastmodified":1560969119,
     "wof:name":"El-Warraq",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/202/039/5/1092020395.geojson
+++ b/data/109/202/039/5/1092020395.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":29.300167,
     "geom:longitude":31.1614,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Wasty Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Wasty District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":29.290123,
     "lbl:longitude":31.162852,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092020395,
-    "wof:lastmodified":1553718042,
+    "wof:lastmodified":1560969117,
     "wof:name":"El-Wasty",
     "wof:parent_id":85671053,
     "wof:placetype":"county",

--- a/data/109/202/043/7/1092020437.geojson
+++ b/data/109/202/043/7/1092020437.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.055682,
     "geom:longitude":31.222671,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Zamalek Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Zamalek Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092020437,
-    "wof:lastmodified":1553718041,
+    "wof:lastmodified":1560969119,
     "wof:name":"El-Zamalek",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/047/9/1092020479.geojson
+++ b/data/109/202/047/9/1092020479.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.590807,
     "geom:longitude":31.49723,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Zaqazeeq Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Zaqazeeq District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.541432,
     "lbl:longitude":31.534948,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092020479,
-    "wof:lastmodified":1553718042,
+    "wof:lastmodified":1560969116,
     "wof:name":"El-Zaqazeeq",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/202/050/9/1092020509.geojson
+++ b/data/109/202/050/9/1092020509.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.226837,
     "geom:longitude":31.675044,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "El-Zarqah Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "El-Zarqah District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.242944,
     "lbl:longitude":31.696255,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092020509,
-    "wof:lastmodified":1553718042,
+    "wof:lastmodified":1560969119,
     "wof:name":"El-Zarqah",
     "wof:parent_id":85671025,
     "wof:placetype":"county",

--- a/data/109/202/055/1/1092020551.geojson
+++ b/data/109/202/055/1/1092020551.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.101079,
     "geom:longitude":31.269688,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Zawyah El-Hamra Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Zawyah El-Hamra Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092020551,
-    "wof:lastmodified":1553718042,
+    "wof:lastmodified":1560969116,
     "wof:name":"El-Zawyah El-Hamra",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/059/9/1092020599.geojson
+++ b/data/109/202/059/9/1092020599.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.104348,
     "geom:longitude":31.302853,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "El-Zaytoon Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "El-Zaytoon Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092020599,
-    "wof:lastmodified":1553718042,
+    "wof:lastmodified":1560969119,
     "wof:name":"El-Zaytoon",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/063/1/1092020631.geojson
+++ b/data/109/202/063/1/1092020631.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.174784,
     "geom:longitude":31.023679,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Embabah Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
     "label:eng_x_preferred_longname":[
-        "Embabah Kism"
+        "Embabah District"
     ],
     "label:eng_x_preferred_placetype":[
-        "kism"
+        "district"
     ],
     "lbl:latitude":30.170678,
     "lbl:longitude":31.058554,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092020631,
-    "wof:lastmodified":1553718042,
+    "wof:lastmodified":1560969116,
     "wof:name":"Embabah",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/202/068/3/1092020683.geojson
+++ b/data/109/202/068/3/1092020683.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.078633,
     "geom:longitude":31.20647,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Embabah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
-        "Embabah Markaz"
+        "Embabah Kism"
     ],
     "label:eng_x_preferred_placetype":[
-        "markaz"
+        "kism"
     ],
     "lbl:latitude":30.079269,
     "lbl:longitude":31.210726,
@@ -76,7 +85,7 @@
         }
     ],
     "wof:id":1092020683,
-    "wof:lastmodified":1553718042,
+    "wof:lastmodified":1560969119,
     "wof:name":"Embabah",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/202/072/1/1092020721.geojson
+++ b/data/109/202/072/1/1092020721.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":25.353645,
     "geom:longitude":32.541544,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Esna Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Esna District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":25.349849,
     "lbl:longitude":32.53437,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092020721,
-    "wof:lastmodified":1553718042,
+    "wof:lastmodified":1560969119,
     "wof:name":"Esna",
     "wof:parent_id":85671075,
     "wof:placetype":"county",

--- a/data/109/202/074/9/1092020749.geojson
+++ b/data/109/202/074/9/1092020749.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.884829,
     "geom:longitude":30.66173,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Etay El-Barood Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Etay El-Barood District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.884715,
     "lbl:longitude":30.650605,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092020749,
-    "wof:lastmodified":1553718042,
+    "wof:lastmodified":1560969118,
     "wof:name":"Etay El-Barood",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/202/078/9/1092020789.geojson
+++ b/data/109/202/078/9/1092020789.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":26.000577,
     "geom:longitude":32.812271,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Faqat Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Faqat District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":26.001954,
     "lbl:longitude":32.807946,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092020789,
-    "wof:lastmodified":1553718042,
+    "wof:lastmodified":1560969116,
     "wof:name":"Faqat",
     "wof:parent_id":85671075,
     "wof:placetype":"county",

--- a/data/109/202/083/3/1092020833.geojson
+++ b/data/109/202/083/3/1092020833.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.752994,
     "geom:longitude":31.855981,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Faqoos Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
-        "Faqoos Markaz"
+        "Faqoos Kism"
     ],
     "label:eng_x_preferred_placetype":[
-        "markaz"
+        "kism"
     ],
     "lbl:latitude":30.751501,
     "lbl:longitude":31.844352,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092020833,
-    "wof:lastmodified":1553718042,
+    "wof:lastmodified":1560969116,
     "wof:name":"Faqoos",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/202/086/5/1092020865.geojson
+++ b/data/109/202/086/5/1092020865.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.313969,
     "geom:longitude":31.743828,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Farasko Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Farasko District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.304107,
     "lbl:longitude":31.736645,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092020865,
-    "wof:lastmodified":1553718042,
+    "wof:lastmodified":1560969119,
     "wof:name":"Farasko",
     "wof:parent_id":85671025,
     "wof:placetype":"county",

--- a/data/109/202/090/3/1092020903.geojson
+++ b/data/109/202/090/3/1092020903.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":26.04944,
     "geom:longitude":32.15636,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Farshoot Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Farshoot District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":26.045786,
     "lbl:longitude":32.157209,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092020903,
-    "wof:lastmodified":1553718042,
+    "wof:lastmodified":1560969117,
     "wof:name":"Farshoot",
     "wof:parent_id":85671075,
     "wof:placetype":"county",

--- a/data/109/202/094/5/1092020945.geojson
+++ b/data/109/202/094/5/1092020945.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.379333,
     "geom:longitude":32.328471,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Fayed Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Fayed District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.428185,
     "lbl:longitude":32.328481,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092020945,
-    "wof:lastmodified":1553718042,
+    "wof:lastmodified":1560969120,
     "wof:name":"Fayed",
     "wof:parent_id":85670989,
     "wof:placetype":"county",

--- a/data/109/202/097/9/1092020979.geojson
+++ b/data/109/202/097/9/1092020979.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.048384,
     "geom:longitude":32.492731,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Feisal Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Feisal Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092020979,
-    "wof:lastmodified":1553718042,
+    "wof:lastmodified":1560969117,
     "wof:name":"Feisal",
     "wof:parent_id":85671013,
     "wof:placetype":"county",

--- a/data/109/202/100/1/1092021001.geojson
+++ b/data/109/202/100/1/1092021001.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":31.206439,
     "geom:longitude":32.320825,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Fouad Port Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Fouad Port Kism"
     ],
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092021001,
-    "wof:lastmodified":1553718043,
+    "wof:lastmodified":1560969118,
     "wof:name":"Fouad Port",
     "wof:parent_id":85671021,
     "wof:placetype":"county",

--- a/data/109/202/104/5/1092021045.geojson
+++ b/data/109/202/104/5/1092021045.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.226457,
     "geom:longitude":30.579152,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Fowah Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Fowah District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.228495,
     "lbl:longitude":30.572046,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092021045,
-    "wof:lastmodified":1553718043,
+    "wof:lastmodified":1560969115,
     "wof:name":"Fowah",
     "wof:parent_id":85671057,
     "wof:placetype":"county",

--- a/data/109/202/108/3/1092021083.geojson
+++ b/data/109/202/108/3/1092021083.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":26.33965,
     "geom:longitude":31.884702,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Gerga City Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
-        "Gerga City"
+        "Gerga City Kism"
     ],
     "label:eng_x_preferred_placetype":[
-        "markaz"
+        "kism"
     ],
     "lbl:latitude":26.336856,
     "lbl:longitude":31.886048,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092021083,
-    "wof:lastmodified":1555092024,
+    "wof:lastmodified":1560969118,
     "wof:name":"Gerga City",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/202/112/7/1092021127.geojson
+++ b/data/109/202/112/7/1092021127.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":26.30987,
     "geom:longitude":31.848807,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Gerga Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
     "label:eng_x_preferred_longname":[
-        "Gerga Kism"
+        "Gerga District"
     ],
     "label:eng_x_preferred_placetype":[
-        "kism"
+        "district"
     ],
     "lbl:latitude":26.318161,
     "lbl:longitude":31.834386,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092021127,
-    "wof:lastmodified":1553718043,
+    "wof:lastmodified":1560969120,
     "wof:name":"Gerga",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/202/117/3/1092021173.geojson
+++ b/data/109/202/117/3/1092021173.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":29.943031,
     "geom:longitude":31.208916,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Giza Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
     "label:eng_x_preferred_longname":[
-        "Giza Kism"
+        "Giza District"
     ],
     "label:eng_x_preferred_placetype":[
-        "kism"
+        "district"
     ],
     "lbl:latitude":29.943336,
     "lbl:longitude":31.208916,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092021173,
-    "wof:lastmodified":1553718043,
+    "wof:lastmodified":1560969117,
     "wof:name":"Giza",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/202/120/3/1092021203.geojson
+++ b/data/109/202/120/3/1092021203.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":29.996324,
     "geom:longitude":31.215167,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Giza Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
-        "Giza Markaz"
+        "Giza Kism"
     ],
     "label:eng_x_preferred_placetype":[
-        "markaz"
+        "kism"
     ],
     "lbl:latitude":29.997266,
     "lbl:longitude":31.217164,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092021203,
-    "wof:lastmodified":1553718042,
+    "wof:lastmodified":1560969117,
     "wof:name":"Giza",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/202/123/3/1092021233.geojson
+++ b/data/109/202/123/3/1092021233.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":26.682317,
     "geom:longitude":31.470067,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Gohaynah El-Gharbeyah Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Gohaynah El-Gharbeyah District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":26.687702,
     "lbl:longitude":31.470052,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092021233,
-    "wof:lastmodified":1553718042,
+    "wof:lastmodified":1560969120,
     "wof:name":"Gohaynah El-Gharbeyah",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/202/127/5/1092021275.geojson
+++ b/data/109/202/127/5/1092021275.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.090817,
     "geom:longitude":31.281813,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Hadayeq El-Qobbah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Hadayeq El-Qobbah Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092021275,
-    "wof:lastmodified":1553718043,
+    "wof:lastmodified":1560969117,
     "wof:name":"Hadayeq El-Qobbah",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/131/9/1092021319.geojson
+++ b/data/109/202/131/9/1092021319.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.661422,
     "geom:longitude":31.595539,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Hahya Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Hahya District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.658165,
     "lbl:longitude":31.602125,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092021319,
-    "wof:lastmodified":1553718043,
+    "wof:lastmodified":1560969118,
     "wof:name":"Hahya",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/202/134/9/1092021349.geojson
+++ b/data/109/202/134/9/1092021349.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":22.184828,
     "geom:longitude":36.608716,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Halayeb Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Halayeb Kism"
     ],
@@ -79,7 +88,7 @@
         }
     ],
     "wof:id":1092021349,
-    "wof:lastmodified":1553718043,
+    "wof:lastmodified":1560969115,
     "wof:name":"Halayeb",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/202/138/7/1092021387.geojson
+++ b/data/109/202/138/7/1092021387.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.091295,
     "geom:longitude":31.324337,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Heliopolis Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Heliopolis Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092021387,
-    "wof:lastmodified":1553718043,
+    "wof:lastmodified":1560969118,
     "wof:name":"Heliopolis",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/142/7/1092021427.geojson
+++ b/data/109/202/142/7/1092021427.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":29.859512,
     "geom:longitude":31.310512,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Helwan Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Helwan Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092021427,
-    "wof:lastmodified":1553718043,
+    "wof:lastmodified":1560969117,
     "wof:name":"Helwan",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/145/9/1092021459.geojson
+++ b/data/109/202/145/9/1092021459.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.874313,
     "geom:longitude":30.318339,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Housh Eisa Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Housh Eisa District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.845569,
     "lbl:longitude":30.31038,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092021459,
-    "wof:lastmodified":1553718043,
+    "wof:lastmodified":1560969117,
     "wof:name":"Housh Eisa",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/202/149/7/1092021497.geojson
+++ b/data/109/202/149/7/1092021497.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":27.128441,
     "geom:longitude":33.245102,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Hurghada Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Hurghada Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092021497,
-    "wof:lastmodified":1553718043,
+    "wof:lastmodified":1560969120,
     "wof:name":"Hurghada",
     "wof:parent_id":85671085,
     "wof:placetype":"county",

--- a/data/109/202/154/1/1092021541.geojson
+++ b/data/109/202/154/1/1092021541.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.11304,
     "geom:longitude":30.095811,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Kafr El-Dawwar Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
-        "Kafr El-Dawwar Markaz"
+        "Kafr El-Dawwar Kism"
     ],
     "label:eng_x_preferred_placetype":[
-        "markaz"
+        "kism"
     ],
     "lbl:latitude":31.119484,
     "lbl:longitude":30.110842,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092021541,
-    "wof:lastmodified":1553718043,
+    "wof:lastmodified":1560969118,
     "wof:name":"Kafr El-Dawwar",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/202/158/1/1092021581.geojson
+++ b/data/109/202/158/1/1092021581.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.157621,
     "geom:longitude":30.967281,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Kafr El-Sheikh Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Kafr El-Sheikh District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.126056,
     "lbl:longitude":30.979461,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092021581,
-    "wof:lastmodified":1553718044,
+    "wof:lastmodified":1560969115,
     "wof:name":"Kafr El-Sheikh",
     "wof:parent_id":85671057,
     "wof:placetype":"county",

--- a/data/109/202/162/3/1092021623.geojson
+++ b/data/109/202/162/3/1092021623.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.801736,
     "geom:longitude":30.82938,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Kafr El-Zayyat Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Kafr El-Zayyat District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.777152,
     "lbl:longitude":30.836541,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092021623,
-    "wof:lastmodified":1553718043,
+    "wof:lastmodified":1560969118,
     "wof:name":"Kafr El-Zayyat",
     "wof:parent_id":85670985,
     "wof:placetype":"county",

--- a/data/109/202/167/3/1092021673.geojson
+++ b/data/109/202/167/3/1092021673.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.371803,
     "geom:longitude":31.629888,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Kafr Sa'd Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Kafr Sa'd District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.35525,
     "lbl:longitude":31.653365,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092021673,
-    "wof:lastmodified":1553718044,
+    "wof:lastmodified":1560969115,
     "wof:name":"Kafr Sa'd",
     "wof:parent_id":85671025,
     "wof:placetype":"county",

--- a/data/109/202/171/5/1092021715.geojson
+++ b/data/109/202/171/5/1092021715.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.839373,
     "geom:longitude":31.664357,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Kafr Saqr Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Kafr Saqr District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.838839,
     "lbl:longitude":31.675072,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092021715,
-    "wof:lastmodified":1553718043,
+    "wof:lastmodified":1560969120,
     "wof:name":"Kafr Saqr",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/202/174/7/1092021747.geojson
+++ b/data/109/202/174/7/1092021747.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.555969,
     "geom:longitude":31.277611,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Kafr Shokr Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Kafr Shokr District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.558232,
     "lbl:longitude":31.278588,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092021747,
-    "wof:lastmodified":1553718043,
+    "wof:lastmodified":1560969117,
     "wof:name":"Kafr Shokr",
     "wof:parent_id":85671003,
     "wof:placetype":"county",

--- a/data/109/202/179/1/1092021791.geojson
+++ b/data/109/202/179/1/1092021791.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":31.168227,
     "geom:longitude":29.89981,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Karmooz Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Karmooz Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":31.166372,
     "lbl:longitude":29.896937,
     "meso:admin_1":"Alexandria",
@@ -57,7 +72,7 @@
         }
     ],
     "wof:id":1092021791,
-    "wof:lastmodified":1555047465,
+    "wof:lastmodified":1560969120,
     "wof:name":"Karmooz",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/202/182/9/1092021829.geojson
+++ b/data/109/202/182/9/1092021829.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.079587,
     "geom:longitude":30.834056,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Keleen Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Keleen District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.07667,
     "lbl:longitude":30.820524,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092021829,
-    "wof:lastmodified":1553718044,
+    "wof:lastmodified":1560969120,
     "wof:name":"Keleen",
     "wof:parent_id":85671057,
     "wof:placetype":"county",

--- a/data/109/202/188/1/1092021881.geojson
+++ b/data/109/202/188/1/1092021881.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":30.625431,
     "geom:longitude":30.579736,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Koum Hamadah Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Koum Hamadah District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
+    ],
     "lbl:latitude":30.630644,
     "lbl:longitude":30.662688,
     "meso:admin_1":"Behera",
@@ -56,7 +71,7 @@
         }
     ],
     "wof:id":1092021881,
-    "wof:lastmodified":1555047465,
+    "wof:lastmodified":1560969117,
     "wof:name":"Koum Hamadah",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/202/192/7/1092021927.geojson
+++ b/data/109/202/192/7/1092021927.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":24.534224,
     "geom:longitude":32.941192,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Koum Ombu Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Koum Ombu District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":24.518322,
     "lbl:longitude":32.919767,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092021927,
-    "wof:lastmodified":1553718044,
+    "wof:lastmodified":1560969115,
     "wof:name":"Koum Ombu",
     "wof:parent_id":85671061,
     "wof:placetype":"county",

--- a/data/109/202/196/5/1092021965.geojson
+++ b/data/109/202/196/5/1092021965.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":28.622303,
     "geom:longitude":30.783684,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Maghaghah Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Maghaghah District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":28.626223,
     "lbl:longitude":30.817528,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092021965,
-    "wof:lastmodified":1553718044,
+    "wof:lastmodified":1560969118,
     "wof:name":"Maghaghah",
     "wof:parent_id":85671049,
     "wof:placetype":"county",

--- a/data/109/202/200/5/1092022005.geojson
+++ b/data/109/202/200/5/1092022005.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":27.762713,
     "geom:longitude":30.788327,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Mallawy Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Mallawy Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092022005,
-    "wof:lastmodified":1553718043,
+    "wof:lastmodified":1560969119,
     "wof:name":"Mallawy",
     "wof:parent_id":85671049,
     "wof:placetype":"county",

--- a/data/109/202/204/5/1092022045.geojson
+++ b/data/109/202/204/5/1092022045.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":27.288966,
     "geom:longitude":30.938527,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Manfalout Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Manfalout District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":27.271641,
     "lbl:longitude":30.947172,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092022045,
-    "wof:lastmodified":1553718044,
+    "wof:lastmodified":1560969116,
     "wof:name":"Manfalout",
     "wof:parent_id":85671069,
     "wof:placetype":"county",

--- a/data/109/202/209/3/1092022093.geojson
+++ b/data/109/202/209/3/1092022093.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":24.562918,
     "geom:longitude":34.283961,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Marsa Alam Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Marsa Alam Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092022093,
-    "wof:lastmodified":1553718043,
+    "wof:lastmodified":1560969119,
     "wof:name":"Marsa Alam",
     "wof:parent_id":85671085,
     "wof:placetype":"county",

--- a/data/109/202/211/5/1092022115.geojson
+++ b/data/109/202/211/5/1092022115.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.239351,
     "geom:longitude":27.059197,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Marsa Matrooh Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
     "label:eng_x_preferred_longname":[
-        "Marsa Matrooh Kism"
+        "Marsa Matrooh District"
     ],
     "label:eng_x_preferred_placetype":[
-        "kism"
+        "district"
     ],
     "lbl:latitude":30.242915,
     "lbl:longitude":27.074339,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092022115,
-    "wof:lastmodified":1553718043,
+    "wof:lastmodified":1560969115,
     "wof:name":"Marsa Matrooh",
     "wof:parent_id":85671031,
     "wof:placetype":"county",

--- a/data/109/202/216/5/1092022165.geojson
+++ b/data/109/202/216/5/1092022165.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.374697,
     "geom:longitude":31.378658,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Mashtool El-Sooq Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Mashtool El-Sooq District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.367092,
     "lbl:longitude":31.377924,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092022165,
-    "wof:lastmodified":1553718043,
+    "wof:lastmodified":1560969115,
     "wof:name":"Mashtool El-Sooq",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/202/221/1/1092022211.geojson
+++ b/data/109/202/221/1/1092022211.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.00722,
     "geom:longitude":31.238599,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Masr El-Qadeemah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Masr El-Qadeemah Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092022211,
-    "wof:lastmodified":1553718043,
+    "wof:lastmodified":1560969116,
     "wof:name":"Masr El-Qadeemah",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/223/9/1092022239.geojson
+++ b/data/109/202/223/9/1092022239.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":28.412605,
     "geom:longitude":30.716159,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Matay Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Matay District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":28.407242,
     "lbl:longitude":30.723954,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092022239,
-    "wof:lastmodified":1553718043,
+    "wof:lastmodified":1560969118,
     "wof:name":"Matay",
     "wof:parent_id":85671049,
     "wof:placetype":"county",

--- a/data/109/202/227/7/1092022277.geojson
+++ b/data/109/202/227/7/1092022277.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.714323,
     "geom:longitude":31.319513,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Meet Ghamr Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
-        "Meet Ghamr Markaz"
+        "Meet Ghamr Kism"
     ],
     "label:eng_x_preferred_placetype":[
-        "markaz"
+        "kism"
     ],
     "lbl:latitude":30.721424,
     "lbl:longitude":31.321028,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092022277,
-    "wof:lastmodified":1553718044,
+    "wof:lastmodified":1560969115,
     "wof:name":"Meet Ghamr",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/202/232/5/1092022325.geojson
+++ b/data/109/202/232/5/1092022325.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.256176,
     "geom:longitude":31.812066,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Meet Salseel Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Meet Salseel District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.23243,
     "lbl:longitude":31.797883,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092022325,
-    "wof:lastmodified":1553718044,
+    "wof:lastmodified":1560969116,
     "wof:name":"Meet Salseel",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/202/236/9/1092022369.geojson
+++ b/data/109/202/236/9/1092022369.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.460979,
     "geom:longitude":30.912992,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Menoof Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
     "label:eng_x_preferred_longname":[
-        "Menoof Kism"
+        "Menoof District"
     ],
     "label:eng_x_preferred_placetype":[
-        "kism"
+        "district"
     ],
     "lbl:latitude":30.471625,
     "lbl:longitude":30.9024,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092022369,
-    "wof:lastmodified":1553718044,
+    "wof:lastmodified":1560969119,
     "wof:name":"Menoof",
     "wof:parent_id":85670995,
     "wof:placetype":"county",

--- a/data/109/202/240/3/1092022403.geojson
+++ b/data/109/202/240/3/1092022403.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.506026,
     "geom:longitude":31.367671,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Menya El-Qamh Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Menya El-Qamh District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.51253,
     "lbl:longitude":31.360071,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092022403,
-    "wof:lastmodified":1553718043,
+    "wof:lastmodified":1560969119,
     "wof:name":"Menya El-Qamh",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/202/245/1/1092022451.geojson
+++ b/data/109/202/245/1/1092022451.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.1653,
     "geom:longitude":31.709644,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Menyet El-Nasr Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Menyet El-Nasr District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.170338,
     "lbl:longitude":31.692729,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092022451,
-    "wof:lastmodified":1553718044,
+    "wof:lastmodified":1560969116,
     "wof:name":"Menyet El-Nasr",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/202/249/9/1092022499.geojson
+++ b/data/109/202/249/9/1092022499.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":31.156478,
     "geom:longitude":29.865961,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Mina El-Basal Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Mina El-Basal Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":31.159637,
     "lbl:longitude":29.872242,
     "meso:admin_1":"Alexandria",
@@ -57,7 +72,7 @@
         }
     ],
     "wof:id":1092022499,
-    "wof:lastmodified":1555047465,
+    "wof:lastmodified":1560969119,
     "wof:name":"Mina El-Basal",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/202/252/5/1092022525.geojson
+++ b/data/109/202/252/5/1092022525.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":31.177899,
     "geom:longitude":29.918697,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Moharam Bek Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Moharam Bek Kism"
     ],
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092022525,
-    "wof:lastmodified":1553718043,
+    "wof:lastmodified":1560969120,
     "wof:name":"Moharam Bek",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/202/257/1/1092022571.geojson
+++ b/data/109/202/257/1/1092022571.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.045099,
     "geom:longitude":31.281746,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Monshaet Naser Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Monshaet Naser Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092022571,
-    "wof:lastmodified":1553718044,
+    "wof:lastmodified":1560969116,
     "wof:name":"Monshaet Naser",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/261/7/1092022617.geojson
+++ b/data/109/202/261/7/1092022617.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.377521,
     "geom:longitude":30.514573,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Motobas Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Motobas District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.404774,
     "lbl:longitude":30.478412,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092022617,
-    "wof:lastmodified":1553718044,
+    "wof:lastmodified":1560969116,
     "wof:name":"Motobas",
     "wof:parent_id":85671057,
     "wof:placetype":"county",

--- a/data/109/202/265/3/1092022653.geojson
+++ b/data/109/202/265/3/1092022653.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":26.051714,
     "geom:longitude":32.274918,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Nag' Hammady Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Nag' Hammady District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":26.041789,
     "lbl:longitude":32.273054,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092022653,
-    "wof:lastmodified":1553718044,
+    "wof:lastmodified":1560969119,
     "wof:name":"Nag' Hammady",
     "wof:parent_id":85671075,
     "wof:placetype":"county",

--- a/data/109/202/269/7/1092022697.geojson
+++ b/data/109/202/269/7/1092022697.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":29.975625,
     "geom:longitude":34.00309,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Nakhl Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
     "label:eng_x_preferred_longname":[
-        "Nakhl Kism"
+        "Nakhl District"
     ],
     "label:eng_x_preferred_placetype":[
-        "kism"
+        "district"
     ],
     "lbl:latitude":29.981944,
     "lbl:longitude":34.10736,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092022697,
-    "wof:lastmodified":1553718044,
+    "wof:lastmodified":1560969117,
     "wof:name":"Nakhl",
     "wof:parent_id":85671093,
     "wof:placetype":"county",

--- a/data/109/202/273/9/1092022739.geojson
+++ b/data/109/202/273/9/1092022739.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":25.885627,
     "geom:longitude":32.731029,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Naqadah Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Naqadah District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":25.840252,
     "lbl:longitude":32.719792,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092022739,
-    "wof:lastmodified":1553718044,
+    "wof:lastmodified":1560969115,
     "wof:name":"Naqadah",
     "wof:parent_id":85671075,
     "wof:placetype":"county",

--- a/data/109/202/277/9/1092022779.geojson
+++ b/data/109/202/277/9/1092022779.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":29.184539,
     "geom:longitude":31.092731,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Naser Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Naser District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":29.177245,
     "lbl:longitude":31.121319,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092022779,
-    "wof:lastmodified":1553718044,
+    "wof:lastmodified":1560969118,
     "wof:name":"Naser",
     "wof:parent_id":85671053,
     "wof:placetype":"county",

--- a/data/109/202/282/3/1092022823.geojson
+++ b/data/109/202/282/3/1092022823.geojson
@@ -10,8 +10,17 @@
     "geom:latitude":30.05628,
     "geom:longitude":31.365738,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Nasr City Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
-        "Nasr City"
+        "Nasr City Kism"
     ],
     "label:eng_x_preferred_placetype":[
         "kism"
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092022823,
-    "wof:lastmodified":1555092024,
+    "wof:lastmodified":1560969119,
     "wof:name":"Nasr City",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/286/7/1092022867.geojson
+++ b/data/109/202/286/7/1092022867.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":24.518759,
     "geom:longitude":33.008547,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Nasr Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Nasr District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":24.581018,
     "lbl:longitude":32.979249,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092022867,
-    "wof:lastmodified":1553718044,
+    "wof:lastmodified":1560969116,
     "wof:name":"Nasr",
     "wof:parent_id":85671061,
     "wof:placetype":"county",

--- a/data/109/202/307/5/1092023075.geojson
+++ b/data/109/202/307/5/1092023075.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":31.07052,
     "geom:longitude":32.414037,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Mubarak - Sharq at-Tafri'tah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Mubarak - Sharq at-Tafri'tah Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092023075,
-    "wof:lastmodified":1555092024,
+    "wof:lastmodified":1560969567,
     "wof:name":"Mubarak - Sharq at-Tafri'tah",
     "wof:parent_id":85671021,
     "wof:placetype":"county",

--- a/data/109/202/324/1/1092023241.geojson
+++ b/data/109/202/324/1/1092023241.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":29.273866,
     "geom:longitude":34.411174,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Noweiba' Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Noweiba' Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092023241,
-    "wof:lastmodified":1553718045,
+    "wof:lastmodified":1560969117,
     "wof:name":"Noweiba'",
     "wof:parent_id":85671089,
     "wof:placetype":"county",

--- a/data/109/202/328/3/1092023283.geojson
+++ b/data/109/202/328/3/1092023283.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":30.1236,
     "geom:longitude":31.145679,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Oseem Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Oseem District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
+    ],
     "lbl:latitude":30.129899,
     "lbl:longitude":31.143248,
     "meso:admin_1":"6th of October",
@@ -57,7 +72,7 @@
         }
     ],
     "wof:id":1092023283,
-    "wof:lastmodified":1555047465,
+    "wof:lastmodified":1560969120,
     "wof:name":"Oseem",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/202/333/1/1092023331.geojson
+++ b/data/109/202/333/1/1092023331.geojson
@@ -10,8 +10,17 @@
     "geom:latitude":29.969991,
     "geom:longitude":32.568632,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Police staion of Suez Port Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
-        "Suez Port Kism"
+        "Police staion of Suez Port Kism"
     ],
     "label:eng_x_preferred_placetype":[
         "kism"
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092023331,
-    "wof:lastmodified":1555092024,
+    "wof:lastmodified":1560969118,
     "wof:name":"Police staion of Suez Port",
     "wof:parent_id":85671013,
     "wof:placetype":"county",

--- a/data/109/202/337/3/1092023373.geojson
+++ b/data/109/202/337/3/1092023373.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":31.185279,
     "geom:longitude":29.874037,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Police station of Alexandria Port Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Police station of Alexandria Port Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":31.185134,
     "lbl:longitude":29.874035,
     "meso:admin_1":"Alexandria",
@@ -53,7 +68,7 @@
         }
     ],
     "wof:id":1092023373,
-    "wof:lastmodified":1536615092,
+    "wof:lastmodified":1560969115,
     "wof:name":"Police station of Alexandria Port",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/202/340/5/1092023405.geojson
+++ b/data/109/202/340/5/1092023405.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":31.257136,
     "geom:longitude":32.304567,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Police station of Port Said  Port Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Police station of Port Said  Port Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":31.250568,
     "lbl:longitude":32.299923,
     "meso:admin_1":"Port Said",
@@ -54,7 +69,7 @@
         }
     ],
     "wof:id":1092023405,
-    "wof:lastmodified":1536615092,
+    "wof:lastmodified":1560969117,
     "wof:name":"Police station of Port Said  Port",
     "wof:parent_id":85671021,
     "wof:placetype":"county",

--- a/data/109/202/344/7/1092023447.geojson
+++ b/data/109/202/344/7/1092023447.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.204,
     "geom:longitude":31.229014,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Qalyoub Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
-        "Qalyoub Markaz"
+        "Qalyoub Kism"
     ],
     "label:eng_x_preferred_placetype":[
-        "markaz"
+        "kism"
     ],
     "lbl:latitude":30.200342,
     "lbl:longitude":31.22354,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092023447,
-    "wof:lastmodified":1553718045,
+    "wof:lastmodified":1560969120,
     "wof:name":"Qalyoub",
     "wof:parent_id":85671003,
     "wof:placetype":"county",

--- a/data/109/202/349/3/1092023493.geojson
+++ b/data/109/202/349/3/1092023493.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.043224,
     "geom:longitude":31.233361,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Qasr El-Nil Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Qasr El-Nil Kism"
     ],
@@ -76,7 +85,7 @@
         }
     ],
     "wof:id":1092023493,
-    "wof:lastmodified":1553718045,
+    "wof:lastmodified":1560969117,
     "wof:name":"Qasr El-Nil",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/352/7/1092023527.geojson
+++ b/data/109/202/352/7/1092023527.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":26.123254,
     "geom:longitude":32.689606,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Qena Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Qena District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":26.171765,
     "lbl:longitude":32.625347,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092023527,
-    "wof:lastmodified":1553718045,
+    "wof:lastmodified":1560969115,
     "wof:name":"Qena",
     "wof:parent_id":85671075,
     "wof:placetype":"county",

--- a/data/109/202/358/1/1092023581.geojson
+++ b/data/109/202/358/1/1092023581.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":25.879229,
     "geom:longitude":32.781865,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Qoos Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Qoos District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":25.886672,
     "lbl:longitude":32.780916,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092023581,
-    "wof:lastmodified":1553718045,
+    "wof:lastmodified":1560969118,
     "wof:name":"Qoos",
     "wof:parent_id":85671075,
     "wof:placetype":"county",

--- a/data/109/202/362/7/1092023627.geojson
+++ b/data/109/202/362/7/1092023627.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.970462,
     "geom:longitude":30.972486,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Qotoor Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Qotoor District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.970519,
     "lbl:longitude":30.974715,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092023627,
-    "wof:lastmodified":1553718045,
+    "wof:lastmodified":1560969115,
     "wof:name":"Qotoor",
     "wof:parent_id":85670985,
     "wof:placetype":"county",

--- a/data/109/202/367/1/1092023671.geojson
+++ b/data/109/202/367/1/1092023671.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.556004,
     "geom:longitude":31.153369,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Qoweisna Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Qoweisna District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.542552,
     "lbl:longitude":31.134275,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092023671,
-    "wof:lastmodified":1553718046,
+    "wof:lastmodified":1560969118,
     "wof:name":"Qoweisna",
     "wof:parent_id":85670995,
     "wof:placetype":"county",

--- a/data/109/202/371/5/1092023715.geojson
+++ b/data/109/202/371/5/1092023715.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":31.056337,
     "geom:longitude":33.879318,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Rabe' El-Areesh Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Rabe' El-Areesh Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":31.057936,
     "lbl:longitude":33.880861,
     "meso:admin_1":"North Sinai",
@@ -57,7 +72,7 @@
         }
     ],
     "wof:id":1092023715,
-    "wof:lastmodified":1555047465,
+    "wof:lastmodified":1560969117,
     "wof:name":"Rabe' El-Areesh",
     "wof:parent_id":85671093,
     "wof:placetype":"county",

--- a/data/109/202/376/3/1092023763.geojson
+++ b/data/109/202/376/3/1092023763.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.118514,
     "geom:longitude":34.240827,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Rafah Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
     "label:eng_x_preferred_longname":[
-        "Rafah Kism"
+        "Rafah District"
     ],
     "label:eng_x_preferred_placetype":[
-        "kism"
+        "district"
     ],
     "lbl:latitude":31.103734,
     "lbl:longitude":34.248869,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092023763,
-    "wof:lastmodified":1553718045,
+    "wof:lastmodified":1560969117,
     "wof:name":"Rafah",
     "wof:parent_id":85671093,
     "wof:placetype":"county",

--- a/data/109/202/379/9/1092023799.geojson
+++ b/data/109/202/379/9/1092023799.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":31.516557,
     "geom:longitude":31.837541,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Ras El-Bar Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Ras El-Bar Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":31.514424,
     "lbl:longitude":31.836315,
     "meso:admin_1":"Domiat",
@@ -57,7 +72,7 @@
         }
     ],
     "wof:id":1092023799,
-    "wof:lastmodified":1555047465,
+    "wof:lastmodified":1560969117,
     "wof:name":"Ras El-Bar",
     "wof:parent_id":85671025,
     "wof:placetype":"county",

--- a/data/109/202/382/5/1092023825.geojson
+++ b/data/109/202/382/5/1092023825.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":28.266836,
     "geom:longitude":32.691282,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Ras Ghareb Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Ras Ghareb Kism"
     ],
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092023825,
-    "wof:lastmodified":1553718046,
+    "wof:lastmodified":1560969117,
     "wof:name":"Ras Ghareb",
     "wof:parent_id":85671085,
     "wof:placetype":"county",

--- a/data/109/202/387/3/1092023873.geojson
+++ b/data/109/202/387/3/1092023873.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":29.640019,
     "geom:longitude":33.29189,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Ras Sedr Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Ras Sedr Kism"
     ],
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092023873,
-    "wof:lastmodified":1553718045,
+    "wof:lastmodified":1560969120,
     "wof:name":"Ras Sedr",
     "wof:parent_id":85671089,
     "wof:placetype":"county",

--- a/data/109/202/392/1/1092023921.geojson
+++ b/data/109/202/392/1/1092023921.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.349464,
     "geom:longitude":30.424053,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Rasheed Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Rasheed District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.388135,
     "lbl:longitude":30.383194,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092023921,
-    "wof:lastmodified":1553718045,
+    "wof:lastmodified":1560969117,
     "wof:name":"Rasheed",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/202/395/3/1092023953.geojson
+++ b/data/109/202/395/3/1092023953.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":30.804337,
     "geom:longitude":32.699145,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Rommanah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Rommanah Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":30.80012,
     "lbl:longitude":32.701676,
     "meso:admin_1":"North Sinai",
@@ -57,7 +72,7 @@
         }
     ],
     "wof:id":1092023953,
-    "wof:lastmodified":1555047465,
+    "wof:lastmodified":1560969117,
     "wof:name":"Rommanah",
     "wof:parent_id":85671093,
     "wof:placetype":"county",

--- a/data/109/202/399/5/1092023995.geojson
+++ b/data/109/202/399/5/1092023995.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.075569,
     "geom:longitude":31.237593,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Roud El-Farag Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Roud El-Farag Kism"
     ],
@@ -76,7 +85,7 @@
         }
     ],
     "wof:id":1092023995,
-    "wof:lastmodified":1553718045,
+    "wof:lastmodified":1560969115,
     "wof:name":"Roud El-Farag",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/403/9/1092024039.geojson
+++ b/data/109/202/403/9/1092024039.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":26.937879,
     "geom:longitude":31.361579,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Sadfa Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Sadfa District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":26.945137,
     "lbl:longitude":31.360558,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092024039,
-    "wof:lastmodified":1553718045,
+    "wof:lastmodified":1560969119,
     "wof:name":"Sadfa",
     "wof:parent_id":85671069,
     "wof:placetype":"county",

--- a/data/109/202/408/7/1092024087.geojson
+++ b/data/109/202/408/7/1092024087.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":26.509437,
     "geom:longitude":33.649608,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Safaga Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Safaga Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092024087,
-    "wof:lastmodified":1553718046,
+    "wof:lastmodified":1560969116,
     "wof:name":"Safaga",
     "wof:parent_id":85671085,
     "wof:placetype":"county",

--- a/data/109/202/412/3/1092024123.geojson
+++ b/data/109/202/412/3/1092024123.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":27.064223,
     "geom:longitude":31.343017,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Sahel Seleem Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Sahel Seleem District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":27.057802,
     "lbl:longitude":31.342027,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092024123,
-    "wof:lastmodified":1553718045,
+    "wof:lastmodified":1560969116,
     "wof:name":"Sahel Seleem",
     "wof:parent_id":85671069,
     "wof:placetype":"county",

--- a/data/109/202/416/7/1092024167.geojson
+++ b/data/109/202/416/7/1092024167.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":28.877195,
     "geom:longitude":34.025331,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Saint Cathrine Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Saint Cathrine Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":28.856437,
     "lbl:longitude":34.059889,
     "meso:admin_1":"South Sinai",
@@ -56,7 +71,7 @@
         }
     ],
     "wof:id":1092024167,
-    "wof:lastmodified":1555047465,
+    "wof:lastmodified":1560969119,
     "wof:name":"Saint Cathrine",
     "wof:parent_id":85671089,
     "wof:placetype":"county",

--- a/data/109/202/421/7/1092024217.geojson
+++ b/data/109/202/421/7/1092024217.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":28.283177,
     "geom:longitude":30.664059,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Samaloot Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Samaloot District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":28.278094,
     "lbl:longitude":30.665898,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092024217,
-    "wof:lastmodified":1553718045,
+    "wof:lastmodified":1560969118,
     "wof:name":"Samaloot",
     "wof:parent_id":85671049,
     "wof:placetype":"county",

--- a/data/109/202/425/3/1092024253.geojson
+++ b/data/109/202/425/3/1092024253.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.962724,
     "geom:longitude":31.241548,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Samanoud Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Samanoud District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.013372,
     "lbl:longitude":31.269105,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092024253,
-    "wof:lastmodified":1553718045,
+    "wof:lastmodified":1560969116,
     "wof:name":"Samanoud",
     "wof:parent_id":85670985,
     "wof:placetype":"county",

--- a/data/109/202/429/9/1092024299.geojson
+++ b/data/109/202/429/9/1092024299.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":28.939043,
     "geom:longitude":30.850377,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Samasta Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Samasta District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":28.952515,
     "lbl:longitude":30.855201,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092024299,
-    "wof:lastmodified":1553718045,
+    "wof:lastmodified":1560969118,
     "wof:name":"Samasta",
     "wof:parent_id":85671053,
     "wof:placetype":"county",

--- a/data/109/202/437/9/1092024379.geojson
+++ b/data/109/202/437/9/1092024379.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":26.680631,
     "geom:longitude":31.648752,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Saqaltah Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Saqaltah District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":26.662968,
     "lbl:longitude":31.660085,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092024379,
-    "wof:lastmodified":1553718046,
+    "wof:lastmodified":1560969116,
     "wof:name":"Saqaltah",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/202/441/1/1092024411.geojson
+++ b/data/109/202/441/1/1092024411.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.440833,
     "geom:longitude":30.971455,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Sars El-Layanah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Sars El-Layanah Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092024411,
-    "wof:lastmodified":1553718046,
+    "wof:lastmodified":1560969116,
     "wof:name":"Sars El-Layanah",
     "wof:parent_id":85670995,
     "wof:placetype":"county",

--- a/data/109/202/445/7/1092024457.geojson
+++ b/data/109/202/445/7/1092024457.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":29.418256,
     "geom:longitude":30.824495,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Senorus Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Senorus District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":29.418099,
     "lbl:longitude":30.824494,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092024457,
-    "wof:lastmodified":1553718046,
+    "wof:lastmodified":1560969119,
     "wof:name":"Senorus",
     "wof:parent_id":85671037,
     "wof:placetype":"county",

--- a/data/109/202/450/5/1092024505.geojson
+++ b/data/109/202/450/5/1092024505.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":28.024785,
     "geom:longitude":34.250548,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Sharm El-Sheikh Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Sharm El-Sheikh Kism"
     ],
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092024505,
-    "wof:lastmodified":1553718046,
+    "wof:lastmodified":1560969119,
     "wof:name":"Sharm El-Sheikh",
     "wof:parent_id":85671089,
     "wof:placetype":"county",

--- a/data/109/202/454/3/1092024543.geojson
+++ b/data/109/202/454/3/1092024543.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.561717,
     "geom:longitude":31.011242,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Shebeen El-Koum Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Shebeen El-Koum District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.560879,
     "lbl:longitude":31.011265,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092024543,
-    "wof:lastmodified":1553718046,
+    "wof:lastmodified":1560969117,
     "wof:name":"Shebeen El-Koum",
     "wof:parent_id":85670995,
     "wof:placetype":"county",

--- a/data/109/202/459/3/1092024593.geojson
+++ b/data/109/202/459/3/1092024593.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.301099,
     "geom:longitude":31.306758,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Shebeen El-Qanater Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Shebeen El-Qanater District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.29291,
     "lbl:longitude":31.296552,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092024593,
-    "wof:lastmodified":1553718045,
+    "wof:lastmodified":1560969119,
     "wof:name":"Shebeen El-Qanater",
     "wof:parent_id":85671003,
     "wof:placetype":"county",

--- a/data/109/202/475/9/1092024759.geojson
+++ b/data/109/202/475/9/1092024759.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.25729,
     "geom:longitude":31.552994,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Sherbeen Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Sherbeen District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.259927,
     "lbl:longitude":31.554769,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092024759,
-    "wof:lastmodified":1553718045,
+    "wof:lastmodified":1560969118,
     "wof:name":"Sherbeen",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/202/480/5/1092024805.geojson
+++ b/data/109/202/480/5/1092024805.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.073811,
     "geom:longitude":31.250511,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Shobra Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Shobra Kism"
     ],
@@ -99,7 +108,7 @@
         }
     ],
     "wof:id":1092024805,
-    "wof:lastmodified":1553718045,
+    "wof:lastmodified":1560969119,
     "wof:name":"Shobra",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/484/9/1092024849.geojson
+++ b/data/109/202/484/9/1092024849.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.998279,
     "geom:longitude":30.679021,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Shobrakheet Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Shobrakheet District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.003695,
     "lbl:longitude":30.670044,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092024849,
-    "wof:lastmodified":1553718045,
+    "wof:lastmodified":1560969116,
     "wof:name":"Shobrakheet",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/202/489/9/1092024899.geojson
+++ b/data/109/202/489/9/1092024899.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.348377,
     "geom:longitude":25.94153,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Sidy Barrany Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
     "label:eng_x_preferred_longname":[
-        "Sidy Barrany Kism"
+        "Sidy Barrany District"
     ],
     "label:eng_x_preferred_placetype":[
-        "kism"
+        "district"
     ],
     "lbl:latitude":30.347656,
     "lbl:longitude":25.931851,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092024899,
-    "wof:lastmodified":1553718045,
+    "wof:lastmodified":1560969119,
     "wof:name":"Sidy Barrany",
     "wof:parent_id":85671031,
     "wof:placetype":"county",

--- a/data/109/202/494/3/1092024943.geojson
+++ b/data/109/202/494/3/1092024943.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":31.203111,
     "geom:longitude":29.945223,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Sidy Gaber Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Sidy Gaber Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092024943,
-    "wof:lastmodified":1553718046,
+    "wof:lastmodified":1560969119,
     "wof:name":"Sidy Gaber",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/202/497/1/1092024971.geojson
+++ b/data/109/202/497/1/1092024971.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.33954,
     "geom:longitude":30.74767,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Sidy Salem Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Sidy Salem District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.330402,
     "lbl:longitude":30.776434,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092024971,
-    "wof:lastmodified":1553718046,
+    "wof:lastmodified":1560969116,
     "wof:name":"Sidy Salem",
     "wof:parent_id":85671057,
     "wof:placetype":"county",

--- a/data/109/202/501/9/1092025019.geojson
+++ b/data/109/202/501/9/1092025019.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":28.464772,
     "geom:longitude":26.318028,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Siwah Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
     "label:eng_x_preferred_longname":[
-        "Siwah Kism"
+        "Siwah District"
     ],
     "label:eng_x_preferred_placetype":[
-        "kism"
+        "district"
     ],
     "lbl:latitude":28.391819,
     "lbl:longitude":26.28796,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092025019,
-    "wof:lastmodified":1553718045,
+    "wof:lastmodified":1560969118,
     "wof:name":"Siwah",
     "wof:parent_id":85671031,
     "wof:placetype":"county",

--- a/data/109/202/506/3/1092025063.geojson
+++ b/data/109/202/506/3/1092025063.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":26.551318,
     "geom:longitude":31.676857,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Sohag Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Sohag District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":26.584002,
     "lbl:longitude":31.650291,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092025063,
-    "wof:lastmodified":1553718046,
+    "wof:lastmodified":1560969118,
     "wof:name":"Sohag",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/202/510/1/1092025101.geojson
+++ b/data/109/202/510/1/1092025101.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":26.772803,
     "geom:longitude":31.459092,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Tahta Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
     "label:eng_x_preferred_longname":[
-        "Tahta Kism"
+        "Tahta District"
     ],
     "label:eng_x_preferred_placetype":[
-        "kism"
+        "district"
     ],
     "lbl:latitude":26.778309,
     "lbl:longitude":31.487328,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092025101,
-    "wof:lastmodified":1553718046,
+    "wof:lastmodified":1560969117,
     "wof:name":"Tahta",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/202/514/5/1092025145.geojson
+++ b/data/109/202/514/5/1092025145.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.680153,
     "geom:longitude":30.921274,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Tala Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Tala District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.681192,
     "lbl:longitude":30.932685,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092025145,
-    "wof:lastmodified":1553718047,
+    "wof:lastmodified":1560969120,
     "wof:name":"Tala",
     "wof:parent_id":85670995,
     "wof:placetype":"county",

--- a/data/109/202/518/9/1092025189.geojson
+++ b/data/109/202/518/9/1092025189.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":31.030928,
     "geom:longitude":33.766013,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Talet El-Areesh Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Talet El-Areesh Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092025189,
-    "wof:lastmodified":1553718046,
+    "wof:lastmodified":1560969117,
     "wof:name":"Talet El-Areesh",
     "wof:parent_id":85671093,
     "wof:placetype":"county",

--- a/data/109/202/523/1/1092025231.geojson
+++ b/data/109/202/523/1/1092025231.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.612599,
     "geom:longitude":32.283719,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Talet El-Esmailiah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Talet El-Esmailiah Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092025231,
-    "wof:lastmodified":1553718046,
+    "wof:lastmodified":1560969120,
     "wof:name":"Talet El-Esmailiah",
     "wof:parent_id":85670989,
     "wof:placetype":"county",

--- a/data/109/202/526/5/1092025265.geojson
+++ b/data/109/202/526/5/1092025265.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":31.127347,
     "geom:longitude":31.343939,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Talkha Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Talkha District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":31.125575,
     "lbl:longitude":31.341893,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092025265,
-    "wof:lastmodified":1553718046,
+    "wof:lastmodified":1560969117,
     "wof:name":"Talkha",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/202/532/9/1092025329.geojson
+++ b/data/109/202/532/9/1092025329.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":26.856914,
     "geom:longitude":31.415455,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Tama Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Tama District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":26.861609,
     "lbl:longitude":31.423563,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092025329,
-    "wof:lastmodified":1553718047,
+    "wof:lastmodified":1560969115,
     "wof:name":"Tama",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/202/538/1/1092025381.geojson
+++ b/data/109/202/538/1/1092025381.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.954459,
     "geom:longitude":31.594581,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Tamy El-Amdeed Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Tamy El-Amdeed District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.952781,
     "lbl:longitude":31.601993,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092025381,
-    "wof:lastmodified":1553718047,
+    "wof:lastmodified":1560969118,
     "wof:name":"Tamy El-Amdeed",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/202/541/7/1092025417.geojson
+++ b/data/109/202/541/7/1092025417.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":29.463076,
     "geom:longitude":30.976327,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Tamyah Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Tamyah District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":29.468025,
     "lbl:longitude":30.978392,
@@ -76,7 +85,7 @@
         }
     ],
     "wof:id":1092025417,
-    "wof:lastmodified":1553718047,
+    "wof:lastmodified":1560969120,
     "wof:name":"Tamyah",
     "wof:parent_id":85671037,
     "wof:placetype":"county",

--- a/data/109/202/546/5/1092025465.geojson
+++ b/data/109/202/546/5/1092025465.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.820139,
     "geom:longitude":30.980231,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Tanta Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Tanta District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.838228,
     "lbl:longitude":30.939692,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092025465,
-    "wof:lastmodified":1553718047,
+    "wof:lastmodified":1560969120,
     "wof:name":"Tanta",
     "wof:parent_id":85670985,
     "wof:placetype":"county",

--- a/data/109/202/551/3/1092025513.geojson
+++ b/data/109/202/551/3/1092025513.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":27.170192,
     "geom:longitude":31.170137,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Tany Asiut Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Tany Asiut Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":27.170931,
     "lbl:longitude":31.171738,
     "meso:admin_1":"Assiut",
@@ -57,7 +72,7 @@
         }
     ],
     "wof:id":1092025513,
-    "wof:lastmodified":1555047465,
+    "wof:lastmodified":1560969115,
     "wof:name":"Tany Asiut",
     "wof:parent_id":85671069,
     "wof:placetype":"county",

--- a/data/109/202/555/3/1092025553.geojson
+++ b/data/109/202/555/3/1092025553.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":31.018586,
     "geom:longitude":33.656166,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Tany El-Areesh Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Tany El-Areesh Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":31.018447,
     "lbl:longitude":33.656166,
     "meso:admin_1":"North Sinai",
@@ -57,7 +72,7 @@
         }
     ],
     "wof:id":1092025553,
-    "wof:lastmodified":1555047465,
+    "wof:lastmodified":1560969118,
     "wof:name":"Tany El-Areesh",
     "wof:parent_id":85671093,
     "wof:placetype":"county",

--- a/data/109/202/559/1/1092025591.geojson
+++ b/data/109/202/559/1/1092025591.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.622371,
     "geom:longitude":32.277254,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Tany El-Esmailiah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Tany El-Esmailiah Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092025591,
-    "wof:lastmodified":1553718046,
+    "wof:lastmodified":1560969115,
     "wof:name":"Tany El-Esmailiah",
     "wof:parent_id":85670989,
     "wof:placetype":"county",

--- a/data/109/202/563/7/1092025637.geojson
+++ b/data/109/202/563/7/1092025637.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.987505,
     "geom:longitude":31.161307,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Tany El-Mahallah El-Kobra Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Tany El-Mahallah El-Kobra Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092025637,
-    "wof:lastmodified":1553718047,
+    "wof:lastmodified":1560969118,
     "wof:name":"Tany El-Mahallah El-Kobra",
     "wof:parent_id":85670985,
     "wof:placetype":"county",

--- a/data/109/202/568/1/1092025681.geojson
+++ b/data/109/202/568/1/1092025681.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":31.037224,
     "geom:longitude":31.394983,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Tany El-Mansourah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Tany El-Mansourah Kism"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "kism"
+    ],
     "lbl:latitude":31.040599,
     "lbl:longitude":31.39438,
     "meso:admin_1":"Dakahlia",
@@ -57,7 +72,7 @@
         }
     ],
     "wof:id":1092025681,
-    "wof:lastmodified":1555047465,
+    "wof:lastmodified":1560969115,
     "wof:name":"Tany El-Mansourah",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/202/571/3/1092025713.geojson
+++ b/data/109/202/571/3/1092025713.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.602675,
     "geom:longitude":31.523566,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Tany El-Zaqazeeq Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Tany El-Zaqazeeq Kism"
     ],
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092025713,
-    "wof:lastmodified":1553718046,
+    "wof:lastmodified":1560969120,
     "wof:name":"Tany El-Zaqazeeq",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/202/576/1/1092025761.geojson
+++ b/data/109/202/576/1/1092025761.geojson
@@ -10,8 +10,17 @@
     "geom:latitude":30.046346,
     "geom:longitude":31.313662,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Tany Nasr City Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
-        "Tany Nasr City"
+        "Tany Nasr City Kism"
     ],
     "label:eng_x_preferred_placetype":[
         "kism"
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092025761,
-    "wof:lastmodified":1555092024,
+    "wof:lastmodified":1560969120,
     "wof:name":"Tany Nasr City",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/580/7/1092025807.geojson
+++ b/data/109/202/580/7/1092025807.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.13822,
     "geom:longitude":31.282289,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Tany Shobra El-Kheimah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Tany Shobra El-Kheimah Kism"
     ],
@@ -76,7 +85,7 @@
         }
     ],
     "wof:id":1092025807,
-    "wof:lastmodified":1553718047,
+    "wof:lastmodified":1560969117,
     "wof:name":"Tany Shobra El-Kheimah",
     "wof:parent_id":85671003,
     "wof:placetype":"county",

--- a/data/109/202/585/3/1092025853.geojson
+++ b/data/109/202/585/3/1092025853.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":26.524862,
     "geom:longitude":31.695463,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Tany Sohag Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Tany Sohag Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092025853,
-    "wof:lastmodified":1553718047,
+    "wof:lastmodified":1560969120,
     "wof:name":"Tany Sohag",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/202/589/3/1092025893.geojson
+++ b/data/109/202/589/3/1092025893.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":30.779407,
     "geom:longitude":30.999012,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Tany Tanta Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Tany Tanta Kism"
     ],
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092025893,
-    "wof:lastmodified":1553718047,
+    "wof:lastmodified":1560969117,
     "wof:name":"Tany Tanta",
     "wof:parent_id":85670985,
     "wof:placetype":"county",

--- a/data/109/202/593/9/1092025939.geojson
+++ b/data/109/202/593/9/1092025939.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.341407,
     "geom:longitude":31.195795,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Tookh Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Tookh District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.337035,
     "lbl:longitude":31.204072,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092025939,
-    "wof:lastmodified":1553718047,
+    "wof:lastmodified":1560969115,
     "wof:name":"Tookh",
     "wof:parent_id":85671003,
     "wof:placetype":"county",

--- a/data/109/202/598/7/1092025987.geojson
+++ b/data/109/202/598/7/1092025987.geojson
@@ -10,6 +10,15 @@
     "geom:latitude":29.940141,
     "geom:longitude":31.303819,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longnamee":[
+        "Torah Aqsam"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "aqsam"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0642\u0633\u0645"
+    ],
     "label:eng_x_preferred_longname":[
         "Torah Kism"
     ],
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":1092025987,
-    "wof:lastmodified":1553718047,
+    "wof:lastmodified":1560969118,
     "wof:name":"Torah",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/602/3/1092026023.geojson
+++ b/data/109/202/602/3/1092026023.geojson
@@ -10,6 +10,21 @@
     "geom:latitude":30.377517,
     "geom:longitude":30.365405,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Wady El-Natroon Markaz"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Wady El-Natroon District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
+    ],
     "lbl:latitude":30.31765,
     "lbl:longitude":30.435844,
     "meso:admin_1":"Behera",
@@ -57,7 +72,7 @@
         }
     ],
     "wof:id":1092026023,
-    "wof:lastmodified":1555047465,
+    "wof:lastmodified":1560969116,
     "wof:name":"Wady El-Natroon",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/202/606/9/1092026069.geojson
+++ b/data/109/202/606/9/1092026069.geojson
@@ -10,11 +10,20 @@
     "geom:latitude":30.725228,
     "geom:longitude":31.214578,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
+    "label:ara_latn_x_preferred_longname":[
         "Zefta Markaz"
     ],
-    "label:eng_x_preferred_placetype":[
+    "label:ara_latn_x_preferred_placetype":[
         "markaz"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u0631\u0643\u0632"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Zefta District"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "district"
     ],
     "lbl:latitude":30.698172,
     "lbl:longitude":31.215582,
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":1092026069,
-    "wof:lastmodified":1553718047,
+    "wof:lastmodified":1560969119,
     "wof:name":"Zefta",
     "wof:parent_id":85670985,
     "wof:placetype":"county",

--- a/data/856/709/85/85670985.geojson
+++ b/data/856/709/85/85670985.geojson
@@ -11,6 +11,18 @@
     "geom:longitude":31.048261,
     "gn:id":"",
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Al Gharbiyah Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u063a\u0631\u0628\u064a\u0629"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "Al Gharbiyah Governorate"
     ],
@@ -320,7 +332,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550382,
+    "wof:lastmodified":1560967935,
     "wof:name":"Al Gharbiyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/709/89/85670989.geojson
+++ b/data/856/709/89/85670989.geojson
@@ -11,6 +11,18 @@
     "geom:longitude":32.318856,
     "gn:id":"",
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Al Isma`iliyah Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0627\u0633\u0645\u0627\u0639\u064a\u0644\u064a\u0629"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "Al Isma`iliyah Governorate"
     ],
@@ -318,7 +330,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550382,
+    "wof:lastmodified":1560967935,
     "wof:name":"Al Isma`iliyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/709/95/85670995.geojson
+++ b/data/856/709/95/85670995.geojson
@@ -11,6 +11,18 @@
     "geom:longitude":30.998207,
     "gn:id":"",
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Al Minufiyah Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0645\u0646\u0648\u0641\u064a\u0629"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "Al Minufiyah Governorate"
     ],
@@ -317,7 +329,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550382,
+    "wof:lastmodified":1560967934,
     "wof:name":"Al Minufiyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/709/99/85670999.geojson
+++ b/data/856/709/99/85670999.geojson
@@ -11,6 +11,18 @@
     "geom:longitude":31.597689,
     "gn:id":"",
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Al Qahirah Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0642\u0627\u0647\u0631\u0629"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "Al Qahirah Governorate"
     ],
@@ -334,7 +346,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550382,
+    "wof:lastmodified":1560967935,
     "wof:name":"Al Qahirah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/03/85671003.geojson
+++ b/data/856/710/03/85671003.geojson
@@ -11,6 +11,18 @@
     "geom:longitude":31.272107,
     "gn:id":"",
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Al Qalyubiyah Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0642\u0644\u064a\u0648\u0628\u064a\u0629"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "Al Qalyubiyah Governorate"
     ],
@@ -313,7 +325,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550338,
+    "wof:lastmodified":1560967935,
     "wof:name":"Al Qalyubiyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/07/85671007.geojson
+++ b/data/856/710/07/85671007.geojson
@@ -11,6 +11,18 @@
     "geom:longitude":31.753846,
     "gn:id":"",
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Ash Sharqiyah Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0634\u0631\u0642\u064a\u0629"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "Ash Sharqiyah Governorate"
     ],
@@ -323,7 +335,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550340,
+    "wof:lastmodified":1560967936,
     "wof:name":"Ash Sharqiyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/13/85671013.geojson
+++ b/data/856/710/13/85671013.geojson
@@ -11,6 +11,18 @@
     "geom:longitude":32.237747,
     "gn:id":"",
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "As Suways Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0633\u0648\u064a\u0633"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "As Suways Governorate"
     ],
@@ -319,7 +331,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550342,
+    "wof:lastmodified":1560967937,
     "wof:name":"As Suways",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/17/85671017.geojson
+++ b/data/856/710/17/85671017.geojson
@@ -11,6 +11,18 @@
     "geom:longitude":31.519728,
     "gn:id":"",
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Ad Daqahliyah Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u062f\u0642\u0647\u0644\u064a\u0629"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "Ad Daqahliyah Governorate"
     ],
@@ -319,7 +331,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550384,
+    "wof:lastmodified":1560967935,
     "wof:name":"Ad Daqahliyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/21/85671021.geojson
+++ b/data/856/710/21/85671021.geojson
@@ -11,6 +11,18 @@
     "geom:longitude":32.30583,
     "gn:id":"",
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Bur Sa`id Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0628\u0648\u0631\u0633\u0639\u064a\u062f"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "Bur Sa`id Governorate"
     ],
@@ -317,7 +329,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550352,
+    "wof:lastmodified":1560967935,
     "wof:name":"Bur Sa`id",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/25/85671025.geojson
+++ b/data/856/710/25/85671025.geojson
@@ -5,12 +5,24 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.088166,
-    "geom:area_square_m":930676828.462509,
+    "geom:area_square_m":930676828.462511,
     "geom:bbox":"31.483703,31.1673,32.063652,31.535778",
     "geom:latitude":31.385107,
     "geom:longitude":31.769091,
     "gn:id":"",
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Dumyat Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u062f\u0645\u064a\u0627\u0637"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "Dumyat Governorate"
     ],
@@ -324,7 +336,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553814768,
+    "wof:lastmodified":1560967937,
     "wof:name":"Dumyat",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/31/85671031.geojson
+++ b/data/856/710/31/85671031.geojson
@@ -11,6 +11,18 @@
     "geom:longitude":26.983103,
     "gn:id":"",
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Matruh Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0645\u0637\u0631\u0648\u062d"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "Matruh Governorate"
     ],
@@ -323,7 +335,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550343,
+    "wof:lastmodified":1560967936,
     "wof:name":"Matruh",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/35/85671035.geojson
+++ b/data/856/710/35/85671035.geojson
@@ -11,6 +11,18 @@
     "geom:longitude":30.298099,
     "gn:id":"",
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Al Buhayrah Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0628\u062d\u064a\u0631\u0629"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "Al Buhayrah Governorate"
     ],
@@ -323,7 +335,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550344,
+    "wof:lastmodified":1560967935,
     "wof:name":"Al Buhayrah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/37/85671037.geojson
+++ b/data/856/710/37/85671037.geojson
@@ -11,6 +11,18 @@
     "geom:longitude":30.797677,
     "gn:id":"",
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Al Fayyum Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0641\u064a\u0648\u0645"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "Al Fayyum Governorate"
     ],
@@ -281,7 +293,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550332,
+    "wof:lastmodified":1560967936,
     "wof:name":"Al Fayyum",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/41/85671041.geojson
+++ b/data/856/710/41/85671041.geojson
@@ -5,13 +5,25 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.256166,
-    "geom:area_square_m":2719783584.143626,
+    "geom:area_square_m":2719783584.143685,
     "geom:bbox":"29.356734,30.26259,30.087226,31.329745",
     "geom:latitude":30.837802,
     "geom:longitude":29.742322,
     "gn:id":"",
     "gn:population":3811516,
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Al Iskandariyah Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0627\u0633\u0643\u0646\u062f\u0631\u064a\u0629"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "Al Iskandariyah Governorate"
     ],
@@ -330,7 +342,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553814768,
+    "wof:lastmodified":1560967936,
     "wof:name":"Al Iskandariyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/47/85671047.geojson
+++ b/data/856/710/47/85671047.geojson
@@ -11,6 +11,18 @@
     "geom:longitude":29.409065,
     "gn:id":"",
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Al Jizah Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u062c\u064a\u0632\u0629"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "Al Jizah Governorate"
     ],
@@ -322,7 +334,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550336,
+    "wof:lastmodified":1560967937,
     "wof:name":"Al Jizah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/49/85671049.geojson
+++ b/data/856/710/49/85671049.geojson
@@ -5,12 +5,24 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.691351,
-    "geom:area_square_m":18443007238.724251,
+    "geom:area_square_m":18443007238.724518,
     "geom:bbox":"28.466408,27.576852,30.903162,28.77903",
     "geom:latitude":28.130037,
     "geom:longitude":30.007302,
     "gn:id":"",
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Al Minya Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0645\u0646\u064a\u0627"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "Al Minya Governorate"
     ],
@@ -334,7 +346,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553814769,
+    "wof:lastmodified":1560967937,
     "wof:name":"Al Minya",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/53/85671053.geojson
+++ b/data/856/710/53/85671053.geojson
@@ -11,6 +11,18 @@
     "geom:longitude":30.638469,
     "gn:id":"",
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Bani Suwayf Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0628\u0646\u064a \u0633\u0648\u064a\u0641"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "Bani Suwayf Governorate"
     ],
@@ -374,7 +386,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550337,
+    "wof:lastmodified":1560967936,
     "wof:name":"Bani Suwayf",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/57/85671057.geojson
+++ b/data/856/710/57/85671057.geojson
@@ -11,6 +11,18 @@
     "geom:longitude":30.902975,
     "gn:id":"",
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Kafr ash Shaykh Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0643\u0641\u0631 \u0627\u0644\u0634\u064a\u062e"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "Kafr ash Shaykh Governorate"
     ],
@@ -313,7 +325,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550338,
+    "wof:lastmodified":1560967935,
     "wof:name":"Kafr ash Shaykh",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/61/85671061.geojson
+++ b/data/856/710/61/85671061.geojson
@@ -11,6 +11,18 @@
     "geom:longitude":32.791903,
     "gn:id":"",
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Aswan Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0633\u0648\u0627\u0646"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "Aswan Governorate"
     ],
@@ -400,7 +412,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550338,
+    "wof:lastmodified":1560967935,
     "wof:name":"Aswan",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/69/85671069.geojson
+++ b/data/856/710/69/85671069.geojson
@@ -11,6 +11,18 @@
     "geom:longitude":31.072969,
     "gn:id":"",
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Asyut Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0633\u064a\u0648\u0637"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "Asyut Governorate"
     ],
@@ -381,7 +393,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550340,
+    "wof:lastmodified":1560967935,
     "wof:name":"Asyut",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/71/85671071.geojson
+++ b/data/856/710/71/85671071.geojson
@@ -11,6 +11,18 @@
     "geom:longitude":28.559904,
     "gn:id":"",
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Al Wadi at Jadid Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0648\u0627\u062f\u064a \u0627\u0644\u062c\u062f\u064a\u062f"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "Al Wadi at Jadid Governorate"
     ],
@@ -319,7 +331,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550341,
+    "wof:lastmodified":1560967937,
     "wof:name":"Al Wadi at Jadid",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/75/85671075.geojson
+++ b/data/856/710/75/85671075.geojson
@@ -11,6 +11,18 @@
     "geom:longitude":32.487045,
     "gn:id":"",
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Qina Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0642\u0646\u0627"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "Qina Governorate"
     ],
@@ -320,7 +332,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550341,
+    "wof:lastmodified":1560967936,
     "wof:name":"Qina",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/79/85671079.geojson
+++ b/data/856/710/79/85671079.geojson
@@ -11,6 +11,18 @@
     "geom:longitude":31.704916,
     "gn:id":"",
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Suhaj Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0633\u0648\u0647\u0627\u062c"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "Suhaj Governorate"
     ],
@@ -322,7 +334,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550341,
+    "wof:lastmodified":1560967936,
     "wof:name":"Suhaj",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/85/85671085.geojson
+++ b/data/856/710/85/85671085.geojson
@@ -11,6 +11,18 @@
     "geom:longitude":33.51608,
     "gn:id":"",
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Al Bahr al Ahmar Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0628\u062d\u0631 \u0627\u0644\u0627\u062d\u0645\u0631"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "Al Bahr al Ahmar Governorate"
     ],
@@ -326,7 +338,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550346,
+    "wof:lastmodified":1560967937,
     "wof:name":"Al Bahr al Ahmar",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/89/85671089.geojson
+++ b/data/856/710/89/85671089.geojson
@@ -11,6 +11,18 @@
     "geom:longitude":33.798794,
     "gn:id":"",
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Janub Sina' Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u062c\u0646\u0648\u0628 \u0633\u064a\u0646\u0627\u0621"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "Janub Sina' Governorate"
     ],
@@ -326,7 +338,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550350,
+    "wof:lastmodified":1560967935,
     "wof:name":"Janub Sina'",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/93/85671093.geojson
+++ b/data/856/710/93/85671093.geojson
@@ -11,6 +11,18 @@
     "geom:longitude":33.716551,
     "gn:id":"",
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Shamal Sina' Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0634\u0645\u0627\u0644 \u0633\u064a\u0646\u0627\u0621"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "Shamal Sina' Governorate"
     ],
@@ -323,7 +335,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550352,
+    "wof:lastmodified":1560967935,
     "wof:name":"Shamal Sina'",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/97/85671097.geojson
+++ b/data/856/710/97/85671097.geojson
@@ -11,6 +11,18 @@
     "geom:longitude":32.625967,
     "gn:id":"",
     "iso:country":"EG",
+    "label:ara_latn_x_preferred_longname":[
+        "Luxor Mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_latn_x_preferred_placetype":[
+        "mu\u1e25\u0101fa\u1e93ah"
+    ],
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0627\u0642\u0635\u0631"
+    ],
+    "label:ara_x_preferred_placetype":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629"
+    ],
     "label:eng_x_preferred_longname":[
         "Luxor Governorate"
     ],
@@ -283,7 +295,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550343,
+    "wof:lastmodified":1560967936,
     "wof:name":"Luxor",
     "wof:parent_id":85632581,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes the Egypt portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1640.

- Adds and updates labels in region and county records in Egypt
- Regions had existing English labels, this adds `ara` and `ara_latn` labels to regions
- Some counties had existing English labels, this adds `ara` and `ara_latn` placetypes, as well as corrects some existing English labels
- All but two of the meso-sourced county records are missing Arabic name translations, so the fill `ara_x_preferred_longname` is not included

No PIP required, can merge once approved.

References:
- https://en.wikipedia.org/wiki/Markaz_(country_subdivision)
- https://en.wikipedia.org/wiki/Subdivisions_of_Egypt
