### PR TITLE
Deprecate bunk GN locality

### DIFF
--- a/data/132/731/199/1/1327311991.geojson
+++ b/data/132/731/199/1/1327311991.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-01-06",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
@@ -52,7 +53,7 @@
         }
     ],
     "wof:id":1327311991,
-    "wof:lastmodified":1566585596,
+    "wof:lastmodified":1578333557,
     "wof:name":"testing",
     "wof:parent_id":1092022997,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1771

No PIP work required, can merge as-is.