### PR TITLE
geom_alt props

### DIFF
--- a/data/109/201/472/7/1092014727.geojson
+++ b/data/109/201/472/7/1092014727.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"EG",
     "wof:created":1473897148,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"fd1acecd34cff5242d829dc9776c934b",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":1092014727,
-    "wof:lastmodified":1566586499,
+    "wof:lastmodified":1582352375,
     "wof:name":"Awal Shobra El-Kheimah",
     "wof:parent_id":85671003,
     "wof:placetype":"county",

--- a/data/109/201/583/9/1092015839.geojson
+++ b/data/109/201/583/9/1092015839.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"EG",
     "wof:created":1473897187,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"6fe865c17c64c546156b5ff2ac160d87",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":1092015839,
-    "wof:lastmodified":1566586507,
+    "wof:lastmodified":1582352375,
     "wof:name":"Boulaq",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/748/9/1092017489.geojson
+++ b/data/109/201/748/9/1092017489.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"EG",
     "wof:created":1473897245,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"b39044916c06fba23030ad46baa3da87",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":1092017489,
-    "wof:lastmodified":1566586494,
+    "wof:lastmodified":1582352375,
     "wof:name":"El-Dokky",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/201/949/9/1092019499.geojson
+++ b/data/109/201/949/9/1092019499.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"EG",
     "wof:created":1473897326,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"c4b677ff90ea6b9d29628f52696dc24b",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":1092019499,
-    "wof:lastmodified":1566586494,
+    "wof:lastmodified":1582352375,
     "wof:name":"El-Sahel",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/034/9/1092020349.geojson
+++ b/data/109/202/034/9/1092020349.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"EG",
     "wof:created":1473897357,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"f86ff37c875045f990aba1f8a767f627",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":1092020349,
-    "wof:lastmodified":1566586476,
+    "wof:lastmodified":1582352374,
     "wof:name":"El-Warraq",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/202/043/7/1092020437.geojson
+++ b/data/109/202/043/7/1092020437.geojson
@@ -77,6 +77,9 @@
     },
     "wof:country":"EG",
     "wof:created":1473897360,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"c40aa5091b92d8ae45dbc50d894f23a8",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":1092020437,
-    "wof:lastmodified":1566586474,
+    "wof:lastmodified":1582352374,
     "wof:name":"El-Zamalek",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/055/1/1092020551.geojson
+++ b/data/109/202/055/1/1092020551.geojson
@@ -77,6 +77,9 @@
     },
     "wof:country":"EG",
     "wof:created":1473897364,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"1404c48cdccb037cabd23731e91df05f",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":1092020551,
-    "wof:lastmodified":1566586462,
+    "wof:lastmodified":1582352374,
     "wof:name":"El-Zawyah El-Hamra",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/068/3/1092020683.geojson
+++ b/data/109/202/068/3/1092020683.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"EG",
     "wof:created":1473897369,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"1f2c1823ad1830f237fb09b247b2388a",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":1092020683,
-    "wof:lastmodified":1566586476,
+    "wof:lastmodified":1582352374,
     "wof:name":"Embabah",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/202/349/3/1092023493.geojson
+++ b/data/109/202/349/3/1092023493.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"EG",
     "wof:created":1473897476,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"7421a2e47343268f74d6c2fd61dd8897",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":1092023493,
-    "wof:lastmodified":1566586466,
+    "wof:lastmodified":1582352374,
     "wof:name":"Qasr El-Nil",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/399/5/1092023995.geojson
+++ b/data/109/202/399/5/1092023995.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"EG",
     "wof:created":1473897494,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"e57b4fd4285cf01be338ef11675678f8",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":1092023995,
-    "wof:lastmodified":1566586456,
+    "wof:lastmodified":1582352374,
     "wof:name":"Roud El-Farag",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/541/7/1092025417.geojson
+++ b/data/109/202/541/7/1092025417.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"EG",
     "wof:created":1473897543,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"f4c493b6f5000fbf5a74f88342dc8f01",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":1092025417,
-    "wof:lastmodified":1566586479,
+    "wof:lastmodified":1582352374,
     "wof:name":"Tamyah",
     "wof:parent_id":85671037,
     "wof:placetype":"county",

--- a/data/109/202/580/7/1092025807.geojson
+++ b/data/109/202/580/7/1092025807.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"EG",
     "wof:created":1473897556,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"97d967fc165eb25cfa1a08f095d2a652",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":1092025807,
-    "wof:lastmodified":1566586467,
+    "wof:lastmodified":1582352374,
     "wof:name":"Tany Shobra El-Kheimah",
     "wof:parent_id":85671003,
     "wof:placetype":"county",

--- a/data/421/174/399/421174399.geojson
+++ b/data/421/174/399/421174399.geojson
@@ -788,6 +788,9 @@
     },
     "wof:country":"EG",
     "wof:created":1459009031,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d8a7dd9e5f59332fcc7036638f8c20ae",
     "wof:hierarchy":[
         {
@@ -799,7 +802,7 @@
         }
     ],
     "wof:id":421174399,
-    "wof:lastmodified":1566586560,
+    "wof:lastmodified":1582352376,
     "wof:name":"\u0627\u0644\u0642\u0627\u0647\u0631\u0629",
     "wof:parent_id":1092016929,
     "wof:placetype":"locality",

--- a/data/421/186/177/421186177.geojson
+++ b/data/421/186/177/421186177.geojson
@@ -143,6 +143,9 @@
     },
     "wof:country":"EG",
     "wof:created":1459009472,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"6b50491dc6054f908e80da48cfce608d",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
         }
     ],
     "wof:id":421186177,
-    "wof:lastmodified":1534379294,
+    "wof:lastmodified":1582352376,
     "wof:name":"El Qasr",
     "wof:parent_id":1092020201,
     "wof:placetype":"locality",

--- a/data/421/189/949/421189949.geojson
+++ b/data/421/189/949/421189949.geojson
@@ -148,6 +148,9 @@
     },
     "wof:country":"EG",
     "wof:created":1459009641,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"8993ee2fe86d586d4d61311d1ff0c461",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":421189949,
-    "wof:lastmodified":1566586563,
+    "wof:lastmodified":1582352376,
     "wof:name":"Salum",
     "wof:parent_id":1092019621,
     "wof:placetype":"locality",

--- a/data/421/189/959/421189959.geojson
+++ b/data/421/189/959/421189959.geojson
@@ -203,6 +203,9 @@
     },
     "wof:country":"EG",
     "wof:created":1459009642,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"c12fc080176cad1b0aa423bed228202b",
     "wof:hierarchy":[
         {
@@ -214,7 +217,7 @@
         }
     ],
     "wof:id":421189959,
-    "wof:lastmodified":1566586564,
+    "wof:lastmodified":1582352376,
     "wof:name":"Siwa",
     "wof:parent_id":1092025019,
     "wof:placetype":"locality",

--- a/data/856/325/81/85632581.geojson
+++ b/data/856/325/81/85632581.geojson
@@ -1045,7 +1045,6 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "meso",
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1120,7 +1119,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1582352362,
+    "wof:lastmodified":1583232899,
     "wof:name":"Egypt",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/325/81/85632581.geojson
+++ b/data/856/325/81/85632581.geojson
@@ -1044,8 +1044,9 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "meso",
         "naturalearth",
-        "meso"
+        "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -1100,6 +1101,11 @@
     },
     "wof:country":"EG",
     "wof:country_alpha3":"EGY",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"f3e4a70bcd760e047d32b127faade2ec",
     "wof:hierarchy":[
         {
@@ -1114,7 +1120,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585855,
+    "wof:lastmodified":1582352362,
     "wof:name":"Egypt",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/709/85/85670985.geojson
+++ b/data/856/709/85/85670985.geojson
@@ -339,6 +339,9 @@
         "wd:id":"Q30835"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f580e4cb5f908bea6cb4ec066fef5ccc",
     "wof:hierarchy":[
         {
@@ -354,7 +357,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585854,
+    "wof:lastmodified":1582352362,
     "wof:name":"Al Gharbiyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/709/89/85670989.geojson
+++ b/data/856/709/89/85670989.geojson
@@ -337,6 +337,9 @@
         "wd:id":"Q31067"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"da74eac567876cdc84730ab3aab7228f",
     "wof:hierarchy":[
         {
@@ -352,7 +355,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585854,
+    "wof:lastmodified":1582352361,
     "wof:name":"Al Isma`iliyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/709/95/85670995.geojson
+++ b/data/856/709/95/85670995.geojson
@@ -331,6 +331,9 @@
         "wd:id":"Q30786"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f953090aac5fdbe4b7fe7728ccbc3ddf",
     "wof:hierarchy":[
         {
@@ -346,7 +349,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585854,
+    "wof:lastmodified":1582352361,
     "wof:name":"Al Minufiyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/709/99/85670999.geojson
+++ b/data/856/709/99/85670999.geojson
@@ -324,6 +324,7 @@
     "qs:type":"Governorate",
     "src:geom":"whosonfirst",
     "src:geom_alt":[
+        "meso",
         "quattroshapes"
     ],
     "src:geom_via":"meso",
@@ -357,6 +358,10 @@
         "wd:id":"Q30805"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "meso",
+        "quattroshapes"
+    ],
     "wof:geomhash":"55e3dacd65ca9e77c9c83f7607196dbe",
     "wof:hierarchy":[
         {
@@ -372,7 +377,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585854,
+    "wof:lastmodified":1582352361,
     "wof:name":"Al Qahirah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/03/85671003.geojson
+++ b/data/856/710/03/85671003.geojson
@@ -294,6 +294,7 @@
     "qs:type":"Governorate",
     "src:geom":"whosonfirst",
     "src:geom_alt":[
+        "meso",
         "quattroshapes"
     ],
     "src:geom_via":"meso",
@@ -327,6 +328,10 @@
         "wd:id":"Q31075"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "meso",
+        "quattroshapes"
+    ],
     "wof:geomhash":"2ba98a128ce2a83ca3247d0b6eae37ee",
     "wof:hierarchy":[
         {
@@ -342,7 +347,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585858,
+    "wof:lastmodified":1582352363,
     "wof:name":"Al Qalyubiyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/07/85671007.geojson
+++ b/data/856/710/07/85671007.geojson
@@ -336,6 +336,9 @@
         "wd:id":"Q31074"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4a82af3877c6ffe6f8df5003488d1526",
     "wof:hierarchy":[
         {
@@ -351,7 +354,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585861,
+    "wof:lastmodified":1582352364,
     "wof:name":"Ash Sharqiyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/13/85671013.geojson
+++ b/data/856/710/13/85671013.geojson
@@ -335,6 +335,9 @@
         "wd:id":"Q31070"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fb4a38b8e2eaa732a81dfdf1382db98a",
     "wof:hierarchy":[
         {
@@ -350,7 +353,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585865,
+    "wof:lastmodified":1582352365,
     "wof:name":"As Suways",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/17/85671017.geojson
+++ b/data/856/710/17/85671017.geojson
@@ -338,6 +338,9 @@
         "wd:id":"Q31068"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b457319cd9886fbb6d449fce214067fc",
     "wof:hierarchy":[
         {
@@ -353,7 +356,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585860,
+    "wof:lastmodified":1582352364,
     "wof:name":"Ad Daqahliyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/21/85671021.geojson
+++ b/data/856/710/21/85671021.geojson
@@ -331,6 +331,9 @@
         "wd:id":"Q31079"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"361d9653ee0f3a0bb6ac525ab5fb0f73",
     "wof:hierarchy":[
         {
@@ -346,7 +349,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585860,
+    "wof:lastmodified":1582352364,
     "wof:name":"Bur Sa`id",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/25/85671025.geojson
+++ b/data/856/710/25/85671025.geojson
@@ -332,6 +332,9 @@
         "wd:id":"Q30644"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7b9dceefb3eb11384297340f1a2bc834",
     "wof:hierarchy":[
         {
@@ -347,7 +350,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585865,
+    "wof:lastmodified":1582352365,
     "wof:name":"Dumyat",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/31/85671031.geojson
+++ b/data/856/710/31/85671031.geojson
@@ -342,6 +342,9 @@
         "wd:id":"Q30682"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b99419c005cc0c94b084078f9a9ea5c9",
     "wof:hierarchy":[
         {
@@ -357,7 +360,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585861,
+    "wof:lastmodified":1582352364,
     "wof:name":"Matruh",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/35/85671035.geojson
+++ b/data/856/710/35/85671035.geojson
@@ -340,6 +340,9 @@
         "wd:id":"Q30630"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"afe1a087e3bca0ed41a4d8b12c88359d",
     "wof:hierarchy":[
         {
@@ -355,7 +358,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585858,
+    "wof:lastmodified":1582352363,
     "wof:name":"Al Buhayrah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/37/85671037.geojson
+++ b/data/856/710/37/85671037.geojson
@@ -261,6 +261,7 @@
     "qs:type":"Governorate",
     "src:geom":"whosonfirst",
     "src:geom_alt":[
+        "meso",
         "quattroshapes"
     ],
     "src:geom_via":"meso",
@@ -294,6 +295,10 @@
         "wd:id":"Q30656"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "meso",
+        "quattroshapes"
+    ],
     "wof:geomhash":"bcc7401277b763954860e41319d1d31d",
     "wof:hierarchy":[
         {
@@ -309,7 +314,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585862,
+    "wof:lastmodified":1582352364,
     "wof:name":"Al Fayyum",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/41/85671041.geojson
+++ b/data/856/710/41/85671041.geojson
@@ -355,6 +355,9 @@
         "wk:page":"Alexandria Governorate"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cfe521f2a73c1dceb744cc0a78a40a3d",
     "wof:hierarchy":[
         {
@@ -370,7 +373,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585863,
+    "wof:lastmodified":1582352364,
     "wof:name":"Al Iskandariyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/47/85671047.geojson
+++ b/data/856/710/47/85671047.geojson
@@ -308,6 +308,7 @@
     "qs:type":"Governorate",
     "src:geom":"whosonfirst",
     "src:geom_alt":[
+        "meso",
         "quattroshapes"
     ],
     "src:geom_via":"meso",
@@ -341,6 +342,10 @@
         "wd:id":"Q30832"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "meso",
+        "quattroshapes"
+    ],
     "wof:geomhash":"4254a18da7ba021e8e24e4fb17a78155",
     "wof:hierarchy":[
         {
@@ -356,7 +361,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585865,
+    "wof:lastmodified":1582352365,
     "wof:name":"Al Jizah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/49/85671049.geojson
+++ b/data/856/710/49/85671049.geojson
@@ -356,6 +356,9 @@
         "wd:id":"Q30675"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a77e4a76783ce40a2efbb95f16bc0ae0",
     "wof:hierarchy":[
         {
@@ -371,7 +374,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585865,
+    "wof:lastmodified":1582352365,
     "wof:name":"Al Minya",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/53/85671053.geojson
+++ b/data/856/710/53/85671053.geojson
@@ -397,6 +397,9 @@
         "wd:id":"Q30683"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"746e59f1bc0084cf4e22b59f46160e14",
     "wof:hierarchy":[
         {
@@ -412,7 +415,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585861,
+    "wof:lastmodified":1582352364,
     "wof:name":"Bani Suwayf",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/57/85671057.geojson
+++ b/data/856/710/57/85671057.geojson
@@ -324,6 +324,9 @@
         "wd:id":"Q30946"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3e712e8b138bb0f52214c5182b313509",
     "wof:hierarchy":[
         {
@@ -339,7 +342,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585857,
+    "wof:lastmodified":1582352363,
     "wof:name":"Kafr ash Shaykh",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/61/85671061.geojson
+++ b/data/856/710/61/85671061.geojson
@@ -447,6 +447,9 @@
         "wd:id":"Q29937"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9d8520d72c571e12f4c8e318b4c96f09",
     "wof:hierarchy":[
         {
@@ -462,7 +465,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585857,
+    "wof:lastmodified":1582352363,
     "wof:name":"Aswan",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/69/85671069.geojson
+++ b/data/856/710/69/85671069.geojson
@@ -436,6 +436,9 @@
         "wd:id":"Q29965"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4ce05b9e6584850fd47fe8a206ba1858",
     "wof:hierarchy":[
         {
@@ -451,7 +454,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585859,
+    "wof:lastmodified":1582352363,
     "wof:name":"Asyut",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/71/85671071.geojson
+++ b/data/856/710/71/85671071.geojson
@@ -332,6 +332,9 @@
         "wd:id":"Q30650"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4b49ff36a31381b11f5c2f5aff7bb41e",
     "wof:hierarchy":[
         {
@@ -347,7 +350,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585864,
+    "wof:lastmodified":1582352365,
     "wof:name":"Al Wadi at Jadid",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/75/85671075.geojson
+++ b/data/856/710/75/85671075.geojson
@@ -333,6 +333,9 @@
         "wd:id":"Q31065"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ed36c24e98c3c0550a18862fee6fd769",
     "wof:hierarchy":[
         {
@@ -348,7 +351,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585860,
+    "wof:lastmodified":1582352364,
     "wof:name":"Qina",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/79/85671079.geojson
+++ b/data/856/710/79/85671079.geojson
@@ -335,6 +335,9 @@
         "wd:id":"Q30669"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7a52f6295f629885bbe609cca14f5dfb",
     "wof:hierarchy":[
         {
@@ -350,7 +353,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585862,
+    "wof:lastmodified":1582352364,
     "wof:name":"Suhaj",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/85/85671085.geojson
+++ b/data/856/710/85/85671085.geojson
@@ -336,6 +336,9 @@
         "wd:id":"Q30831"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"880c9e07fefc4662ccdb1f30ee3a35f9",
     "wof:hierarchy":[
         {
@@ -351,7 +354,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585864,
+    "wof:lastmodified":1582352365,
     "wof:name":"Al Bahr al Ahmar",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/89/85671089.geojson
+++ b/data/856/710/89/85671089.geojson
@@ -339,6 +339,9 @@
         "wd:id":"Q30815"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b631dcb2e644211c5aa86db8ba5b623d",
     "wof:hierarchy":[
         {
@@ -354,7 +357,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585859,
+    "wof:lastmodified":1582352364,
     "wof:name":"Janub Sina'",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/93/85671093.geojson
+++ b/data/856/710/93/85671093.geojson
@@ -333,6 +333,9 @@
         "wd:id":"Q30662"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"25516249639b3fc613cb680e28acfcf9",
     "wof:hierarchy":[
         {
@@ -348,7 +351,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585859,
+    "wof:lastmodified":1582352364,
     "wof:name":"Shamal Sina'",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/97/85671097.geojson
+++ b/data/856/710/97/85671097.geojson
@@ -299,6 +299,9 @@
         "wd:id":"Q30797"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a95bfb4c480c202b55f9cb8ba18af23e",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566585862,
+    "wof:lastmodified":1582352364,
     "wof:name":"Luxor",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/859/029/19/85902919.geojson
+++ b/data/859/029/19/85902919.geojson
@@ -86,6 +86,10 @@
         "qs_pg:id":1118016
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"2884128215ce223a075479afb178bc5c",
     "wof:hierarchy":[
         {
@@ -101,7 +105,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585850,
+    "wof:lastmodified":1582352360,
     "wof:name":"Abbasiyah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/23/85902923.geojson
+++ b/data/859/029/23/85902923.geojson
@@ -68,6 +68,9 @@
         "gp:id":1521977
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d29e20ce92789dab23ea3f570b2fe4f8",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585851,
+    "wof:lastmodified":1582352360,
     "wof:name":"Al Urm\u00e5n",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/25/85902925.geojson
+++ b/data/859/029/25/85902925.geojson
@@ -88,6 +88,9 @@
         "wd:id":"Q4518971"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"68e2c18b09499cbf12ed3d131a242fd2",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379294,
+    "wof:lastmodified":1582352361,
     "wof:name":"Wardian",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/27/85902927.geojson
+++ b/data/859/029/27/85902927.geojson
@@ -104,6 +104,9 @@
         "qs_pg:id":1118020
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0755ff2383ea836794b83434e83560ce",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585850,
+    "wof:lastmodified":1582352360,
     "wof:name":"Er Raml",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/29/85902929.geojson
+++ b/data/859/029/29/85902929.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":1118024
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9a6604b685ca0fd5c6cc60ddd90a489f",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585850,
+    "wof:lastmodified":1582352360,
     "wof:name":"El-Raswa",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/31/85902931.geojson
+++ b/data/859/029/31/85902931.geojson
@@ -87,6 +87,10 @@
         "qs_pg:id":891539
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c9d7cb4eb8a6dc1c0f7fa973b6a80beb",
     "wof:hierarchy":[
         {
@@ -102,7 +106,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566585851,
+    "wof:lastmodified":1582352360,
     "wof:name":"\u0627\u0644\u0633\u064a\u062f\u0629 \u0632\u064a\u0646\u0628",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/33/85902933.geojson
+++ b/data/859/029/33/85902933.geojson
@@ -85,6 +85,9 @@
         "qs:id":1120441
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"93643f47c2485d6885f42e527891519d",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379294,
+    "wof:lastmodified":1582352360,
     "wof:name":"Chatbi",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/35/85902935.geojson
+++ b/data/859/029/35/85902935.geojson
@@ -87,6 +87,10 @@
         "qs_pg:id":221273
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"699e4437dffe6446d09f1589bec0e935",
     "wof:hierarchy":[
         {
@@ -102,7 +106,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585849,
+    "wof:lastmodified":1582352360,
     "wof:name":"El Gez\u00eera",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/37/85902937.geojson
+++ b/data/859/029/37/85902937.geojson
@@ -100,6 +100,10 @@
         "wd:id":"Q4837230"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bb28eda0bb18cf48fa89f026e9fd0618",
     "wof:hierarchy":[
         {
@@ -115,7 +119,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566585851,
+    "wof:lastmodified":1582352360,
     "wof:name":"\u0628\u0627\u0628 \u0627\u0644\u0644\u0648\u0642",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/41/85902941.geojson
+++ b/data/859/029/41/85902941.geojson
@@ -82,6 +82,9 @@
         "gp:id":1522460
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cf1c63d2fe6c9f770dac37006b2c49a2",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566585851,
+    "wof:lastmodified":1582352360,
     "wof:name":"\u0628\u0627\u0628 \u0627\u0644\u0634\u0639\u0631\u064a\u0629",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/43/85902943.geojson
+++ b/data/859/029/43/85902943.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":428317
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f7c3765cc74a7377ddc42ab3411a0f36",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585850,
+    "wof:lastmodified":1582352360,
     "wof:name":"B\u00f8l\u00e5q",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/45/85902945.geojson
+++ b/data/859/029/45/85902945.geojson
@@ -113,6 +113,9 @@
         "qs_pg:id":1083606
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e5266481d5221c699d3ae0c3ee65b072",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585850,
+    "wof:lastmodified":1582352360,
     "wof:name":"Bulkeley",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/47/85902947.geojson
+++ b/data/859/029/47/85902947.geojson
@@ -334,6 +334,10 @@
         "wk:page":"Port Said"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"9b3af386893ecaa538731c92fb8524d4",
     "wof:hierarchy":[
         {
@@ -349,7 +353,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585851,
+    "wof:lastmodified":1582352361,
     "wof:name":"B\u016br Sa\u2019\u012bd",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/49/85902949.geojson
+++ b/data/859/029/49/85902949.geojson
@@ -79,6 +79,9 @@
         "gp:id":1523720
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c4be6c9d32828eb2b1c5f4dbfeac2533",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566585851,
+    "wof:lastmodified":1582352361,
     "wof:name":"\u062c\u0627\u0631\u062f\u0646 \u0633\u064a\u062a\u0649",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/51/85902951.geojson
+++ b/data/859/029/51/85902951.geojson
@@ -90,6 +90,10 @@
         "wd:id":"Q4519049"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e5d28e438458aa4041abca6dc09053e9",
     "wof:hierarchy":[
         {
@@ -105,7 +109,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566585849,
+    "wof:lastmodified":1582352360,
     "wof:name":"\u0643\u0631\u0645\u0648\u0632",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/53/85902953.geojson
+++ b/data/859/029/53/85902953.geojson
@@ -80,6 +80,10 @@
         "qs_pg:id":891550
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2d562de3185719214ec160a72d11fccd",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585851,
+    "wof:lastmodified":1582352360,
     "wof:name":"Kubri el Kubbeh",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/55/85902955.geojson
+++ b/data/859/029/55/85902955.geojson
@@ -80,6 +80,10 @@
         "qs_pg:id":891551
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"8f06efcc1ab5bca3c649c35f47eece21",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585851,
+    "wof:lastmodified":1582352360,
     "wof:name":"Al-Muka\u1e6d\u1e6dam City",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/59/85902959.geojson
+++ b/data/859/029/59/85902959.geojson
@@ -141,6 +141,9 @@
         "wk:page":"Nasr City"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"956bd8176a47372653b3f0037bfb10b2",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585849,
+    "wof:lastmodified":1582352360,
     "wof:name":"Mad\u012bnat an Na\u015fr",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/61/85902961.geojson
+++ b/data/859/029/61/85902961.geojson
@@ -79,6 +79,10 @@
         "qs_pg:id":891554
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"fae493a764123bbcc7796d191a920e75",
     "wof:hierarchy":[
         {
@@ -94,7 +98,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585849,
+    "wof:lastmodified":1582352360,
     "wof:name":"El Fostat",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/63/85902963.geojson
+++ b/data/859/029/63/85902963.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":1118056
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"96d4810c17865e4e1754fad928ae8512",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585851,
+    "wof:lastmodified":1582352360,
     "wof:name":"Muh\u0327arram Bey",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/65/85902965.geojson
+++ b/data/859/029/65/85902965.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Shubra"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c8f3d5cc95fa80630c544b542c45e110",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1534379294,
+    "wof:lastmodified":1582352360,
     "wof:name":"\u0634\u0628\u0631\u0627",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/67/85902967.geojson
+++ b/data/859/029/67/85902967.geojson
@@ -121,6 +121,9 @@
         "wd:id":"Q2169497"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3127ba4091dc8d296a286b98a39b6557",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566585850,
+    "wof:lastmodified":1582352360,
     "wof:name":"\u0633\u064a\u062f\u0649 \u062c\u0627\u0628\u0631",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/69/85902969.geojson
+++ b/data/859/029/69/85902969.geojson
@@ -77,6 +77,9 @@
         "qs_pg:id":909932
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"96952f54f31a70acdda7f27e06f0f80f",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585849,
+    "wof:lastmodified":1582352360,
     "wof:name":"Tall al Qulzum",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/063/63/85906363.geojson
+++ b/data/859/063/63/85906363.geojson
@@ -107,6 +107,9 @@
         "wk:page":"Sidi Bishr"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"be64e8fa729f36e524ed6b761ff93bdd",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585848,
+    "wof:lastmodified":1582352360,
     "wof:name":"Sidi Bishr",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/067/57/85906757.geojson
+++ b/data/859/067/57/85906757.geojson
@@ -70,6 +70,10 @@
         "qs_pg:id":989999
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ceecc5e197349c5f310bc1c3aea28912",
     "wof:hierarchy":[
         {
@@ -85,7 +89,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585853,
+    "wof:lastmodified":1582352361,
     "wof:name":"Mina El Basal District",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/067/59/85906759.geojson
+++ b/data/859/067/59/85906759.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":1184271
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"251b94531b8ca28a01df4ea17ff8262f",
     "wof:hierarchy":[
         {
@@ -81,7 +85,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585853,
+    "wof:lastmodified":1582352361,
     "wof:name":"Karmose District",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/067/61/85906761.geojson
+++ b/data/859/067/61/85906761.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":893531
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"87df91d61496f02f61c17f8cdd649381",
     "wof:hierarchy":[
         {
@@ -81,7 +85,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585853,
+    "wof:lastmodified":1582352361,
     "wof:name":"El Manshia District",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/067/63/85906763.geojson
+++ b/data/859/067/63/85906763.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":237754
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e276d9cef4295736f3799a9b48635fe6",
     "wof:hierarchy":[
         {
@@ -81,7 +85,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585853,
+    "wof:lastmodified":1582352361,
     "wof:name":"El Attarien District",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/067/65/85906765.geojson
+++ b/data/859/067/65/85906765.geojson
@@ -63,6 +63,10 @@
         "qs_pg:id":897001
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"af3c5580a2558eb738b1723d16ebc13b",
     "wof:hierarchy":[
         {
@@ -77,7 +81,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585853,
+    "wof:lastmodified":1582352361,
     "wof:name":"Al Gomrok District",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/067/67/85906767.geojson
+++ b/data/859/067/67/85906767.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":897002
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"585a764290c4643d5f30facb8b7f11b9",
     "wof:hierarchy":[
         {
@@ -81,7 +85,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585853,
+    "wof:lastmodified":1582352361,
     "wof:name":"Bab Sharq District",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/067/69/85906769.geojson
+++ b/data/859/067/69/85906769.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":14484
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fa1e61172ac3c5631daddf90cd7e583d",
     "wof:hierarchy":[
         {
@@ -81,7 +85,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585853,
+    "wof:lastmodified":1582352361,
     "wof:name":"Moharam Bey District",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/067/71/85906771.geojson
+++ b/data/859/067/71/85906771.geojson
@@ -85,6 +85,10 @@
         "wd:id":"Q2169497"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"114de1ab830450a411f472c556e79b85",
     "wof:hierarchy":[
         {
@@ -100,7 +104,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585854,
+    "wof:lastmodified":1582352361,
     "wof:name":"Sidi Gaber District",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/067/75/85906775.geojson
+++ b/data/859/067/75/85906775.geojson
@@ -85,6 +85,10 @@
         "wd:id":"Q4518509"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"d68cecd7d977508a41a5940dfb0fcd46",
     "wof:hierarchy":[
         {
@@ -100,7 +104,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585853,
+    "wof:lastmodified":1582352361,
     "wof:name":"El Raml District",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/067/77/85906777.geojson
+++ b/data/859/067/77/85906777.geojson
@@ -66,6 +66,10 @@
         "wd:id":"Q5258869"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"0733e0e3ce91d8cba562bfeb62226944",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585854,
+    "wof:lastmodified":1582352361,
     "wof:name":"El Minaa District",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/81/85906981.geojson
+++ b/data/859/069/81/85906981.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":990006
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f7d9f7076ef81bf65f3f8db90dd668c8",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585852,
+    "wof:lastmodified":1582352361,
     "wof:name":"Masakin Az-zawiya Al-hamra",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/83/85906983.geojson
+++ b/data/859/069/83/85906983.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":220218
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"7b3da18890685dd2b23685a18dec37e2",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585852,
+    "wof:lastmodified":1582352361,
     "wof:name":"Raud Al Farag",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/85/85906985.geojson
+++ b/data/859/069/85/85906985.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":366761
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"87122900e71ce920286c3bfe0efb0b02",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585853,
+    "wof:lastmodified":1582352361,
     "wof:name":"As Subra",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/87/85906987.geojson
+++ b/data/859/069/87/85906987.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":366762
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a26d2ecf3e580b3fcc693be172468284",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566585852,
+    "wof:lastmodified":1582352361,
     "wof:name":"\u0627\u0644\u0648\u0627\u064a\u0644\u0649",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/91/85906991.geojson
+++ b/data/859/069/91/85906991.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1109772
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"2000cce8480e6a42d3ca37aec521bd97",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585852,
+    "wof:lastmodified":1582352361,
     "wof:name":"Masakin Subra Al-balad",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/93/85906993.geojson
+++ b/data/859/069/93/85906993.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":366760
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"0386ae3622ac05d34da832e538deaccb",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585852,
+    "wof:lastmodified":1582352361,
     "wof:name":"Masakin Al-waila Al-kabir",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/95/85906995.geojson
+++ b/data/859/069/95/85906995.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":14491
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"226fe9a9e904f2857b29cf570d7cd4ee",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585852,
+    "wof:lastmodified":1582352361,
     "wof:name":"Az-zahir",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/97/85906997.geojson
+++ b/data/859/069/97/85906997.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1087558
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1d4ee302201f01c8caf943d82e58fb78",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585852,
+    "wof:lastmodified":1582352361,
     "wof:name":"Darb An-nasr",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/069/99/85906999.geojson
+++ b/data/859/069/99/85906999.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1087554
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"75f5fc3373623d62b8b23157374b9813",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585852,
+    "wof:lastmodified":1582352361,
     "wof:name":"Madinat Al-bu'ut",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/01/85907001.geojson
+++ b/data/859/070/01/85907001.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1087561
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f60ef51451c539a51bf10862da53885b",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585848,
+    "wof:lastmodified":1582352360,
     "wof:name":"Bab As-si'riya",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/03/85907003.geojson
+++ b/data/859/070/03/85907003.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":501233
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ba688d8696b83217f9ead1a4db81421e",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585846,
+    "wof:lastmodified":1582352359,
     "wof:name":"Gazira",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/05/85907005.geojson
+++ b/data/859/070/05/85907005.geojson
@@ -84,6 +84,9 @@
         "qs:id":1086002
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"376e30d2de33902b3251d6d8cb46452a",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379294,
+    "wof:lastmodified":1582352360,
     "wof:name":"As-sayyida Zainab",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/09/85907009.geojson
+++ b/data/859/070/09/85907009.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1087555
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4e190e103c1aef4fc4901399be35b800",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585847,
+    "wof:lastmodified":1582352360,
     "wof:name":"Al-halifa",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/11/85907011.geojson
+++ b/data/859/070/11/85907011.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1087562
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e77852a305f4b046fcd2a8eab4de62b0",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585846,
+    "wof:lastmodified":1582352360,
     "wof:name":"Ad-darb Al-ahmar",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/13/85907013.geojson
+++ b/data/859/070/13/85907013.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1087563
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"30c644ab6dd1e330b5d7a003c3a37f43",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585848,
+    "wof:lastmodified":1582352360,
     "wof:name":"Gazirat Ar-rauda",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/15/85907015.geojson
+++ b/data/859/070/15/85907015.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":212481
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f6b7d743a72181654c72d70369faf418",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585848,
+    "wof:lastmodified":1582352360,
     "wof:name":"Tilal Ain As-sira",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/17/85907017.geojson
+++ b/data/859/070/17/85907017.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":237759
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d5f3b344c0fa55560371e398926e04bf",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585847,
+    "wof:lastmodified":1582352360,
     "wof:name":"City of the Dead",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/19/85907019.geojson
+++ b/data/859/070/19/85907019.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1087564
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5995278a98e391e8b450c7206234bfe8",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585847,
+    "wof:lastmodified":1582352360,
     "wof:name":"Qasr An-nil",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/21/85907021.geojson
+++ b/data/859/070/21/85907021.geojson
@@ -100,6 +100,9 @@
         "qs_pg:id":1086003
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"98e7002d98bff176bcf3728e052e403f",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585847,
+    "wof:lastmodified":1582352360,
     "wof:name":"Masakin Zainhum",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/23/85907023.geojson
+++ b/data/859/070/23/85907023.geojson
@@ -98,6 +98,10 @@
         "wd:id":"Q2063168"
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d7a7e0913f55150e361f0b7f5a3c2dc6",
     "wof:hierarchy":[
         {
@@ -113,7 +117,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585848,
+    "wof:lastmodified":1582352360,
     "wof:name":"Al-azbakiya",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/27/85907027.geojson
+++ b/data/859/070/27/85907027.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":347003
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"01ec8e285e194913f5ca050aaa40a24e",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585846,
+    "wof:lastmodified":1582352360,
     "wof:name":"Al-gamaliya",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/29/85907029.geojson
+++ b/data/859/070/29/85907029.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":212320
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"d0a1d5ca88585b9022210822d087bc7d",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585847,
+    "wof:lastmodified":1582352360,
     "wof:name":"Han Al-halili",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/31/85907031.geojson
+++ b/data/859/070/31/85907031.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":212321
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"d41c29156e74f8b780a29211ae5f2c15",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585847,
+    "wof:lastmodified":1582352360,
     "wof:name":"Al-muski",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/33/85907033.geojson
+++ b/data/859/070/33/85907033.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":898855
     },
     "wof:country":"EG",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"ee50b724d9a7a214eeecef6f35248d83",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585846,
+    "wof:lastmodified":1582352359,
     "wof:name":"Al-abidin",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.