### PR TITLE
Update non-ascii names, store existing localized names

### DIFF
--- a/data/112/605/527/3/1126055273.geojson
+++ b/data/112/605/527/3/1126055273.geojson
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1126055273,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423087,
     "wof:name":"At Tur",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/605/527/3/1126055273.geojson
+++ b/data/112/605/527/3/1126055273.geojson
@@ -20,6 +20,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0637\u0648\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "At Tur"
+    ],
     "qs_pg:aaroncc":"EG",
     "qs_pg:gn_country":"EG",
     "qs_pg:name":"\u0627\u0644\u0637\u0648\u0631",
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":1126055273,
-    "wof:lastmodified":1566586583,
-    "wof:name":"\u0627\u0644\u0637\u0648\u0631",
+    "wof:lastmodified":1601068391,
+    "wof:name":"At Tur",
     "wof:parent_id":-1,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/112/608/964/9/1126089649.geojson
+++ b/data/112/608/964/9/1126089649.geojson
@@ -20,6 +20,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0633\u064a\u062f\u0649 \u062c\u0627\u0628\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Sidi Gaber"
+    ],
     "qs_pg:aaroncc":"EG",
     "qs_pg:gn_country":"EG",
     "qs_pg:gn_fcode":"PPLX",
@@ -72,8 +78,8 @@
         }
     ],
     "wof:id":1126089649,
-    "wof:lastmodified":1534379294,
-    "wof:name":"\u0633\u064a\u062f\u0649 \u062c\u0627\u0628\u0631",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Sidi Gaber",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/112/608/964/9/1126089649.geojson
+++ b/data/112/608/964/9/1126089649.geojson
@@ -53,10 +53,10 @@
     "woe:name_adm1":"\u0627\u0644\u0627\u0633\u0643\u0646\u062f\u0631\u064a\u0629",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85671041,
         102191573,
         85632581,
-        1092024943
+        1092024943,
+        85671041
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -78,7 +78,7 @@
         }
     ],
     "wof:id":1126089649,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Sidi Gaber",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/172/089/421172089.geojson
+++ b/data/421/172/089/421172089.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0634\u0631\u0645 \u0627\u0644\u0634\u064a\u062e"
+    ],
+    "name:eng_x_preferred":[
+        "Sharm El Sheikh"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421172089,
-    "wof:lastmodified":1566586566,
-    "wof:name":"\u0634\u0631\u0645 \u0627\u0644\u0634\u064a\u062e",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Sharm El Sheikh",
     "wof:parent_id":1092024505,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/172/089/421172089.geojson
+++ b/data/421/172/089/421172089.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85671089,
-        1092024505
+        1092024505,
+        85671089
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421172089,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Sharm El Sheikh",
     "wof:parent_id":1092024505,
     "wof:placetype":"locality",

--- a/data/421/172/093/421172093.geojson
+++ b/data/421/172/093/421172093.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85671075,
-        1092023581
+        1092023581,
+        85671075
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421172093,
-    "wof:lastmodified":1601068400,
+    "wof:lastmodified":1601423091,
     "wof:name":"Qus Centre",
     "wof:parent_id":1092023581,
     "wof:placetype":"locality",

--- a/data/421/172/093/421172093.geojson
+++ b/data/421/172/093/421172093.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0631\u0643\u0632 \u0642\u0648\u0635"
+    ],
+    "name:eng_x_preferred":[
+        "Qus Centre"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421172093,
-    "wof:lastmodified":1566586566,
-    "wof:name":"\u0645\u0631\u0643\u0632 \u0642\u0648\u0635",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Qus Centre",
     "wof:parent_id":1092023581,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/172/095/421172095.geojson
+++ b/data/421/172/095/421172095.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85671047,
-        1092018891
+        1092018891,
+        85671047
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421172095,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Sakiat Makki",
     "wof:parent_id":1092018891,
     "wof:placetype":"locality",

--- a/data/421/172/095/421172095.geojson
+++ b/data/421/172/095/421172095.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0633\u0627\u0642\u064a\u0629 \u0645\u0643\u0649"
+    ],
+    "name:eng_x_preferred":[
+        "Sakiat Makki"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421172095,
-    "wof:lastmodified":1566586566,
-    "wof:name":"\u0633\u0627\u0642\u064a\u0629 \u0645\u0643\u0649",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Sakiat Makki",
     "wof:parent_id":1092018891,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/174/837/421174837.geojson
+++ b/data/421/174/837/421174837.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85670989,
-        1092014845
+        1092014845,
+        85670989
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421174837,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423089,
     "wof:name":"Ismailia",
     "wof:parent_id":1092014845,
     "wof:placetype":"locality",

--- a/data/421/174/837/421174837.geojson
+++ b/data/421/174/837/421174837.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0627\u0633\u0645\u0627\u0639\u064a\u0644\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Ismailia"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421174837,
-    "wof:lastmodified":1566586560,
-    "wof:name":"\u0627\u0644\u0627\u0633\u0645\u0627\u0639\u064a\u0644\u064a\u0629",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Ismailia",
     "wof:parent_id":1092014845,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/178/333/421178333.geojson
+++ b/data/421/178/333/421178333.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0633\u0648\u0627\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Aswan"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421178333,
-    "wof:lastmodified":1566586572,
-    "wof:name":"\u0627\u0633\u0648\u0627\u0646",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Aswan",
     "wof:parent_id":1092014635,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/178/333/421178333.geojson
+++ b/data/421/178/333/421178333.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85671061,
-        1092014635
+        1092014635,
+        85671061
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421178333,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423087,
     "wof:name":"Aswan",
     "wof:parent_id":1092014635,
     "wof:placetype":"locality",

--- a/data/421/182/151/421182151.geojson
+++ b/data/421/182/151/421182151.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0643\u0631\u062f\u0627\u0633\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Kerdasa"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421182151,
-    "wof:lastmodified":1566586572,
-    "wof:name":"\u0643\u0631\u062f\u0627\u0633\u0629",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Kerdasa",
     "wof:parent_id":1092022885,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/182/151/421182151.geojson
+++ b/data/421/182/151/421182151.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85671047,
-        1092022885
+        1092022885,
+        85671047
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421182151,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423090,
     "wof:name":"Kerdasa",
     "wof:parent_id":1092022885,
     "wof:placetype":"locality",

--- a/data/421/182/327/421182327.geojson
+++ b/data/421/182/327/421182327.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0648\u0627\u062d\u0627\u062a \u0627\u0644\u062e\u0627\u0631\u062c\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Kharga Oases"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421182327,
-    "wof:lastmodified":1566586572,
-    "wof:name":"\u0627\u0644\u0648\u0627\u062d\u0627\u062a \u0627\u0644\u062e\u0627\u0631\u062c\u0629",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Kharga Oases",
     "wof:parent_id":1092020223,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/182/327/421182327.geojson
+++ b/data/421/182/327/421182327.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85671071,
-        1092020223
+        1092020223,
+        85671071
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421182327,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423090,
     "wof:name":"Kharga Oases",
     "wof:parent_id":1092020223,
     "wof:placetype":"locality",

--- a/data/421/185/685/421185685.geojson
+++ b/data/421/185/685/421185685.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85670999,
-        1092018203
+        1092018203,
+        85670999
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421185685,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Maadi",
     "wof:parent_id":1092018203,
     "wof:placetype":"locality",

--- a/data/421/185/685/421185685.geojson
+++ b/data/421/185/685/421185685.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u0639\u0627\u062f\u0649"
+    ],
+    "name:eng_x_preferred":[
+        "Al Maadi"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421185685,
-    "wof:lastmodified":1566586573,
-    "wof:name":"\u0627\u0644\u0645\u0639\u0627\u062f\u0649",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Maadi",
     "wof:parent_id":1092018203,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/189/895/421189895.geojson
+++ b/data/421/189/895/421189895.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85671085,
-        1092019787
+        1092019787,
+        85671085
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421189895,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al Shalateen",
     "wof:parent_id":1092019787,
     "wof:placetype":"locality",

--- a/data/421/189/895/421189895.geojson
+++ b/data/421/189/895/421189895.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0634\u0644\u0627\u062a\u064a\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Al Shalateen"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421189895,
-    "wof:lastmodified":1566586563,
-    "wof:name":"\u0627\u0644\u0634\u0644\u0627\u062a\u064a\u0646",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Al Shalateen",
     "wof:parent_id":1092019787,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/189/897/421189897.geojson
+++ b/data/421/189/897/421189897.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85671003,
-        1092018935
+        1092018935,
+        85671003
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421189897,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423091,
     "wof:name":"Qalyub",
     "wof:parent_id":1092018935,
     "wof:placetype":"locality",

--- a/data/421/189/897/421189897.geojson
+++ b/data/421/189/897/421189897.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0642\u0644\u064a\u0648\u0628"
+    ],
+    "name:eng_x_preferred":[
+        "Qalyub"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421189897,
-    "wof:lastmodified":1566586565,
-    "wof:name":"\u0642\u0644\u064a\u0648\u0628",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Qalyub",
     "wof:parent_id":1092018935,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/189/915/421189915.geojson
+++ b/data/421/189/915/421189915.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0632\u0642\u0627\u0632\u064a\u0642"
+    ],
+    "name:eng_x_preferred":[
+        "Al Zagazig"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421189915,
-    "wof:lastmodified":1566586563,
-    "wof:name":"\u0627\u0644\u0632\u0642\u0627\u0632\u064a\u0642",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Al Zagazig",
     "wof:parent_id":1092020479,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/189/915/421189915.geojson
+++ b/data/421/189/915/421189915.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85671007,
-        1092020479
+        1092020479,
+        85671007
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421189915,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al Zagazig",
     "wof:parent_id":1092020479,
     "wof:placetype":"locality",

--- a/data/421/189/917/421189917.geojson
+++ b/data/421/189/917/421189917.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85671003,
-        1092015253
+        1092015253,
+        85671003
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421189917,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423088,
     "wof:name":"Benha",
     "wof:parent_id":1092015253,
     "wof:placetype":"locality",

--- a/data/421/189/917/421189917.geojson
+++ b/data/421/189/917/421189917.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0646\u0647\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Benha"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421189917,
-    "wof:lastmodified":1566586565,
-    "wof:name":"\u0628\u0646\u0647\u0627",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Benha",
     "wof:parent_id":1092015253,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/189/919/421189919.geojson
+++ b/data/421/189/919/421189919.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0646\u0649 \u0633\u0648\u064a\u0641"
+    ],
+    "name:eng_x_preferred":[
+        "Bani Suef"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421189919,
-    "wof:lastmodified":1566586565,
-    "wof:name":"\u0628\u0646\u0649 \u0633\u0648\u064a\u0641",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Bani Suef",
     "wof:parent_id":1092015341,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/189/919/421189919.geojson
+++ b/data/421/189/919/421189919.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85671053,
-        1092015341
+        1092015341,
+        85671053
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421189919,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423087,
     "wof:name":"Bani Suef",
     "wof:parent_id":1092015341,
     "wof:placetype":"locality",

--- a/data/421/189/921/421189921.geojson
+++ b/data/421/189/921/421189921.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85671007,
-        1092015569
+        1092015569,
+        85671007
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421189921,
-    "wof:lastmodified":1601068400,
+    "wof:lastmodified":1601423088,
     "wof:name":"Bilbeis Centre",
     "wof:parent_id":1092015569,
     "wof:placetype":"locality",

--- a/data/421/189/921/421189921.geojson
+++ b/data/421/189/921/421189921.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0631\u0643\u0632 \u0628\u0644\u0628\u064a\u0633"
+    ],
+    "name:eng_x_preferred":[
+        "Bilbeis Centre"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421189921,
-    "wof:lastmodified":1566586565,
-    "wof:name":"\u0645\u0631\u0643\u0632 \u0628\u0644\u0628\u064a\u0633",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Bilbeis Centre",
     "wof:parent_id":1092015569,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/189/923/421189923.geojson
+++ b/data/421/189/923/421189923.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"32.3247805,31.2315175,32.3247805,31.2315175",
+    "geom:bbox":"32.324781,31.231517,32.324781,31.231517",
     "geom:latitude":31.231517,
     "geom:longitude":32.324781,
     "iso:country":"EG",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85671021,
-        1092021001
+        1092021001,
+        85671021
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"EG",
     "wof:created":1459009640,
-    "wof:geomhash":"413d8f1caa96d662b73f256cdfa054c4",
+    "wof:geomhash":"dc636b5be5ae73ceb35232caa23135de",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421189923,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423091,
     "wof:name":"Port Fuad",
     "wof:parent_id":1092021001,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    32.3247805,
-    31.2315175,
-    32.3247805,
-    31.2315175
+    32.324781,
+    31.231517,
+    32.324781,
+    31.231517
 ],
-  "geometry": {"coordinates":[32.3247805,31.2315175],"type":"Point"}
+  "geometry": {"coordinates":[32.324781,31.231517],"type":"Point"}
 }

--- a/data/421/189/923/421189923.geojson
+++ b/data/421/189/923/421189923.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0648\u0631\u0641\u0648\u0627\u062f"
+    ],
+    "name:eng_x_preferred":[
+        "Port Fuad"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421189923,
-    "wof:lastmodified":1566586563,
-    "wof:name":"\u0628\u0648\u0631\u0641\u0648\u0627\u062f",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Port Fuad",
     "wof:parent_id":1092021001,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/189/927/421189927.geojson
+++ b/data/421/189/927/421189927.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85670999,
-        1092015839
+        1092015839,
+        85670999
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421189927,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423089,
     "wof:name":"Imbaba",
     "wof:parent_id":1092015839,
     "wof:placetype":"locality",

--- a/data/421/189/927/421189927.geojson
+++ b/data/421/189/927/421189927.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0645\u0628\u0627\u0628\u0647"
+    ],
+    "name:eng_x_preferred":[
+        "Imbaba"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421189927,
-    "wof:lastmodified":1566586565,
-    "wof:name":"\u0627\u0645\u0628\u0627\u0628\u0647",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Imbaba",
     "wof:parent_id":1092015839,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/189/931/421189931.geojson
+++ b/data/421/189/931/421189931.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0643\u0648\u0645 \u0627\u0645\u0628\u0648"
+    ],
+    "name:eng_x_preferred":[
+        "Kom Ombo"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421189931,
-    "wof:lastmodified":1566586562,
-    "wof:name":"\u0643\u0648\u0645 \u0627\u0645\u0628\u0648",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Kom Ombo",
     "wof:parent_id":1092021927,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/189/931/421189931.geojson
+++ b/data/421/189/931/421189931.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85671061,
-        1092021927
+        1092021927,
+        85671061
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421189931,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423090,
     "wof:name":"Kom Ombo",
     "wof:parent_id":1092021927,
     "wof:placetype":"locality",

--- a/data/421/189/941/421189941.geojson
+++ b/data/421/189/941/421189941.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0631\u0643\u0632 \u0646\u062c\u0639 \u062d\u0645\u0627\u062f\u064a"
+    ],
+    "name:eng_x_preferred":[
+        "Nagaa Hamadi Centre"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421189941,
-    "wof:lastmodified":1566586563,
-    "wof:name":"\u0645\u0631\u0643\u0632 \u0646\u062c\u0639 \u062d\u0645\u0627\u062f\u064a",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Nagaa Hamadi Centre",
     "wof:parent_id":1092022653,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/189/941/421189941.geojson
+++ b/data/421/189/941/421189941.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85671075,
-        1092022653
+        1092022653,
+        85671075
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421189941,
-    "wof:lastmodified":1601068400,
+    "wof:lastmodified":1601423091,
     "wof:name":"Nagaa Hamadi Centre",
     "wof:parent_id":1092022653,
     "wof:placetype":"locality",

--- a/data/421/189/955/421189955.geojson
+++ b/data/421/189/955/421189955.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85671047,
-        1092020349
+        1092020349,
+        85671047
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421189955,
-    "wof:lastmodified":1601068401,
+    "wof:lastmodified":1601423094,
     "wof:name":"Warraq Al Arab",
     "wof:parent_id":1092020349,
     "wof:placetype":"locality",

--- a/data/421/189/955/421189955.geojson
+++ b/data/421/189/955/421189955.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0648\u0631\u0627\u0642 \u0627\u0644\u0639\u0631\u0628"
+    ],
+    "name:eng_x_preferred":[
+        "Warraq Al Arab"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421189955,
-    "wof:lastmodified":1566586562,
-    "wof:name":"\u0648\u0631\u0627\u0642 \u0627\u0644\u0639\u0631\u0628",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Warraq Al Arab",
     "wof:parent_id":1092020349,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/191/703/421191703.geojson
+++ b/data/421/191/703/421191703.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u062f\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Badr"
+    ],
     "qs:gn_country":"EG",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":415561,
@@ -69,8 +75,8 @@
         }
     ],
     "wof:id":421191703,
-    "wof:lastmodified":1566586568,
-    "wof:name":"\u0628\u062f\u0631",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Badr",
     "wof:parent_id":1092022997,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/191/703/421191703.geojson
+++ b/data/421/191/703/421191703.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85671047,
         1092022997,
+        85671047,
         85670999
     ],
     "wof:breaches":[],
@@ -75,7 +75,7 @@
         }
     ],
     "wof:id":421191703,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423087,
     "wof:name":"Badr",
     "wof:parent_id":1092022997,
     "wof:placetype":"locality",

--- a/data/421/193/723/421193723.geojson
+++ b/data/421/193/723/421193723.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85671093,
-        1092023715
+        1092023715,
+        85671093
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421193723,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423083,
     "wof:name":"Al Arish",
     "wof:parent_id":1092023715,
     "wof:placetype":"locality",

--- a/data/421/193/723/421193723.geojson
+++ b/data/421/193/723/421193723.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0639\u0631\u064a\u0634"
+    ],
+    "name:eng_x_preferred":[
+        "Al Arish"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421193723,
-    "wof:lastmodified":1566586557,
-    "wof:name":"\u0627\u0644\u0639\u0631\u064a\u0634",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Al Arish",
     "wof:parent_id":1092023715,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/200/695/421200695.geojson
+++ b/data/421/200/695/421200695.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0633\u0641\u0627\u062c\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Safaga"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421200695,
-    "wof:lastmodified":1566586570,
-    "wof:name":"\u0633\u0641\u0627\u062c\u0627",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Safaga",
     "wof:parent_id":1092024087,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/200/695/421200695.geojson
+++ b/data/421/200/695/421200695.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85671085,
-        1092024087
+        1092024087,
+        85671085
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421200695,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Safaga",
     "wof:parent_id":1092024087,
     "wof:placetype":"locality",

--- a/data/421/200/903/421200903.geojson
+++ b/data/421/200/903/421200903.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85671017,
-        1092025681
+        1092025681,
+        85671017
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421200903,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Mansoura",
     "wof:parent_id":1092025681,
     "wof:placetype":"locality",

--- a/data/421/200/903/421200903.geojson
+++ b/data/421/200/903/421200903.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u0646\u0635\u0648\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Mansoura"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421200903,
-    "wof:lastmodified":1566586570,
-    "wof:name":"\u0627\u0644\u0645\u0646\u0635\u0648\u0631\u0629",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Mansoura",
     "wof:parent_id":1092025681,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/200/905/421200905.geojson
+++ b/data/421/200/905/421200905.geojson
@@ -21,7 +21,7 @@
         "\u0627\u0644\u0627\u0633\u0643\u0646\u062f\u0631\u064a\u0629"
     ],
     "name:eng_x_preferred":[
-        "Alexandria "
+        "Alexandria"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85671041,
-        1092015183
+        1092015183,
+        85671041
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,8 +66,8 @@
         }
     ],
     "wof:id":421200905,
-    "wof:lastmodified":1601068388,
-    "wof:name":"Alexandria ",
+    "wof:lastmodified":1601423086,
+    "wof:name":"Alexandria",
     "wof:parent_id":1092015183,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/200/905/421200905.geojson
+++ b/data/421/200/905/421200905.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0627\u0633\u0643\u0646\u062f\u0631\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Alexandria "
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421200905,
-    "wof:lastmodified":1566586570,
-    "wof:name":"\u0627\u0644\u0627\u0633\u0643\u0646\u062f\u0631\u064a\u0629",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Alexandria ",
     "wof:parent_id":1092015183,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/200/907/421200907.geojson
+++ b/data/421/200/907/421200907.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u0627\u0638\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Almaza"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421200907,
-    "wof:lastmodified":1566586569,
-    "wof:name":"\u0627\u0644\u0645\u0627\u0638\u0629",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Almaza",
     "wof:parent_id":1092022823,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/200/907/421200907.geojson
+++ b/data/421/200/907/421200907.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85670999,
-        1092022823
+        1092022823,
+        85670999
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421200907,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423086,
     "wof:name":"Almaza",
     "wof:parent_id":1092022823,
     "wof:placetype":"locality",

--- a/data/421/200/911/421200911.geojson
+++ b/data/421/200/911/421200911.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0637\u0646\u0637\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Tanta"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421200911,
-    "wof:lastmodified":1566586570,
-    "wof:name":"\u0637\u0646\u0637\u0627",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Tanta",
     "wof:parent_id":1092025893,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/200/911/421200911.geojson
+++ b/data/421/200/911/421200911.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85670985,
-        1092025893
+        1092025893,
+        85670985
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421200911,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423093,
     "wof:name":"Tanta",
     "wof:parent_id":1092025893,
     "wof:placetype":"locality",

--- a/data/421/200/913/421200913.geojson
+++ b/data/421/200/913/421200913.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u063a\u0631\u062f\u0642\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Hurghada"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421200913,
-    "wof:lastmodified":1566586570,
-    "wof:name":"\u0627\u0644\u063a\u0631\u062f\u0642\u0629",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Hurghada",
     "wof:parent_id":1092021497,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/200/913/421200913.geojson
+++ b/data/421/200/913/421200913.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"33.8348175,27.235269,33.8348175,27.235269",
+    "geom:bbox":"33.834817,27.235269,33.834817,27.235269",
     "geom:latitude":27.235269,
     "geom:longitude":33.834817,
     "iso:country":"EG",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85671085,
-        1092021497
+        1092021497,
+        85671085
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"EG",
     "wof:created":1459010045,
-    "wof:geomhash":"f359cfa21b03ced14f5e80891d2fe01c",
+    "wof:geomhash":"28f810696754e4693d05cacf0dbe3567",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421200913,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423089,
     "wof:name":"Hurghada",
     "wof:parent_id":1092021497,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    33.8348175,
+    33.834817,
     27.235269,
-    33.8348175,
+    33.834817,
     27.235269
 ],
-  "geometry": {"coordinates":[33.8348175,27.235269],"type":"Point"}
+  "geometry": {"coordinates":[33.834817,27.235269],"type":"Point"}
 }

--- a/data/421/202/339/421202339.geojson
+++ b/data/421/202/339/421202339.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0648\u0644\u0627\u0642 \u0627\u0644\u062f\u0643\u0631\u0648\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Boulaq Ad Dakrour"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421202339,
-    "wof:lastmodified":1566586558,
-    "wof:name":"\u0628\u0648\u0644\u0627\u0642 \u0627\u0644\u062f\u0643\u0631\u0648\u0631",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Boulaq Ad Dakrour",
     "wof:parent_id":1092015787,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/202/339/421202339.geojson
+++ b/data/421/202/339/421202339.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"31.193532,30.0359595,31.193532,30.0359595",
+    "geom:bbox":"31.193532,30.03596,31.193532,30.03596",
     "geom:latitude":30.03596,
     "geom:longitude":31.193532,
     "iso:country":"EG",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85671047,
-        1092015787
+        1092015787,
+        85671047
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"EG",
     "wof:created":1459010114,
-    "wof:geomhash":"ea94927dd0525a1435df1b027f22c909",
+    "wof:geomhash":"b20acc89b7f8520ac274c9fa59fdd726",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421202339,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423088,
     "wof:name":"Boulaq Ad Dakrour",
     "wof:parent_id":1092015787,
     "wof:placetype":"locality",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     31.193532,
-    30.0359595,
+    30.03596,
     31.193532,
-    30.0359595
+    30.03596
 ],
-  "geometry": {"coordinates":[31.193532,30.0359595],"type":"Point"}
+  "geometry": {"coordinates":[31.193532,30.03596],"type":"Point"}
 }

--- a/data/421/202/535/421202535.geojson
+++ b/data/421/202/535/421202535.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85671069,
-        1092025513
+        1092025513,
+        85671069
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421202535,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423087,
     "wof:name":"Asyut",
     "wof:parent_id":1092025513,
     "wof:placetype":"locality",

--- a/data/421/202/535/421202535.geojson
+++ b/data/421/202/535/421202535.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0633\u064a\u0648\u0637"
+    ],
+    "name:eng_x_preferred":[
+        "Asyut"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421202535,
-    "wof:lastmodified":1566586559,
-    "wof:name":"\u0627\u0633\u064a\u0648\u0637",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Asyut",
     "wof:parent_id":1092025513,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/203/721/421203721.geojson
+++ b/data/421/203/721/421203721.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85671061,
-        1092016437
+        1092016437,
+        85671061
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421203721,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423088,
     "wof:name":"Edfu",
     "wof:parent_id":1092016437,
     "wof:placetype":"locality",

--- a/data/421/203/721/421203721.geojson
+++ b/data/421/203/721/421203721.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u062f\u0641\u0648"
+    ],
+    "name:eng_x_preferred":[
+        "Edfu"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421203721,
-    "wof:lastmodified":1566586558,
-    "wof:name":"\u0627\u062f\u0641\u0648",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Edfu",
     "wof:parent_id":1092016437,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/203/723/421203723.geojson
+++ b/data/421/203/723/421203723.geojson
@@ -10,12 +10,6 @@
     "geom:latitude":30.46776,
     "geom:longitude":30.924119,
     "iso:country":"EG",
-    "label:eng_x_preferred_longname":[
-        "Minuf City"
-    ],
-    "label:eng_x_preferred_placetype":[
-        "city"
-    ],
     "lbl:bbox":"30.904119,30.44776,30.944119,30.48776",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -54,8 +48,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        85670995,
-        1092022369
+        1092022369,
+        85670995
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -75,7 +69,7 @@
         }
     ],
     "wof:id":421203723,
-    "wof:lastmodified":1601337573,
+    "wof:lastmodified":1601423090,
     "wof:name":"Minuf",
     "wof:parent_id":1092022369,
     "wof:placetype":"locality",

--- a/data/421/203/723/421203723.geojson
+++ b/data/421/203/723/421203723.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":30.46776,
     "geom:longitude":30.924119,
     "iso:country":"EG",
+    "label:eng_x_preferred_longname":[
+        "Minuf City"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "city"
+    ],
     "lbl:bbox":"30.904119,30.44776,30.944119,30.48776",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -21,6 +27,9 @@
         "\u0645\u062f\u064a\u0646\u0629 \u0645\u0646\u0648\u0641"
     ],
     "name:eng_x_preferred":[
+        "Minuf"
+    ],
+    "name:eng_x_variant":[
         "Minuf City"
     ],
     "qs:gn_country":null,
@@ -66,8 +75,8 @@
         }
     ],
     "wof:id":421203723,
-    "wof:lastmodified":1601068400,
-    "wof:name":"Minuf City",
+    "wof:lastmodified":1601337573,
+    "wof:name":"Minuf",
     "wof:parent_id":1092022369,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/203/723/421203723.geojson
+++ b/data/421/203/723/421203723.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u062f\u064a\u0646\u0629 \u0645\u0646\u0648\u0641"
+    ],
+    "name:eng_x_preferred":[
+        "Minuf City"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421203723,
-    "wof:lastmodified":1566586558,
-    "wof:name":"\u0645\u062f\u064a\u0646\u0629 \u0645\u0646\u0648\u0641",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Minuf City",
     "wof:parent_id":1092022369,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",

--- a/data/421/204/261/421204261.geojson
+++ b/data/421/204/261/421204261.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"30.016666,31.2881335,30.016666,31.2881335",
+    "geom:bbox":"30.016666,31.288134,30.016666,31.288134",
     "geom:latitude":31.288134,
     "geom:longitude":30.016666,
     "iso:country":"EG",
@@ -54,7 +54,7 @@
     },
     "wof:country":"EG",
     "wof:created":1459010179,
-    "wof:geomhash":"16d92f3e21e1687700eb32600d558cde",
+    "wof:geomhash":"8636d0f604a4d69868fb869da0627459",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421204261,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Montazah",
     "wof:parent_id":85671041,
     "wof:placetype":"locality",
@@ -75,9 +75,9 @@
 },
   "bbox": [
     30.016666,
-    31.2881335,
+    31.288134,
     30.016666,
-    31.2881335
+    31.288134
 ],
-  "geometry": {"coordinates":[30.016666,31.2881335],"type":"Point"}
+  "geometry": {"coordinates":[30.016666,31.288134],"type":"Point"}
 }

--- a/data/421/204/261/421204261.geojson
+++ b/data/421/204/261/421204261.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u0646\u062a\u0632\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Montazah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421204261,
-    "wof:lastmodified":1566586558,
-    "wof:name":"\u0627\u0644\u0645\u0646\u062a\u0632\u0629",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Montazah",
     "wof:parent_id":85671041,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-eg",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/183.

This PR updates loclized `wof:name` values in records that currently have no `name:eng_x_*` properties. There are other records that will need to be updated as part of this work too, but those will be handled in a separate PR.

The existing `wof:name` should be stored in the appropriate `name:*` property, with `wof:name` and `name:eng_x_preferred` properties getting updated English name values.

No PIP work needed, these are just property updates.