### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/109/201/452/7/1092014527.geojson
+++ b/data/109/201/452/7/1092014527.geojson
@@ -51,6 +51,9 @@
     "name:ara_x_variant":[
         "\u062d\u064a \u0639\u064a\u0646 \u0634\u0645\u0633"
     ],
+    "name:azb_x_preferred":[
+        "\u0639\u06cc\u0646 \u0634\u0645\u0633"
+    ],
     "name:cat_x_preferred":[
         "Ayn Shams"
     ],
@@ -73,11 +76,17 @@
     "name:gle_x_preferred":[
         "Ain Shams"
     ],
+    "name:jpn_x_preferred":[
+        "\u30a2\u30a4\u30f3\u30fb\u30b7\u30e3\u30e0\u30b9"
+    ],
     "name:nld_x_preferred":[
         "Ain Shams"
     ],
     "name:rus_x_preferred":[
         "\u0410\u0439\u043d-\u0428\u0430\u043c\u0441"
+    ],
+    "name:slv_x_preferred":[
+        "Ain \u0160ams"
     ],
     "name:spa_x_preferred":[
         "'Ain Schams"
@@ -87,6 +96,9 @@
     ],
     "name:ukr_x_preferred":[
         "\u0410\u0439\u043d-\u0428\u0430\u043c\u0441"
+    ],
+    "name:urd_x_preferred":[
+        "\u0639\u06cc\u0646 \u0634\u0645\u0633"
     ],
     "name:zho_x_preferred":[
         "\u827e\u56e0\u6c99\u59c6\u65af"
@@ -127,7 +139,7 @@
         }
     ],
     "wof:id":1092014527,
-    "wof:lastmodified":1602720860,
+    "wof:lastmodified":1690876045,
     "wof:name":"Ain Shams",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/480/5/1092024805.geojson
+++ b/data/109/202/480/5/1092024805.geojson
@@ -72,6 +72,12 @@
     "name:gle_x_preferred":[
         "Shubra"
     ],
+    "name:heb_x_preferred":[
+        "\u05e9\u05d5\u05d1\u05e8\u05d0"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30b7\u30e5\u30d6\u30e9"
+    ],
     "name:nld_x_preferred":[
         "Shubra"
     ],
@@ -114,7 +120,7 @@
         }
     ],
     "wof:id":1092024805,
-    "wof:lastmodified":1602720868,
+    "wof:lastmodified":1690876045,
     "wof:name":"Shobra",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/112/576/692/1/1125766921.geojson
+++ b/data/112/576/692/1/1125766921.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0628\u0648\u0631 \u0633\u0639\u064a\u062f"
     ],
+    "name:ast_x_preferred":[
+        "Port Said"
+    ],
     "name:azb_x_preferred":[
         "\u067e\u0648\u0631\u062a\u200c\u0633\u0639\u06cc\u062f"
     ],
@@ -43,8 +46,14 @@
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041f\u043e\u0440\u0442-\u0421\u0430\u0456\u0434"
     ],
+    "name:bel_x_variant":[
+        "\u041f\u043e\u0440\u0442-\u0421\u0430\u0456\u0434"
+    ],
     "name:ben_x_preferred":[
         "\u09aa\u09cb\u09b0\u09cd\u099f \u09b8\u0988\u09a6"
+    ],
+    "name:ben_x_variant":[
+        "\u09b8\u09be\u0987\u09a6 \u09ac\u09a8\u09cd\u09a6\u09b0"
     ],
     "name:bul_x_preferred":[
         "\u041f\u043e\u0440\u0442 \u0421\u0430\u0438\u0434"
@@ -60,6 +69,9 @@
     ],
     "name:che_x_preferred":[
         "\u0411\u0443\u0440-\u0421\u0430\u04c0\u0438\u0439\u0434"
+    ],
+    "name:cos_x_preferred":[
+        "Portu Said"
     ],
     "name:cym_x_preferred":[
         "Port Said"
@@ -160,6 +172,9 @@
     "name:mar_x_preferred":[
         "\u092c\u0941\u0930 \u0938\u0948\u0926"
     ],
+    "name:mlg_x_preferred":[
+        "Port Said"
+    ],
     "name:msa_x_preferred":[
         "Port Said"
     ],
@@ -177,6 +192,9 @@
     ],
     "name:nob_x_preferred":[
         "Port Said"
+    ],
+    "name:oss_x_preferred":[
+        "\u041f\u043e\u0440\u0442-\u0421\u0430\u0438\u0434"
     ],
     "name:pan_x_preferred":[
         "\u0a2c\u0a4b\u0a30 \u0a38\u0a08\u0a26"
@@ -223,6 +241,9 @@
     "name:tel_x_preferred":[
         "\u0c2a\u0c4b\u0c30\u0c4d\u0c1f\u0c4d \u0c38\u0c46\u0c21\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u041f\u043e\u0440\u0442-\u0421\u0430\u0438\u0434"
+    ],
     "name:tha_x_preferred":[
         "\u0e1e\u0e2d\u0e23\u0e4c\u0e15\u0e0b\u0e32\u0e2d\u0e34\u0e14"
     ],
@@ -238,11 +259,20 @@
     "name:uzb_x_preferred":[
         "Port-said"
     ],
+    "name:uzb_x_variant":[
+        "Port-Said"
+    ],
+    "name:vec_x_preferred":[
+        "Porto Said"
+    ],
     "name:vie_x_preferred":[
         "Port Said"
     ],
     "name:war_x_preferred":[
         "Port Said"
+    ],
+    "name:wuu_x_preferred":[
+        "\u585e\u5f97\u6e2f"
     ],
     "name:xmf_x_preferred":[
         "\u10de\u10dd\u10e0\u10e2-\u10e1\u10d0\u10d8\u10d3\u10d8"
@@ -252,6 +282,9 @@
     ],
     "name:zho_x_preferred":[
         "\u585e\u5fb7\u6e2f"
+    ],
+    "name:zul_x_preferred":[
+        "Port Said"
     ],
     "qs_pg:aaroncc":"EG",
     "qs_pg:gn_country":"EG",
@@ -306,7 +339,7 @@
         }
     ],
     "wof:id":1125766921,
-    "wof:lastmodified":1566586585,
+    "wof:lastmodified":1690876074,
     "wof:name":"\u0628\u0648\u0631\u0633\u0639\u064a\u062f",
     "wof:parent_id":1092018325,
     "wof:placetype":"locality",

--- a/data/112/578/160/9/1125781609.geojson
+++ b/data/112/578/160/9/1125781609.geojson
@@ -25,6 +25,12 @@
     "name:ara_x_preferred":[
         "\u0643\u0648\u0645 \u0623\u0645\u0628\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0648\u0645 \u0623\u0645\u0628\u0648"
+    ],
+    "name:ast_x_preferred":[
+        "Kom Ombo"
+    ],
     "name:azb_x_preferred":[
         "\u06a9\u0648\u0645 \u0627\u0645\u0628\u0648"
     ],
@@ -41,6 +47,9 @@
         "\u039a\u03bf\u03bc \u038c\u03bc\u03c0\u03bf"
     ],
     "name:eng_x_preferred":[
+        "Kom Ombo"
+    ],
+    "name:epo_x_preferred":[
         "Kom Ombo"
     ],
     "name:eus_x_preferred":[
@@ -100,6 +109,9 @@
     "name:slv_x_preferred":[
         "Kom Ombo"
     ],
+    "name:smn_x_preferred":[
+        "Kom Ombo"
+    ],
     "name:spa_x_preferred":[
         "Kom Ombo"
     ],
@@ -123,6 +135,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8003\u59c6\u7fc1\u5e03"
+    ],
+    "name:zul_x_preferred":[
+        "Kom Ombo"
     ],
     "qs_pg:aaroncc":"EG",
     "qs_pg:gn_country":"EG",
@@ -163,7 +178,7 @@
         }
     ],
     "wof:id":1125781609,
-    "wof:lastmodified":1566586587,
+    "wof:lastmodified":1690876077,
     "wof:name":"Kawm Umb\u016b",
     "wof:parent_id":1092021927,
     "wof:placetype":"locality",

--- a/data/112/580/554/3/1125805543.geojson
+++ b/data/112/580/554/3/1125805543.geojson
@@ -28,6 +28,12 @@
     "name:ara_x_variant":[
         "\u0627\u0644\u062d\u0648\u0627\u0645\u062f\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u062d\u0648\u0627\u0645\u062f\u064a\u0647"
+    ],
+    "name:deu_x_preferred":[
+        "Al-Hawamidiyya"
+    ],
     "name:ell_x_preferred":[
         "\u0395\u03bb \u03a7\u03b1\u03bf\u03c5\u03b1\u03bc\u03bd\u03c4\u03af\u03b1"
     ],
@@ -41,6 +47,9 @@
         "\u042d\u043b\u044c-\u0425\u0430\u0432\u0430\u043c\u0435\u0434\u0438\u044f"
     ],
     "name:nld_x_preferred":[
+        "Al-Hawamidiyya"
+    ],
+    "name:nob_x_preferred":[
         "Al-Hawamidiyya"
     ],
     "name:pol_x_preferred":[
@@ -69,6 +78,12 @@
     ],
     "name:urd_x_variant":[
         "\u062d\u0648\u0627\u0645\u062f\u06cc\u06c1"
+    ],
+    "name:zho_x_preferred":[
+        "\u54c8\u74e6\u59c6\u4ee3\u4e9a"
+    ],
+    "name:zul_x_preferred":[
+        "El Hawamdeya"
     ],
     "qs_pg:aaroncc":"EG",
     "qs_pg:gn_country":"EG",
@@ -109,7 +124,7 @@
         }
     ],
     "wof:id":1125805543,
-    "wof:lastmodified":1566586583,
+    "wof:lastmodified":1690876072,
     "wof:name":"Al \u1e28aw\u0101mid\u012byah",
     "wof:parent_id":1092018065,
     "wof:placetype":"locality",

--- a/data/112/585/284/3/1125852843.geojson
+++ b/data/112/585/284/3/1125852843.geojson
@@ -28,6 +28,9 @@
     "name:ara_x_variant":[
         "\u0645\u062f\u064a\u0646\u0629 \u0633\u064a\u0648\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u062f\u064a\u0646\u0629 \u0633\u064a\u0648\u0647"
+    ],
     "name:deu_x_preferred":[
         "Oase Siwa"
     ],
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":1125852843,
-    "wof:lastmodified":1566586586,
+    "wof:lastmodified":1690876076,
     "wof:name":"S\u012bwah",
     "wof:parent_id":1092025019,
     "wof:placetype":"locality",

--- a/data/112/585/343/7/1125853437.geojson
+++ b/data/112/585/343/7/1125853437.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0646\u062c\u0639 \u062d\u0645\u0627\u062f\u0649"
     ],
+    "name:ast_x_preferred":[
+        "Nag Hammadi"
+    ],
     "name:bul_x_preferred":[
         "\u041d\u0430\u0433 \u0425\u0430\u043c\u0430\u0434\u0438"
     ],
@@ -45,6 +48,9 @@
     ],
     "name:deu_x_preferred":[
         "Nag Hammadi"
+    ],
+    "name:ell_x_preferred":[
+        "\u039d\u03b1\u03b3\u03ba \u03a7\u03b1\u03bc\u03b1\u03bd\u03c4\u03af"
     ],
     "name:eng_x_preferred":[
         "Nag Hamm\u00e2di"
@@ -69,6 +75,9 @@
     ],
     "name:fry_x_preferred":[
         "Nag Hammady"
+    ],
+    "name:gle_x_preferred":[
+        "Nag Hammadi"
     ],
     "name:heb_x_preferred":[
         "\u05e0\u05d2\u05e2 \u05d7\u05de\u05d0\u05d3\u05d9"
@@ -109,6 +118,9 @@
     "name:por_x_preferred":[
         "Nag Hammadi"
     ],
+    "name:ron_x_preferred":[
+        "Nag Hammadi"
+    ],
     "name:rus_x_preferred":[
         "\u041d\u0430\u0433-\u0425\u0430\u043c\u043c\u0430\u0434\u0438"
     ],
@@ -136,8 +148,14 @@
     "name:urd_x_preferred":[
         "\u0646\u0627\u06af \u062d\u0645\u0627\u062f\u06cc"
     ],
+    "name:uzb_x_preferred":[
+        "Nag Hammadi"
+    ],
     "name:zho_x_preferred":[
         "\u62ff\u6208\u746a\u7b2c"
+    ],
+    "name:zul_x_preferred":[
+        "Nag Hammadi"
     ],
     "qs_pg:aaroncc":"EG",
     "qs_pg:gn_country":"EG",
@@ -178,7 +196,7 @@
         }
     ],
     "wof:id":1125853437,
-    "wof:lastmodified":1566586586,
+    "wof:lastmodified":1690876077,
     "wof:name":"Naj\u2018 \u1e28amm\u0101d\u012b",
     "wof:parent_id":1092022653,
     "wof:placetype":"locality",

--- a/data/112/585/386/9/1125853869.geojson
+++ b/data/112/585/386/9/1125853869.geojson
@@ -34,6 +34,9 @@
     "name:ceb_x_preferred":[
         "F\u0101q\u016bs"
     ],
+    "name:deu_x_preferred":[
+        "Faqous"
+    ],
     "name:eng_x_preferred":[
         "Faqous"
     ],
@@ -46,7 +49,13 @@
     "name:kaz_x_preferred":[
         "\u0424\u0430\u043a\u0443\u0441 \u049b\u0430\u043b\u0430\u0441\u044b"
     ],
+    "name:mlg_x_preferred":[
+        "F\u0101q\u016bs"
+    ],
     "name:nld_x_preferred":[
+        "Faqous"
+    ],
+    "name:nob_x_preferred":[
         "Faqous"
     ],
     "name:pol_x_preferred":[
@@ -66,6 +75,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6cd5\u53e4\u65af"
+    ],
+    "name:zul_x_preferred":[
+        "Faqous"
     ],
     "qs_pg:aaroncc":"EG",
     "qs_pg:gn_country":"EG",
@@ -106,7 +118,7 @@
         }
     ],
     "wof:id":1125853869,
-    "wof:lastmodified":1566586586,
+    "wof:lastmodified":1690876077,
     "wof:name":"F\u0101q\u016bs",
     "wof:parent_id":1092020833,
     "wof:placetype":"locality",

--- a/data/112/585/410/1/1125854101.geojson
+++ b/data/112/585/410/1/1125854101.geojson
@@ -28,6 +28,9 @@
     "name:arz_x_preferred":[
         "\u062f\u0645\u0646\u0647\u0648\u0631"
     ],
+    "name:ast_x_preferred":[
+        "Damanhur"
+    ],
     "name:azb_x_preferred":[
         "\u062f\u0645\u0646\u0647\u0648\u0631"
     ],
@@ -79,6 +82,9 @@
     "name:gla_x_preferred":[
         "Damanh\u00f9r"
     ],
+    "name:gle_x_preferred":[
+        "Damanhur"
+    ],
     "name:guj_x_preferred":[
         "\u0aa6\u0aae\u0aa3\u0ab9\u0ac1\u0ab0"
     ],
@@ -123,6 +129,9 @@
     ],
     "name:mar_x_preferred":[
         "\u0926\u092e\u0923\u0939\u0930"
+    ],
+    "name:mlg_x_preferred":[
+        "Damanh\u016br"
     ],
     "name:msa_x_preferred":[
         "Damanhur"
@@ -169,6 +178,9 @@
     "name:tel_x_preferred":[
         "\u0c21\u0c3e\u0c2e\u0c28\u0c4d \u0c39\u0c41\u0c30\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u0414\u0430\u043c\u0430\u043d\u04b3\u0443\u0440"
+    ],
     "name:tha_x_preferred":[
         "\u0e14\u0e32\u0e21\u0e32\u0e19\u0e40\u0e2e\u0e2d\u0e23\u0e4c"
     ],
@@ -190,14 +202,26 @@
     "name:uzb_x_preferred":[
         "Damanxur"
     ],
+    "name:uzb_x_variant":[
+        "Damanhur"
+    ],
+    "name:vec_x_preferred":[
+        "Damanhur"
+    ],
     "name:vie_x_preferred":[
         "Damanhur"
     ],
     "name:war_x_preferred":[
         "Damanhur"
     ],
+    "name:yue_x_preferred":[
+        "\u9054\u66fc\u80e1\u723e"
+    ],
     "name:zho_x_preferred":[
         "\u9054\u66fc\u80e1\u723e"
+    ],
+    "name:zul_x_preferred":[
+        "Damanhur"
     ],
     "qs_pg:aaroncc":"EG",
     "qs_pg:gn_country":"EG",
@@ -238,7 +262,7 @@
         }
     ],
     "wof:id":1125854101,
-    "wof:lastmodified":1566586586,
+    "wof:lastmodified":1690876076,
     "wof:name":"Damanh\u016br",
     "wof:parent_id":1092015921,
     "wof:placetype":"locality",

--- a/data/112/585/415/3/1125854153.geojson
+++ b/data/112/585/415/3/1125854153.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0633\u0641\u0627\u062c\u0627"
     ],
+    "name:ast_x_preferred":[
+        "Safaga"
+    ],
     "name:aze_x_preferred":[
         "safaga haqqinda"
     ],
@@ -79,11 +82,17 @@
     "name:guj_x_preferred":[
         "\u0ab8\u0aab\u0abe\u0a97\u0abe"
     ],
+    "name:heb_x_preferred":[
+        "\u05e1\u05e4\u05d0\u05d2'\u05d0"
+    ],
     "name:hin_x_preferred":[
         "\u0938\u092b\u093e\u0917\u093e"
     ],
     "name:hun_x_preferred":[
         "Szafaga"
+    ],
+    "name:hye_x_preferred":[
+        "\u054d\u0561\u0586\u0561\u0563\u0561"
     ],
     "name:ind_x_preferred":[
         "Safaga"
@@ -175,6 +184,9 @@
     "name:zho_x_preferred":[
         "\u585e\u6cd5\u6770"
     ],
+    "name:zul_x_preferred":[
+        "Safaga"
+    ],
     "qs_pg:aaroncc":"EG",
     "qs_pg:gn_country":"EG",
     "qs_pg:gn_fcode":"PPL",
@@ -214,7 +226,7 @@
         }
     ],
     "wof:id":1125854153,
-    "wof:lastmodified":1566586585,
+    "wof:lastmodified":1690876075,
     "wof:name":"B\u016br Saf\u0101jah",
     "wof:parent_id":1092024087,
     "wof:placetype":"locality",

--- a/data/112/585/424/9/1125854249.geojson
+++ b/data/112/585/424/9/1125854249.geojson
@@ -28,11 +28,17 @@
     "name:arz_x_preferred":[
         "\u0628\u0646\u0647\u0627"
     ],
+    "name:ast_x_preferred":[
+        "Banha"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0646\u0647\u0627"
     ],
     "name:ben_x_preferred":[
         "\u09ac\u09be\u09be\u09a8\u09b9\u09be"
+    ],
+    "name:ben_x_variant":[
+        "\u09ac\u09be\u09a8\u09b9\u09be"
     ],
     "name:cat_x_preferred":[
         "Banha"
@@ -76,6 +82,9 @@
     "name:hin_x_preferred":[
         "\u092c\u0928\u094d\u0939\u093e"
     ],
+    "name:hye_x_preferred":[
+        "\u0532\u0565\u0576\u0570\u0561"
+    ],
     "name:ind_x_preferred":[
         "Banha"
     ],
@@ -106,6 +115,9 @@
     "name:mar_x_preferred":[
         "\u092c\u0945\u0928\u094d\u0939\u093e"
     ],
+    "name:mlg_x_preferred":[
+        "Banh\u0101"
+    ],
     "name:msa_x_preferred":[
         "Banha"
     ],
@@ -123,6 +135,9 @@
     ],
     "name:rus_x_preferred":[
         "\u0411\u0430\u043d\u0445\u0430"
+    ],
+    "name:rus_x_variant":[
+        "\u0411\u0435\u043d\u0445\u0430"
     ],
     "name:sco_x_preferred":[
         "Banha"
@@ -160,6 +175,9 @@
     "name:urd_x_preferred":[
         "\u0628\u0646\u06c1\u0627"
     ],
+    "name:vec_x_preferred":[
+        "Banha"
+    ],
     "name:vie_x_preferred":[
         "Banha"
     ],
@@ -168,6 +186,9 @@
     ],
     "name:zho_x_preferred":[
         "\u672c\u54c8"
+    ],
+    "name:zul_x_preferred":[
+        "Benha"
     ],
     "qs_pg:aaroncc":"EG",
     "qs_pg:gn_country":"EG",
@@ -208,7 +229,7 @@
         }
     ],
     "wof:id":1125854249,
-    "wof:lastmodified":1566586585,
+    "wof:lastmodified":1690876075,
     "wof:name":"Banh\u0101",
     "wof:parent_id":1092015253,
     "wof:placetype":"locality",

--- a/data/112/585/447/7/1125854477.geojson
+++ b/data/112/585/447/7/1125854477.geojson
@@ -28,8 +28,14 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0632\u0642\u0627\u0632\u064a\u0642"
     ],
+    "name:ast_x_preferred":[
+        "Zagazig"
+    ],
     "name:azb_x_preferred":[
         "\u0632\u0642\u0627\u0632\u06cc\u0642"
+    ],
+    "name:aze_x_preferred":[
+        "\u018fz-Z\u0259qaziq"
     ],
     "name:bul_x_preferred":[
         "\u0417\u0430\u043a\u0430\u0437\u0438\u043a"
@@ -51,6 +57,9 @@
     ],
     "name:eng_x_preferred":[
         "Zagazig"
+    ],
+    "name:eng_x_variant":[
+        "\u0637\u0648\u062e \u0627\u0644\u0623\u0642\u0644\u0627\u0645 \u0627\u0644\u0633\u0646\u0628\u0644\u0627\u0648\u064a\u0646"
     ],
     "name:est_x_preferred":[
         "Az-Zaq\u0101z\u012bq"
@@ -106,6 +115,9 @@
     "name:mar_x_preferred":[
         "\u091d\u0917\u093e\u091d\u093f\u0917"
     ],
+    "name:mlg_x_preferred":[
+        "Zagazig"
+    ],
     "name:nld_x_preferred":[
         "Zagazig"
     ],
@@ -142,6 +154,9 @@
     "name:swe_x_preferred":[
         "Zagazig"
     ],
+    "name:tgk_x_preferred":[
+        "\u0410\u0437-\u0417\u0430\u049b\u043e\u0437\u0438\u049b"
+    ],
     "name:tha_x_preferred":[
         "\u0e2d\u0e31\u0e0b\u0e0b\u0e30\u0e01\u0e2d\u0e0b\u0e35\u0e01"
     ],
@@ -157,6 +172,12 @@
     "name:urd_x_preferred":[
         "\u0632\u06af\u0632\u06cc\u06af"
     ],
+    "name:uzb_x_preferred":[
+        "Az-zaqoziq"
+    ],
+    "name:vec_x_preferred":[
+        "Zagazig"
+    ],
     "name:war_x_preferred":[
         "Zagazig"
     ],
@@ -165,6 +186,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5bb0\u52a0\u6d4e\u683c"
+    ],
+    "name:zul_x_preferred":[
+        "Zagazig"
     ],
     "qs_pg:aaroncc":"EG",
     "qs_pg:gn_country":"EG",
@@ -205,7 +229,7 @@
         }
     ],
     "wof:id":1125854477,
-    "wof:lastmodified":1566586585,
+    "wof:lastmodified":1690876075,
     "wof:name":"Az Zaq\u0101z\u012bq",
     "wof:parent_id":1092020479,
     "wof:placetype":"locality",

--- a/data/112/585/455/3/1125854553.geojson
+++ b/data/112/585/455/3/1125854553.geojson
@@ -31,6 +31,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0637\u0648\u0631"
     ],
+    "name:ast_x_preferred":[
+        "El-Tor"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u0637\u0648\u0631"
     ],
@@ -55,6 +58,9 @@
     "name:fas_x_preferred":[
         "\u0627\u0644\u0637\u0648\u0631"
     ],
+    "name:fin_x_preferred":[
+        "Al-Tur"
+    ],
     "name:fra_x_preferred":[
         "El-Tor"
     ],
@@ -64,8 +70,17 @@
     "name:hin_x_preferred":[
         "\u0905\u0932-\u0924\u0942\u0930"
     ],
+    "name:hye_x_preferred":[
+        "\u0537\u056c \u0539\u0578\u0580"
+    ],
+    "name:ind_x_preferred":[
+        "El Tor"
+    ],
     "name:ita_x_preferred":[
         "El-Tor"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30a8\u30eb\u30c8\u30fc\u30eb"
     ],
     "name:kat_x_preferred":[
         "\u10d4\u10da-\u10e2\u10e3\u10e0\u10d8"
@@ -118,6 +133,9 @@
     "name:zho_x_preferred":[
         "\u56fe\u5c14"
     ],
+    "name:zul_x_preferred":[
+        "El Tor"
+    ],
     "qs_pg:aaroncc":"EG",
     "qs_pg:gn_country":"EG",
     "qs_pg:gn_fcode":"PPLA",
@@ -157,7 +175,7 @@
         }
     ],
     "wof:id":1125854553,
-    "wof:lastmodified":1566586585,
+    "wof:lastmodified":1690876075,
     "wof:name":"Tor",
     "wof:parent_id":1092020113,
     "wof:placetype":"locality",

--- a/data/112/585/474/7/1125854747.geojson
+++ b/data/112/585/474/7/1125854747.geojson
@@ -31,20 +31,35 @@
     "name:arz_x_preferred":[
         "\u0627\u0633\u064a\u0648\u0637"
     ],
+    "name:ast_x_preferred":[
+        "Asyut"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0633\u06cc\u0648\u0637"
+    ],
+    "name:aze_x_preferred":[
+        "Asyut"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0410\u0441\u044c\u044e\u0442"
     ],
+    "name:bel_x_variant":[
+        "\u0410\u0441\u044c\u044e\u0442"
+    ],
     "name:ben_x_preferred":[
         "\u0985\u09cd\u09af\u09be\u09b8\u09be\u09af\u09bc\u09be\u09a4"
+    ],
+    "name:ben_x_variant":[
+        "\u0986\u09b8\u09bf\u0989\u09a4"
     ],
     "name:bul_x_preferred":[
         "\u0410\u0441\u044e\u0442"
     ],
     "name:cat_x_preferred":[
         "Asyut"
+    ],
+    "name:cat_x_variant":[
+        "Assiut"
     ],
     "name:ceb_x_preferred":[
         "Asy\u016b\u0163"
@@ -103,6 +118,9 @@
     "name:hye_x_preferred":[
         "\u0531\u057d\u0575\u0578\u0582\u057f"
     ],
+    "name:ibo_x_preferred":[
+        "Asyut"
+    ],
     "name:ind_x_preferred":[
         "Asyuth"
     ],
@@ -111,6 +129,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30a2\u30b9\u30e6\u30fc\u30c8"
+    ],
+    "name:jpn_x_variant":[
+        "\u30a2\u30b7\u30e5\u30fc\u30c8"
     ],
     "name:kab_x_preferred":[
         "Asyu\u1e6d"
@@ -187,6 +208,9 @@
     "name:swe_x_preferred":[
         "Asyut"
     ],
+    "name:szl_x_preferred":[
+        "Asjut"
+    ],
     "name:tam_x_preferred":[
         "\u0b85\u0bb8\u0bcd\u0baf\u0bc2\u0b9f\u0bcd"
     ],
@@ -214,14 +238,26 @@
     "name:uzb_x_preferred":[
         "Asyut"
     ],
+    "name:vec_x_preferred":[
+        "Asy\u016b\u1e6d"
+    ],
     "name:vie_x_preferred":[
         "Asyut"
     ],
     "name:war_x_preferred":[
         "Asyut"
     ],
+    "name:wuu_x_preferred":[
+        "\u827e\u65af\u5c24\u7279"
+    ],
+    "name:yue_x_preferred":[
+        "\u827e\u65af\u5c24\u7279"
+    ],
     "name:zho_x_preferred":[
         "\u827e\u65af\u5c24\u7279"
+    ],
+    "name:zul_x_preferred":[
+        "Asyut"
     ],
     "qs_pg:aaroncc":"EG",
     "qs_pg:gn_country":"EG",
@@ -262,7 +298,7 @@
         }
     ],
     "wof:id":1125854747,
-    "wof:lastmodified":1566586586,
+    "wof:lastmodified":1690876077,
     "wof:name":"Asy\u016b\u0163",
     "wof:parent_id":1092017669,
     "wof:placetype":"locality",

--- a/data/112/585/475/5/1125854755.geojson
+++ b/data/112/585/475/5/1125854755.geojson
@@ -34,14 +34,29 @@
     "name:arz_x_preferred":[
         "\u0623\u0633\u0648\u0627\u0646"
     ],
+    "name:arz_x_variant":[
+        "\u0627\u0633\u0648\u0627\u0646"
+    ],
+    "name:ast_x_preferred":[
+        "Aswan"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0633\u0648\u0627\u0646"
+    ],
+    "name:aze_x_preferred":[
+        "\u018fsvan"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0410\u0441\u0443\u0430\u043d"
     ],
+    "name:bel_x_variant":[
+        "\u0410\u0441\u0443\u0430\u043d"
+    ],
     "name:ben_x_preferred":[
         "\u0986\u09b8\u0989\u09af\u09bc\u09be\u09a8"
+    ],
+    "name:ben_x_variant":[
+        "\u0986\u09b8\u0993\u09af\u09bc\u09be\u09a8"
     ],
     "name:bos_x_preferred":[
         "Asuan"
@@ -57,6 +72,9 @@
     ],
     "name:ces_x_preferred":[
         "Asu\u00e1n"
+    ],
+    "name:ckb_x_preferred":[
+        "\u0626\u06d5\u0633\u0648\u0627\u0646"
     ],
     "name:dan_x_preferred":[
         "Aswan"
@@ -154,8 +172,20 @@
     "name:lit_x_preferred":[
         "Asuanas"
     ],
+    "name:mal_x_preferred":[
+        "\u0d05\u0d38\u0d4d\u0d35\u0d3e\u0d7b"
+    ],
     "name:mar_x_preferred":[
         "\u0906\u0938\u094d\u0935\u093e\u0928"
+    ],
+    "name:mkd_x_preferred":[
+        "\u0410\u0441\u0443\u0430\u043d"
+    ],
+    "name:mlg_x_preferred":[
+        "Aswan"
+    ],
+    "name:mri_x_preferred":[
+        "Hewene"
     ],
     "name:msa_x_preferred":[
         "Aswan"
@@ -174,6 +204,9 @@
     ],
     "name:oci_x_preferred":[
         "Assoan"
+    ],
+    "name:oss_x_preferred":[
+        "\u0410\u0441\u0443\u0430\u043d"
     ],
     "name:pnb_x_preferred":[
         "\u0627\u0633\u0648\u0627\u0646"
@@ -226,11 +259,17 @@
     "name:tel_x_preferred":[
         "\u0c05\u0c38\u0c4d\u0c35\u0c3e\u0c28\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u0410\u0441\u0432\u043e\u043d"
+    ],
     "name:tha_x_preferred":[
         "\u0e2d\u0e31\u0e2a\u0e27\u0e32\u0e19"
     ],
     "name:tur_x_preferred":[
         "Asvan"
+    ],
+    "name:uig_x_preferred":[
+        "\u0626\u06d5\u0633\u06cb\u0627\u0646"
     ],
     "name:ukr_x_preferred":[
         "\u0410\u0441\u0443\u0430\u043d"
@@ -240,6 +279,9 @@
     ],
     "name:uzb_x_preferred":[
         "Asvon"
+    ],
+    "name:vec_x_preferred":[
+        "Assuan"
     ],
     "name:vie_x_preferred":[
         "Aswan"
@@ -255,6 +297,9 @@
     ],
     "name:zho_x_preferred":[
         "\u963f\u65af\u65fa"
+    ],
+    "name:zul_x_preferred":[
+        "Aswan"
     ],
     "qs_pg:aaroncc":"EG",
     "qs_pg:gn_country":"EG",
@@ -295,7 +340,7 @@
         }
     ],
     "wof:id":1125854755,
-    "wof:lastmodified":1566586586,
+    "wof:lastmodified":1690876076,
     "wof:name":"Asw\u0101n",
     "wof:parent_id":1092022915,
     "wof:placetype":"locality",

--- a/data/112/585/561/3/1125855613.geojson
+++ b/data/112/585/561/3/1125855613.geojson
@@ -31,11 +31,23 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0645\u0646\u0635\u0648\u0631\u0647"
     ],
+    "name:ast_x_preferred":[
+        "Mansoura"
+    ],
+    "name:azb_x_preferred":[
+        "\u0645\u0646\u0635\u0648\u0631\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "M\u0259nsur\u0259"
+    ],
     "name:bel_x_preferred":[
         "\u042d\u043b\u044c-\u041c\u0430\u043d\u0441\u0443\u0440\u0430"
     ],
     "name:ben_x_preferred":[
         "\u09ae\u09be\u09a8\u09b8\u09c1\u09b0\u09be"
+    ],
+    "name:ben_x_variant":[
+        "\u09ae\u09a8\u09b8\u09c1\u09b0\u09be"
     ],
     "name:bul_x_preferred":[
         "\u041c\u0430\u043d\u0441\u0443\u0440\u0430"
@@ -60,6 +72,9 @@
     ],
     "name:ell_x_preferred":[
         "\u039c\u03b1\u03bd\u03c3\u03bf\u03cd\u03c1\u03b1"
+    ],
+    "name:ell_x_variant":[
+        "Sinbillawain"
     ],
     "name:eng_x_preferred":[
         "Al Mansurah"
@@ -140,6 +155,9 @@
     "name:nob_x_preferred":[
         "Mansura"
     ],
+    "name:oss_x_preferred":[
+        "\u042d\u043b\u044c-\u041c\u0430\u043d\u0441\u0443\u0440\u00e6"
+    ],
     "name:pol_x_preferred":[
         "Mansura"
     ],
@@ -173,11 +191,17 @@
     "name:swe_x_preferred":[
         "Mansura"
     ],
+    "name:szl_x_preferred":[
+        "Al-Mansura"
+    ],
     "name:tam_x_preferred":[
         "\u0bae\u0ba9\u0bcd\u0b9a\u0bb5\u0bc1\u0bb1\u0bbe"
     ],
     "name:tel_x_preferred":[
         "\u0c2e\u0c28\u0c4d\u0c38\u0c41\u0c30\u0c3e"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0410\u043b-\u041c\u0430\u043d\u0441\u0443\u0440\u0430"
     ],
     "name:tha_x_preferred":[
         "\u0e41\u0e2d\u0e25\u0e41\u0e21\u0e19\u0e0b\u0e38\u0e23\u0e32"
@@ -203,6 +227,12 @@
     "name:urd_x_variant":[
         "\u0645\u0646\u0635\u0648\u0631\u06c1"
     ],
+    "name:uzb_x_preferred":[
+        "Mansura"
+    ],
+    "name:vec_x_preferred":[
+        "Mansura"
+    ],
     "name:vie_x_preferred":[
         "El Mansoura"
     ],
@@ -211,6 +241,9 @@
     ],
     "name:zho_x_preferred":[
         "\u66fc\u82cf\u62c9"
+    ],
+    "name:zul_x_preferred":[
+        "Mansoura"
     ],
     "qs_pg:aaroncc":"EG",
     "qs_pg:gn_country":"EG",
@@ -251,7 +284,7 @@
         }
     ],
     "wof:id":1125855613,
-    "wof:lastmodified":1566586585,
+    "wof:lastmodified":1690876074,
     "wof:name":"Al Man\u015f\u016brah",
     "wof:parent_id":1092025681,
     "wof:placetype":"locality",

--- a/data/112/587/673/9/1125876739.geojson
+++ b/data/112/587/673/9/1125876739.geojson
@@ -31,6 +31,9 @@
     "name:bul_x_preferred":[
         "\u0415\u043b \u0413\u0443\u043d\u0430"
     ],
+    "name:cat_x_preferred":[
+        "El Gouna"
+    ],
     "name:ceb_x_preferred":[
         "El Gouna"
     ],
@@ -43,8 +46,23 @@
     "name:epo_x_preferred":[
         "El Gouna"
     ],
+    "name:fas_x_preferred":[
+        "\u0627\u0644\u062c\u0648\u0646\u0647"
+    ],
+    "name:fin_x_preferred":[
+        "El Gouna"
+    ],
     "name:fra_x_preferred":[
         "El Gouna"
+    ],
+    "name:hye_x_preferred":[
+        "\u0537\u056c \u0533\u0578\u0582\u0576\u0561"
+    ],
+    "name:ita_x_preferred":[
+        "El Gouna"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30a8\u30eb\u30fb\u30b0\u30a6\u30ca"
     ],
     "name:nld_x_preferred":[
         "El Gouna"
@@ -55,14 +73,29 @@
     "name:pol_x_preferred":[
         "Al-D\u017cuna"
     ],
+    "name:ron_x_preferred":[
+        "El Gouna"
+    ],
     "name:rus_x_preferred":[
         "\u042d\u043b\u044c-\u0413\u0443\u043d\u0430"
+    ],
+    "name:spa_x_preferred":[
+        "El Gouna"
     ],
     "name:swe_x_preferred":[
         "El Gouna"
     ],
+    "name:tur_x_preferred":[
+        "El-C\u00fbna"
+    ],
     "name:ukr_x_preferred":[
         "\u0415\u043b\u044c-\u0413\u0443\u043d\u0430"
+    ],
+    "name:urd_x_preferred":[
+        "\u0627\u0644\u062c\u0648\u0646\u06c1"
+    ],
+    "name:uzb_x_preferred":[
+        "El-Guna"
     ],
     "name:zho_x_preferred":[
         "\u827e\u723e\u53e4\u7d0d"
@@ -106,7 +139,7 @@
         }
     ],
     "wof:id":1125876739,
-    "wof:lastmodified":1566586583,
+    "wof:lastmodified":1690876072,
     "wof:name":"El Gouna",
     "wof:parent_id":1092021497,
     "wof:placetype":"locality",

--- a/data/112/587/813/1/1125878131.geojson
+++ b/data/112/587/813/1/1125878131.geojson
@@ -26,6 +26,12 @@
     "name:arz_x_preferred":[
         "\u0627\u0628\u0648 \u0642\u064a\u0631"
     ],
+    "name:azb_x_preferred":[
+        "\u0627\u0628\u0648\u0642\u06cc\u0631"
+    ],
+    "name:ben_x_preferred":[
+        "\u0986\u09ac\u09c1 \u0995\u09bf\u09b0"
+    ],
     "name:bul_x_preferred":[
         "\u0410\u0431\u0443 \u041a\u0438\u0440"
     ],
@@ -64,6 +70,9 @@
     ],
     "name:ita_x_preferred":[
         "Abukir"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30a2\u30d6\u30ad\u30fc\u30eb"
     ],
     "name:lit_x_preferred":[
         "Abu Kiras"
@@ -154,7 +163,7 @@
         }
     ],
     "wof:id":1125878131,
-    "wof:lastmodified":1566586583,
+    "wof:lastmodified":1690876072,
     "wof:name":"Abu Quir",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/587/997/7/1125879977.geojson
+++ b/data/112/587/997/7/1125879977.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u062e\u0644\u064a\u062c \u0645\u0643\u0627\u062f\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u062e\u0644\u064a\u062c \u0645\u0643\u0627\u062f\u0649"
+    ],
     "name:ceb_x_preferred":[
         "Makadi Bay"
     ],
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":1125879977,
-    "wof:lastmodified":1566586583,
+    "wof:lastmodified":1690876072,
     "wof:name":"Makadi Bay",
     "wof:parent_id":1092021497,
     "wof:placetype":"locality",

--- a/data/112/594/961/1/1125949611.geojson
+++ b/data/112/594/961/1/1125949611.geojson
@@ -25,6 +25,12 @@
     "name:ara_x_preferred":[
         "\u0628\u0644\u0628\u064a\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0644\u0628\u064a\u0633"
+    ],
+    "name:ast_x_preferred":[
+        "Bilbeis"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0644\u0628\u06cc\u0633"
     ],
@@ -52,8 +58,17 @@
     "name:fas_x_preferred":[
         "\u0628\u0644\u0628\u06cc\u0633"
     ],
+    "name:fin_x_preferred":[
+        "Bilbays"
+    ],
     "name:fra_x_preferred":[
         "Bilb\u00e9is"
+    ],
+    "name:fra_x_variant":[
+        "Bilb\u00e9\u00efs"
+    ],
+    "name:gle_x_preferred":[
+        "Bilbeis"
     ],
     "name:heb_x_preferred":[
         "\u05d1\u05d9\u05dc\u05d1\u05d9\u05e1"
@@ -63,6 +78,9 @@
     ],
     "name:hye_x_preferred":[
         "\u0532\u056b\u056c\u0562\u0565\u0575\u057d"
+    ],
+    "name:ind_x_preferred":[
+        "Bilbeis"
     ],
     "name:ita_x_preferred":[
         "Bilbeis"
@@ -78,6 +96,9 @@
     ],
     "name:lav_x_preferred":[
         "Bilbeisa"
+    ],
+    "name:mlg_x_preferred":[
+        "Bilbays"
     ],
     "name:nld_x_preferred":[
         "Bilbeis"
@@ -115,8 +136,14 @@
     "name:urd_x_preferred":[
         "\u0628\u0644\u0628\u06cc\u0633"
     ],
+    "name:vec_x_preferred":[
+        "Bilbeis"
+    ],
     "name:zho_x_preferred":[
         "\u6bd4\u52d2\u62dc\u65af"
+    ],
+    "name:zul_x_preferred":[
+        "Bilbeis"
     ],
     "qs_pg:aaroncc":"EG",
     "qs_pg:gn_country":"EG",
@@ -157,7 +184,7 @@
         }
     ],
     "wof:id":1125949611,
-    "wof:lastmodified":1566586582,
+    "wof:lastmodified":1690876071,
     "wof:name":"Bilbays",
     "wof:parent_id":1092015569,
     "wof:placetype":"locality",

--- a/data/112/596/797/5/1125967975.geojson
+++ b/data/112/596/797/5/1125967975.geojson
@@ -28,6 +28,9 @@
     "name:arn_x_preferred":[
         "abu simbel"
     ],
+    "name:arz_x_preferred":[
+        "\u0623\u0628\u0648 \u0633\u0645\u0628\u0644"
+    ],
     "name:ceb_x_preferred":[
         "Ab\u016b Sunbul"
     ],
@@ -51,6 +54,12 @@
     ],
     "name:hun_x_preferred":[
         "Abu Szimbel"
+    ],
+    "name:ibo_x_preferred":[
+        "Ab\u1ee5 Simbel"
+    ],
+    "name:ita_x_preferred":[
+        "Abu Simbel"
     ],
     "name:jpn_x_preferred":[
         "\u30a2\u30d6\u30fb\u30b7\u30f3\u30d9\u30eb"
@@ -76,8 +85,14 @@
     "name:spa_x_preferred":[
         "Abu Simbel"
     ],
+    "name:swa_x_preferred":[
+        "Abu Simbel"
+    ],
     "name:swe_x_preferred":[
         "Abu Simbel"
+    ],
+    "name:tam_x_preferred":[
+        "\u0b85\u0baa\u0bc1 \u0b9a\u0bbf\u0bae\u0bcd\u0baa\u0bc6\u0bb2\u0bcd"
     ],
     "name:ukr_x_preferred":[
         "\u0410\u0431\u0443-\u0421\u0456\u043c\u0431\u0435\u043b"
@@ -87,6 +102,9 @@
     ],
     "name:war_x_preferred":[
         "Abu Simbel"
+    ],
+    "name:zho_x_preferred":[
+        "\u963f\u5e03\u8f9b\u8d1d"
     ],
     "qs_pg:aaroncc":"EG",
     "qs_pg:gn_country":"EG",
@@ -127,7 +145,7 @@
         }
     ],
     "wof:id":1125967975,
-    "wof:lastmodified":1566586583,
+    "wof:lastmodified":1690876073,
     "wof:name":"Ab\u016b Sunbul",
     "wof:parent_id":1092022915,
     "wof:placetype":"locality",

--- a/data/112/601/923/7/1126019237.geojson
+++ b/data/112/601/923/7/1126019237.geojson
@@ -43,6 +43,9 @@
     "name:aze_x_preferred":[
         "\u015earm \u0259\u015f-\u015eeyx"
     ],
+    "name:aze_x_variant":[
+        "\u015e\u0259rm \u0259\u015f-\u015eeyx"
+    ],
     "name:bak_x_preferred":[
         "\u0428\u04d9\u0440\u043c-\u04d9\u0448-\u0428\u04d9\u0439\u0435\u0445"
     ],
@@ -63,6 +66,9 @@
     ],
     "name:che_x_preferred":[
         "\u0428\u0430\u0440\u043c-\u044d\u0448-\u0428\u0435\u0439\u0445"
+    ],
+    "name:ckb_x_preferred":[
+        "\u0634\u06d5\u0631\u0645 \u0626\u06d5\u0644\u0634\u06d5\u06cc\u062e"
     ],
     "name:dan_x_preferred":[
         "Sharm el-Sheikh"
@@ -120,6 +126,12 @@
     ],
     "name:hye_x_preferred":[
         "\u0547\u0561\u0580\u0574 \u0567\u056c \u0547\u0565\u0575\u056d"
+    ],
+    "name:ibo_x_preferred":[
+        "Sharma el-Sheikh"
+    ],
+    "name:ido_x_preferred":[
+        "Sharm el-Sheik"
     ],
     "name:ind_x_preferred":[
         "Sharm el-Sheikh"
@@ -181,6 +193,9 @@
     "name:oci_x_preferred":[
         "Charm el-Cheikh"
     ],
+    "name:pnb_x_preferred":[
+        "\u0634\u0631\u0645 \u0627\u0644\u0634\u06cc\u062e"
+    ],
     "name:pol_x_preferred":[
         "Szarm el-Szejk"
     ],
@@ -208,8 +223,14 @@
     "name:slv_x_preferred":[
         "Sharm El-Sheikh"
     ],
+    "name:slv_x_variant":[
+        "\u0160arm el \u0160ejk"
+    ],
     "name:spa_x_preferred":[
         "Sharm el-Sheij"
+    ],
+    "name:srd_x_preferred":[
+        "Sharm el-Sheikh"
     ],
     "name:srp_x_preferred":[
         "\u0428\u0430\u0440\u043c \u0435\u043b \u0428\u0435\u0438\u043a"
@@ -226,6 +247,9 @@
     "name:tel_x_preferred":[
         "\u0c37\u0c30\u0c4d\u0c2e\u0c4d \u0c0e\u0c32\u0c4d-\u0c37\u0c47\u0c15\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u0428\u0430\u0440\u043c-\u0430\u0448-\u0428\u0430\u0439\u0445"
+    ],
     "name:tha_x_preferred":[
         "\u0e0a\u0e32\u0e23\u0e4c\u0e21 \u0e40\u0e2d\u0e25-\u0e0a\u0e35\u0e04"
     ],
@@ -241,8 +265,14 @@
     "name:urd_x_preferred":[
         "\u0634\u0631\u0645 \u0627\u0644\u0634\u06cc\u062e"
     ],
+    "name:uzb_x_preferred":[
+        "Sharm al-Shayx"
+    ],
     "name:vie_x_preferred":[
         "Sharm el-Sheikh"
+    ],
+    "name:wuu_x_preferred":[
+        "\u6c99\u59c6\u6c99\u4f0a\u8d6b"
     ],
     "name:xmf_x_preferred":[
         "\u10e8\u10d0\u10e0\u10db-\u10d4\u10da-\u10e8\u10d4\u10d8\u10ee\u10d8"
@@ -253,8 +283,14 @@
     "name:yue_x_preferred":[
         "\u6c99\u59c6\u6c99\u4f0a\u8d6b"
     ],
+    "name:zea_x_preferred":[
+        "Sharm el-Sheikh"
+    ],
     "name:zho_x_preferred":[
         "\u6c99\u59c6\u6c99\u4f0a\u8d6b"
+    ],
+    "name:zul_x_preferred":[
+        "Sharm El Sheikh"
     ],
     "qs_pg:aaroncc":"EG",
     "qs_pg:gn_country":"EG",
@@ -295,7 +331,7 @@
         }
     ],
     "wof:id":1126019237,
-    "wof:lastmodified":1566586584,
+    "wof:lastmodified":1690876073,
     "wof:name":"Sharm ash Shaykh",
     "wof:parent_id":1092024505,
     "wof:placetype":"locality",

--- a/data/112/601/924/5/1126019245.geojson
+++ b/data/112/601/924/5/1126019245.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0642\u0648\u064a\u0633\u0646\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0642\u0648\u064a\u0633\u0646\u0627"
+    ],
     "name:azb_x_preferred":[
         "\u0642\u0648\u06cc\u0633\u0646\u0627"
     ],
@@ -36,6 +39,12 @@
     ],
     "name:fas_x_preferred":[
         "\u0642\u0648\u06cc\u0633\u0646\u0627"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e7\u05d5\u05d9\u05e1\u05e0\u05d4"
+    ],
+    "name:mlg_x_preferred":[
+        "Quwaysin\u0101"
     ],
     "name:nld_x_preferred":[
         "Quweisna"
@@ -49,8 +58,14 @@
     "name:swe_x_preferred":[
         "Quwaysin\u0101"
     ],
+    "name:tha_x_preferred":[
+        "\u0e01\u0e38\u0e27\u0e31\u0e22\u0e2a\u0e4c\u0e19\u0e32"
+    ],
     "name:und_x_variant":[
         "Kuesnah"
+    ],
+    "name:zul_x_preferred":[
+        "Quesna"
     ],
     "qs_pg:aaroncc":"EG",
     "qs_pg:gn_country":"EG",
@@ -91,7 +106,7 @@
         }
     ],
     "wof:id":1126019245,
-    "wof:lastmodified":1566586583,
+    "wof:lastmodified":1690876073,
     "wof:name":"Quwaysin\u0101",
     "wof:parent_id":1092023671,
     "wof:placetype":"locality",

--- a/data/112/601/958/5/1126019585.geojson
+++ b/data/112/601/958/5/1126019585.geojson
@@ -37,8 +37,14 @@
     "name:bul_x_preferred":[
         "\u041c\u0430\u0440\u0441\u0430 \u041c\u0430\u0442\u0440\u0443\u0445"
     ],
+    "name:cat_x_preferred":[
+        "Mersa Matruh"
+    ],
     "name:ceb_x_preferred":[
         "Mersa Matruh"
+    ],
+    "name:ces_x_preferred":[
+        "Mars\u00e1 Matr\u00fah"
     ],
     "name:dan_x_preferred":[
         "Marsa Matruh"
@@ -94,6 +100,9 @@
     "name:lit_x_preferred":[
         "Mersa Matruhas"
     ],
+    "name:mlg_x_preferred":[
+        "Mersa Matruh"
+    ],
     "name:nld_x_preferred":[
         "Marsa Matruh"
     ],
@@ -145,6 +154,9 @@
     "name:zho_x_preferred":[
         "\u99ac\u7279\u9b6f\u6e2f"
     ],
+    "name:zul_x_preferred":[
+        "Mersa Matruh"
+    ],
     "qs_pg:aaroncc":"EG",
     "qs_pg:gn_country":"EG",
     "qs_pg:gn_fcode":"PPLA",
@@ -184,7 +196,7 @@
         }
     ],
     "wof:id":1126019585,
-    "wof:lastmodified":1566586584,
+    "wof:lastmodified":1690876074,
     "wof:name":"Mars\u00e1 Ma\u0163r\u016b\u1e29",
     "wof:parent_id":1092022115,
     "wof:placetype":"locality",

--- a/data/112/601/990/9/1126019909.geojson
+++ b/data/112/601/990/9/1126019909.geojson
@@ -25,8 +25,20 @@
     "name:ara_x_preferred":[
         "\u0628\u0646\u064a \u0633\u0648\u064a\u0641"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0646\u064a \u0633\u0648\u064a\u0641"
+    ],
+    "name:ast_x_preferred":[
+        "Beni Suef"
+    ],
+    "name:azb_x_preferred":[
+        "\u0628\u0646\u06cc \u0633\u0648\u06cc\u0641"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0411\u0435\u043d\u0456-\u0421\u0443\u044d\u0439\u0444"
+    ],
+    "name:bel_x_variant":[
+        "\u0411\u0435\u043d\u0456-\u0421\u0443\u044d\u0439\u0444"
     ],
     "name:ben_x_preferred":[
         "\u09ac\u09c7\u09a8\u09bf \u09b8\u09cb\u09af\u09bc\u09c7\u09ab"
@@ -175,6 +187,12 @@
     "name:urd_x_preferred":[
         "\u0628\u0646\u06cc \u0633\u0648\u06cc\u0641"
     ],
+    "name:uzb_x_preferred":[
+        "Banisueyf"
+    ],
+    "name:vec_x_preferred":[
+        "Beni Suef"
+    ],
     "name:vie_x_preferred":[
         "Beni Suef"
     ],
@@ -183,6 +201,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8c9d\u5c3c\u8607\u97cb\u592b"
+    ],
+    "name:zul_x_preferred":[
+        "Beni Suef"
     ],
     "qs_pg:aaroncc":"EG",
     "qs_pg:gn_country":"EG",
@@ -223,7 +244,7 @@
         }
     ],
     "wof:id":1126019909,
-    "wof:lastmodified":1566586583,
+    "wof:lastmodified":1690876073,
     "wof:name":"Ban\u012b Suwayf",
     "wof:parent_id":1092015341,
     "wof:placetype":"locality",

--- a/data/112/602/003/1/1126020031.geojson
+++ b/data/112/602/003/1/1126020031.geojson
@@ -32,6 +32,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0639\u0631\u064a\u0634"
     ],
+    "name:ast_x_preferred":[
+        "Arish"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u0631\u06cc\u0634"
     ],
@@ -84,6 +87,12 @@
     "name:fra_x_preferred":[
         "El-Arich"
     ],
+    "name:gle_x_preferred":[
+        "Arish"
+    ],
+    "name:glg_x_preferred":[
+        "Al-Arish"
+    ],
     "name:heb_x_preferred":[
         "\u05d0\u05dc \u05e2\u05e8\u05d9\u05e9"
     ],
@@ -123,6 +132,9 @@
     "name:mkd_x_preferred":[
         "\u0410\u0440\u0438\u0448"
     ],
+    "name:mlg_x_preferred":[
+        "Arish"
+    ],
     "name:msa_x_preferred":[
         "Arish"
     ],
@@ -156,6 +168,9 @@
     "name:srp_x_preferred":[
         "\u0410\u0440\u0438\u0448"
     ],
+    "name:swa_x_preferred":[
+        "Arish"
+    ],
     "name:swe_x_preferred":[
         "Al-Arish"
     ],
@@ -174,6 +189,9 @@
     "name:urd_x_preferred":[
         "\u0639\u0631\u06cc\u0634"
     ],
+    "name:vec_x_preferred":[
+        "Al-Arish"
+    ],
     "name:war_x_preferred":[
         "Arish"
     ],
@@ -182,6 +200,9 @@
     ],
     "name:zho_x_preferred":[
         "\u963f\u91cc\u4ec0"
+    ],
+    "name:zul_x_preferred":[
+        "Arish"
     ],
     "qs_pg:aaroncc":"EG",
     "qs_pg:gn_country":"EG",
@@ -222,7 +243,7 @@
         }
     ],
     "wof:id":1126020031,
-    "wof:lastmodified":1566586582,
+    "wof:lastmodified":1690876071,
     "wof:name":"Al \u2018Ar\u012bsh",
     "wof:parent_id":1092025189,
     "wof:placetype":"locality",

--- a/data/112/606/936/5/1126069365.geojson
+++ b/data/112/606/936/5/1126069365.geojson
@@ -58,6 +58,12 @@
     "name:gle_x_preferred":[
         "Shubra"
     ],
+    "name:heb_x_preferred":[
+        "\u05e9\u05d5\u05d1\u05e8\u05d0"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30b7\u30e5\u30d6\u30e9"
+    ],
     "name:nld_x_preferred":[
         "Shubra"
     ],
@@ -118,7 +124,7 @@
         }
     ],
     "wof:id":1126069365,
-    "wof:lastmodified":1566586583,
+    "wof:lastmodified":1690876073,
     "wof:name":"\u0634\u0628\u0631\u0627",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/112/609/197/5/1126091975.geojson
+++ b/data/112/609/197/5/1126091975.geojson
@@ -29,6 +29,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0648\u0631\u062f\u064a\u0627\u0646"
     ],
+    "name:azb_x_preferred":[
+        "\u0627\u0644\u0648\u0631\u062f\u06cc\u0627\u0646"
+    ],
     "name:eng_x_colloquial":[
         "El-Wardyan",
         "Al Wardiyaan",
@@ -45,6 +48,9 @@
     ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0648\u0631\u062f\u06cc\u0627\u0646"
+    ],
+    "name:nld_x_preferred":[
+        "Wardeyan"
     ],
     "qs_pg:aaroncc":"EG",
     "qs_pg:gn_country":"EG",
@@ -99,7 +105,7 @@
         }
     ],
     "wof:id":1126091975,
-    "wof:lastmodified":1566586584,
+    "wof:lastmodified":1690876074,
     "wof:name":"Wardian",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/114/190/610/9/1141906109.geojson
+++ b/data/114/190/610/9/1141906109.geojson
@@ -24,8 +24,14 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0632\u0642\u0627\u0632\u064a\u0642"
     ],
+    "name:ast_x_preferred":[
+        "Zagazig"
+    ],
     "name:azb_x_preferred":[
         "\u0632\u0642\u0627\u0632\u06cc\u0642"
+    ],
+    "name:aze_x_preferred":[
+        "\u018fz-Z\u0259qaziq"
     ],
     "name:ben_x_preferred":[
         "\u099c\u09cd\u09af\u09be\u0997\u09be\u099c\u09bf\u0997"
@@ -108,6 +114,9 @@
     "name:mar_x_preferred":[
         "\u091d\u0917\u093e\u091d\u093f\u0917"
     ],
+    "name:mlg_x_preferred":[
+        "Zagazig"
+    ],
     "name:nld_x_preferred":[
         "Zagazig"
     ],
@@ -141,6 +150,9 @@
     "name:swe_x_preferred":[
         "Zagazig"
     ],
+    "name:tgk_x_preferred":[
+        "\u0410\u0437-\u0417\u0430\u049b\u043e\u0437\u0438\u049b"
+    ],
     "name:tha_x_preferred":[
         "\u0e2d\u0e31\u0e0b\u0e0b\u0e30\u0e01\u0e2d\u0e0b\u0e35\u0e01"
     ],
@@ -153,6 +165,12 @@
     "name:urd_x_preferred":[
         "\u0632\u06af\u0632\u06cc\u06af"
     ],
+    "name:uzb_x_preferred":[
+        "Az-zaqoziq"
+    ],
+    "name:vec_x_preferred":[
+        "Zagazig"
+    ],
     "name:vie_x_preferred":[
         "Zagazig"
     ],
@@ -164,6 +182,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5bb0\u52a0\u6d4e\u683c"
+    ],
+    "name:zul_x_preferred":[
+        "Zagazig"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Egypt",
@@ -284,7 +305,7 @@
         }
     ],
     "wof:id":1141906109,
-    "wof:lastmodified":1636502270,
+    "wof:lastmodified":1690876080,
     "wof:name":"Zagazig",
     "wof:parent_id":1092020479,
     "wof:placetype":"locality",

--- a/data/114/190/762/3/1141907623.geojson
+++ b/data/114/190/762/3/1141907623.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"32.2599840889,30.590340799,32.2599840889,30.590340799",
+    "geom:bbox":"32.259984,30.590341,32.259984,30.590341",
     "geom:latitude":30.590341,
     "geom:longitude":32.259984,
     "gn:country":"EG",
@@ -24,20 +24,32 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0625\u0633\u0645\u0627\u0639\u064a\u0644\u064a\u0629"
     ],
-    "name:ara_x_variant":[
-        "\u0627\u0644\u0625\u0633\u0645\u0627\u0639\u064a\u0644\u064a\u0629"
-    ],
     "name:arz_x_preferred":[
         "\u0627\u0633\u0645\u0627\u0639\u064a\u0644\u064a\u0647"
     ],
+    "name:ast_x_preferred":[
+        "Ismailia"
+    ],
+    "name:azb_x_preferred":[
+        "\u0627\u06cc\u0633\u0645\u0627\u0639\u06cc\u0644\u06cc\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "\u018fl-\u0130smailiyy\u0259"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0406\u0441\u043c\u0430\u0456\u043b\u0456\u044f"
+    ],
+    "name:bel_x_variant":[
+        "\u0406\u0441\u043c\u0430\u0456\u043b\u0456\u044f"
     ],
     "name:bul_x_preferred":[
         "\u0418\u0441\u043c\u0430\u0438\u043b\u0438\u044f"
     ],
     "name:cat_x_preferred":[
         "Ismailiyah"
+    ],
+    "name:ceb_x_preferred":[
+        "Ismailia"
     ],
     "name:ces_x_preferred":[
         "Ism\u00e1\u00edl\u00edja"
@@ -58,7 +70,10 @@
         "Isma\u00eflia"
     ],
     "name:eng_x_variant":[
-        "Isma\u00eflia"
+        "Ismailia"
+    ],
+    "name:epo_x_preferred":[
+        "Ismailio"
     ],
     "name:est_x_preferred":[
         "Al-Ism\u0101\u2019\u012bl\u012byah"
@@ -79,6 +94,9 @@
         "Isma\u00eflia"
     ],
     "name:gle_x_preferred":[
+        "Ismailia"
+    ],
+    "name:glg_x_preferred":[
         "Ismailia"
     ],
     "name:heb_x_preferred":[
@@ -108,6 +126,9 @@
     "name:kab_x_preferred":[
         "Isma\u025biliyya"
     ],
+    "name:kab_x_variant":[
+        "Isma\u025bileyya"
+    ],
     "name:kat_x_preferred":[
         "\u10d8\u10e1\u10db\u10d0\u10d8\u10da\u10d8\u10d0"
     ],
@@ -120,6 +141,9 @@
     "name:lit_x_preferred":[
         "Ismailija"
     ],
+    "name:mlg_x_preferred":[
+        "Ismailia"
+    ],
     "name:nds_x_preferred":[
         "Ismailia"
     ],
@@ -129,8 +153,14 @@
     "name:nld_x_variant":[
         "Ismailia"
     ],
+    "name:nno_x_preferred":[
+        "Ismailia"
+    ],
     "name:nob_x_preferred":[
         "Ismailia"
+    ],
+    "name:oci_x_preferred":[
+        "Ismailha"
     ],
     "name:pnb_x_preferred":[
         "\u0627\u0633\u0645\u0627\u0639\u06cc\u0644\u06cc\u06c1"
@@ -140,6 +170,9 @@
     ],
     "name:por_x_preferred":[
         "Isma\u00edlia"
+    ],
+    "name:pus_x_preferred":[
+        "\u0627\u0633\u0645\u0627\u0639\u064a\u0644\u064a\u0647"
     ],
     "name:rus_x_preferred":[
         "\u0418\u0441\u043c\u0430\u0438\u043b\u0438\u044f"
@@ -165,11 +198,20 @@
     "name:szl_x_preferred":[
         "Ismailia"
     ],
+    "name:tam_x_preferred":[
+        "\u0b87\u0b9a\u0bc1\u0bae\u0bbe\u0bb2\u0bbf\u0baf\u0bbe \u0ba8\u0b95\u0bb0\u0bae\u0bcd"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0410\u043b-\u0418\u0441\u043c\u043e\u0438\u043b\u0438\u044f"
+    ],
     "name:tha_x_preferred":[
         "\u0e2d\u0e34\u0e2a\u0e40\u0e21\u0e2d\u0e34\u0e25\u0e35\u0e2d\u0e32"
     ],
     "name:tur_x_preferred":[
         "\u0130smailiye"
+    ],
+    "name:uig_x_preferred":[
+        "\u0626\u0649\u0633\u0645\u0627\u0626\u0649\u0644\u0649\u064a\u06d5"
     ],
     "name:ukr_x_preferred":[
         "\u0406\u0441\u043c\u0430\u0457\u043b\u0456\u044f"
@@ -183,6 +225,9 @@
     "name:uzb_x_preferred":[
         "Ismoiliya"
     ],
+    "name:vec_x_preferred":[
+        "Ismailia"
+    ],
     "name:vie_x_preferred":[
         "Ismailia"
     ],
@@ -192,11 +237,17 @@
     "name:war_x_preferred":[
         "Ismailia"
     ],
+    "name:wuu_x_preferred":[
+        "\u4f0a\u65af\u6885\u5229\u4e9a"
+    ],
     "name:zho_x_preferred":[
         "\u4f0a\u65af\u6885\u5229\u4e9a"
     ],
     "name:zho_x_variant":[
         "\u4f0a\u65af\u6885\u5229\u4e9e"
+    ],
+    "name:zul_x_preferred":[
+        "Ismailia"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Egypt",
@@ -320,7 +371,7 @@
     },
     "wof:country":"EG",
     "wof:created":1499130750,
-    "wof:geomhash":"3f15a7da05a52b143c351413b92121e1",
+    "wof:geomhash":"58013478c14e0d30ff7b5e5d966563a4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -331,7 +382,7 @@
         }
     ],
     "wof:id":1141907623,
-    "wof:lastmodified":1566586923,
+    "wof:lastmodified":1690876080,
     "wof:name":"Ismailia",
     "wof:parent_id":1092025591,
     "wof:placetype":"locality",
@@ -345,10 +396,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    32.2599840888837,
-    30.59034079896685,
-    32.2599840888837,
-    30.59034079896685
+    32.259984,
+    30.590341,
+    32.259984,
+    30.590341
 ],
-  "geometry": {"coordinates":[32.2599840888837,30.59034079896685],"type":"Point"}
+  "geometry": {"coordinates":[32.259984,30.590341],"type":"Point"}
 }

--- a/data/114/190/763/1/1141907631.geojson
+++ b/data/114/190/763/1/1141907631.geojson
@@ -21,14 +21,23 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0636\u0628\u0639\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0636\u0628\u0639\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u0636\u0628\u0639\u0647"
     ],
     "name:ben_x_preferred":[
         "\u098f\u09b2 \u09a6\u09be\u09ac\u09be"
     ],
+    "name:cat_x_preferred":[
+        "El Dabaa"
+    ],
     "name:deu_x_preferred":[
         "Al-Dab'a"
+    ],
+    "name:ell_x_preferred":[
+        "\u0395\u03bb \u039d\u03c4\u03ac\u03bc\u03c0\u03b1"
     ],
     "name:eng_x_preferred":[
         "El Dabaa"
@@ -42,6 +51,12 @@
     "name:fra_x_preferred":[
         "Projet de centrale nucl\u00e9aire d'El-Dabaa"
     ],
+    "name:fra_x_variant":[
+        "Al Dabaa"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d0-\u05d3\u05d1\u05e2\u05d4"
+    ],
     "name:hin_x_preferred":[
         "\u0905\u0932 \u0921\u093e\u092c\u093e"
     ],
@@ -53,6 +68,9 @@
     ],
     "name:ita_x_preferred":[
         "El Dabaa"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30a8\u30eb\u30fb\u30c0\u30d0"
     ],
     "name:kor_x_preferred":[
         "\uc5d8\ub2e4\ubc14"
@@ -68,6 +86,9 @@
     ],
     "name:rus_x_preferred":[
         "\u042d\u043b\u044c-\u0414\u0430\u0431\u0430\u0430"
+    ],
+    "name:rus_x_variant":[
+        "\u042d\u0434-\u0414\u0430\u0431\u044a\u0430"
     ],
     "name:spa_x_preferred":[
         "El Daba"
@@ -92,6 +113,9 @@
     ],
     "name:zho_tw_x_preferred":[
         "\u57c3\u723e\u9054\u5df4"
+    ],
+    "name:zul_x_preferred":[
+        "El Dabaa"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Egypt",
@@ -212,7 +236,7 @@
         }
     ],
     "wof:id":1141907631,
-    "wof:lastmodified":1636502269,
+    "wof:lastmodified":1690876079,
     "wof:name":"El Daba",
     "wof:parent_id":1092017227,
     "wof:placetype":"locality",

--- a/data/114/190/763/5/1141907635.geojson
+++ b/data/114/190/763/5/1141907635.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"30.4700158272,31.0504419139,30.4700158272,31.0504419139",
+    "geom:bbox":"30.470016,31.050442,30.470016,31.050442",
     "geom:latitude":31.050442,
     "geom:longitude":30.470016,
     "iso:country":"EG",
@@ -23,6 +23,9 @@
     ],
     "name:arz_x_preferred":[
         "\u062f\u0645\u0646\u0647\u0648\u0631"
+    ],
+    "name:ast_x_preferred":[
+        "Damanhur"
     ],
     "name:azb_x_preferred":[
         "\u062f\u0645\u0646\u0647\u0648\u0631"
@@ -75,6 +78,9 @@
     "name:gla_x_preferred":[
         "Damanh\u00f9r"
     ],
+    "name:gle_x_preferred":[
+        "Damanhur"
+    ],
     "name:guj_x_preferred":[
         "\u0aa6\u0aae\u0aa3\u0ab9\u0ac1\u0ab0"
     ],
@@ -119,6 +125,9 @@
     ],
     "name:mar_x_preferred":[
         "\u0926\u092e\u0923\u0939\u0930"
+    ],
+    "name:mlg_x_preferred":[
+        "Damanh\u016br"
     ],
     "name:msa_x_preferred":[
         "Damanhur"
@@ -165,6 +174,9 @@
     "name:tel_x_preferred":[
         "\u0c21\u0c3e\u0c2e\u0c28\u0c4d \u0c39\u0c41\u0c30\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u0414\u0430\u043c\u0430\u043d\u04b3\u0443\u0440"
+    ],
     "name:tha_x_preferred":[
         "\u0e14\u0e32\u0e21\u0e32\u0e19\u0e40\u0e2e\u0e2d\u0e23\u0e4c"
     ],
@@ -183,14 +195,26 @@
     "name:uzb_x_preferred":[
         "Damanxur"
     ],
+    "name:uzb_x_variant":[
+        "Damanhur"
+    ],
+    "name:vec_x_preferred":[
+        "Damanhur"
+    ],
     "name:vie_x_preferred":[
         "Damanhur"
     ],
     "name:war_x_preferred":[
         "Damanhur"
     ],
+    "name:yue_x_preferred":[
+        "\u9054\u66fc\u80e1\u723e"
+    ],
     "name:zho_x_preferred":[
         "\u9054\u66fc\u80e1\u723e"
+    ],
+    "name:zul_x_preferred":[
+        "Damanhur"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Egypt",
@@ -300,7 +324,7 @@
     },
     "wof:country":"EG",
     "wof:created":1499130752,
-    "wof:geomhash":"947b81f1e5c46f8b58b2852d07c76839",
+    "wof:geomhash":"0ab9a716ec2cfc8121c39fbd8e5792e8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -311,7 +335,7 @@
         }
     ],
     "wof:id":1141907635,
-    "wof:lastmodified":1566586922,
+    "wof:lastmodified":1690876080,
     "wof:name":"Damanhur",
     "wof:parent_id":1092015921,
     "wof:placetype":"locality",
@@ -321,10 +345,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    30.47001582715785,
-    31.05044191387759,
-    30.47001582715785,
-    31.05044191387759
+    30.470016,
+    31.050442,
+    30.470016,
+    31.050442
 ],
-  "geometry": {"coordinates":[30.47001582715785,31.05044191387759],"type":"Point"}
+  "geometry": {"coordinates":[30.470016,31.050442],"type":"Point"}
 }

--- a/data/114/190/763/7/1141907637.geojson
+++ b/data/114/190/763/7/1141907637.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"31.0900296618,29.0803812856,31.0900296618,29.0803812856",
+    "geom:bbox":"31.09003,29.080381,31.09003,29.080381",
     "geom:latitude":29.080381,
     "geom:longitude":31.09003,
     "iso:country":"EG",
@@ -21,8 +21,20 @@
     "name:ara_x_preferred":[
         "\u0628\u0646\u064a \u0633\u0648\u064a\u0641"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0646\u064a \u0633\u0648\u064a\u0641"
+    ],
+    "name:ast_x_preferred":[
+        "Beni Suef"
+    ],
+    "name:azb_x_preferred":[
+        "\u0628\u0646\u06cc \u0633\u0648\u06cc\u0641"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0411\u0435\u043d\u0456-\u0421\u0443\u044d\u0439\u0444"
+    ],
+    "name:bel_x_variant":[
+        "\u0411\u0435\u043d\u0456-\u0421\u0443\u044d\u0439\u0444"
     ],
     "name:ben_x_preferred":[
         "\u09ac\u09c7\u09a8\u09bf \u09b8\u09cb\u09af\u09bc\u09c7\u09ab"
@@ -171,6 +183,12 @@
     "name:urd_x_preferred":[
         "\u0628\u0646\u06cc \u0633\u0648\u06cc\u0641"
     ],
+    "name:uzb_x_preferred":[
+        "Banisueyf"
+    ],
+    "name:vec_x_preferred":[
+        "Beni Suef"
+    ],
     "name:vie_x_preferred":[
         "Beni Suef"
     ],
@@ -179,6 +197,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8c9d\u5c3c\u8607\u97cb\u592b"
+    ],
+    "name:zul_x_preferred":[
+        "Beni Suef"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Egypt",
@@ -288,7 +309,7 @@
     },
     "wof:country":"EG",
     "wof:created":1499130752,
-    "wof:geomhash":"28c0e7e6c7e0e2497bd4e975ded5d5db",
+    "wof:geomhash":"90a54c4268f664b1cd3249e80a91060c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -299,7 +320,7 @@
         }
     ],
     "wof:id":1141907637,
-    "wof:lastmodified":1566586922,
+    "wof:lastmodified":1690876079,
     "wof:name":"Beni Suef",
     "wof:parent_id":1092015341,
     "wof:placetype":"locality",
@@ -309,10 +330,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    31.09002966179565,
-    29.08038128561464,
-    31.09002966179565,
-    29.08038128561464
+    31.09003,
+    29.080381,
+    31.09003,
+    29.080381
 ],
-  "geometry": {"coordinates":[31.09002966179565,29.08038128561464],"type":"Point"}
+  "geometry": {"coordinates":[31.09003,29.080381],"type":"Point"}
 }

--- a/data/114/190/892/9/1141908929.geojson
+++ b/data/114/190/892/9/1141908929.geojson
@@ -21,6 +21,12 @@
     "name:ara_x_preferred":[
         "\u0643\u0648\u0645 \u0623\u0645\u0628\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0648\u0645 \u0623\u0645\u0628\u0648"
+    ],
+    "name:ast_x_preferred":[
+        "Kom Ombo"
+    ],
     "name:azb_x_preferred":[
         "\u06a9\u0648\u0645 \u0627\u0645\u0628\u0648"
     ],
@@ -40,6 +46,9 @@
         "\u039a\u03bf\u03bc \u038c\u03bc\u03c0\u03bf"
     ],
     "name:eng_x_preferred":[
+        "Kom Ombo"
+    ],
+    "name:epo_x_preferred":[
         "Kom Ombo"
     ],
     "name:eus_x_preferred":[
@@ -105,6 +114,9 @@
     "name:slv_x_preferred":[
         "Kom Ombo"
     ],
+    "name:smn_x_preferred":[
+        "Kom Ombo"
+    ],
     "name:spa_x_preferred":[
         "Kom Ombo"
     ],
@@ -128,6 +140,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8003\u59c6\u7fc1\u5e03"
+    ],
+    "name:zul_x_preferred":[
+        "Kom Ombo"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Egypt",
@@ -248,7 +263,7 @@
         }
     ],
     "wof:id":1141908929,
-    "wof:lastmodified":1636502271,
+    "wof:lastmodified":1690876080,
     "wof:name":"Kom Ombo",
     "wof:parent_id":1092021927,
     "wof:placetype":"locality",

--- a/data/114/190/893/3/1141908933.geojson
+++ b/data/114/190/893/3/1141908933.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"33.8300174548,27.2300032745,33.8300174548,27.2300032745",
+    "geom:bbox":"33.830017,27.230003,33.830017,27.230003",
     "geom:latitude":27.230003,
     "geom:longitude":33.830017,
     "iso:country":"EG",
@@ -36,8 +36,14 @@
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0425\u0443\u0440\u0433\u0430\u0434\u0430"
     ],
+    "name:bel_x_variant":[
+        "\u0425\u0443\u0440\u0433\u0430\u0434\u0430"
+    ],
     "name:ben_x_preferred":[
         "\u09b9\u09be\u09b0\u0998\u09be\u09a6\u09be"
+    ],
+    "name:ben_x_variant":[
+        "\u09b9\u09be\u09b0\u0997\u09be\u09a6\u09be"
     ],
     "name:bul_x_preferred":[
         "\u0425\u0443\u0440\u0433\u0430\u0434\u0430"
@@ -141,6 +147,9 @@
     "name:mkd_x_preferred":[
         "\u0425\u0443\u0440\u0433\u0430\u0434\u0430"
     ],
+    "name:mlg_x_preferred":[
+        "Hurghada"
+    ],
     "name:msa_x_preferred":[
         "Hurghada"
     ],
@@ -172,6 +181,9 @@
         "\u0dc4\u0dbb\u0dca\u0d9c\u0dcf\u0da9\u0dcf"
     ],
     "name:slk_x_preferred":[
+        "Hurgada"
+    ],
+    "name:slv_x_preferred":[
         "Hurgada"
     ],
     "name:spa_x_preferred":[
@@ -210,11 +222,17 @@
     "name:urd_x_preferred":[
         "\u063a\u0631\u062f\u0642\u06c1"
     ],
+    "name:vec_x_preferred":[
+        "Hurghada"
+    ],
     "name:vie_x_preferred":[
         "Hurghada"
     ],
     "name:war_x_preferred":[
         "Hurghada"
+    ],
+    "name:wuu_x_preferred":[
+        "\u53e4\u5c14\u4ee3\u76d6"
     ],
     "name:xmf_x_preferred":[
         "\u10f0\u10e3\u10e0\u10d2\u10d0\u10d3\u10d0"
@@ -224,6 +242,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6d2a\u52a0\u9054"
+    ],
+    "name:zul_x_preferred":[
+        "Hurghada"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Egypt",
@@ -333,7 +354,7 @@
     },
     "wof:country":"EG",
     "wof:created":1499131000,
-    "wof:geomhash":"ab60b37f743761fa1488fe1406533283",
+    "wof:geomhash":"700bae516e777d23d786fc5623e7a084",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -344,7 +365,7 @@
         }
     ],
     "wof:id":1141908933,
-    "wof:lastmodified":1566586924,
+    "wof:lastmodified":1690876081,
     "wof:name":"Hurghada",
     "wof:parent_id":1092021497,
     "wof:placetype":"locality",
@@ -354,10 +375,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    33.83001745477537,
-    27.23000327453946,
-    33.83001745477537,
-    27.23000327453946
+    33.830017,
+    27.230003,
+    33.830017,
+    27.230003
 ],
-  "geometry": {"coordinates":[33.83001745477537,27.23000327453946],"type":"Point"}
+  "geometry": {"coordinates":[33.830017,27.230003],"type":"Point"}
 }

--- a/data/114/190/923/9/1141909239.geojson
+++ b/data/114/190/923/9/1141909239.geojson
@@ -27,14 +27,29 @@
     "name:arz_x_preferred":[
         "\u0623\u0633\u0648\u0627\u0646"
     ],
+    "name:arz_x_variant":[
+        "\u0627\u0633\u0648\u0627\u0646"
+    ],
+    "name:ast_x_preferred":[
+        "Aswan"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0633\u0648\u0627\u0646"
+    ],
+    "name:aze_x_preferred":[
+        "\u018fsvan"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0410\u0441\u0443\u0430\u043d"
     ],
+    "name:bel_x_variant":[
+        "\u0410\u0441\u0443\u0430\u043d"
+    ],
     "name:ben_x_preferred":[
         "\u0986\u09b8\u0989\u09af\u09bc\u09be\u09a8"
+    ],
+    "name:ben_x_variant":[
+        "\u0986\u09b8\u0993\u09af\u09bc\u09be\u09a8"
     ],
     "name:bos_x_preferred":[
         "Asuan"
@@ -50,6 +65,9 @@
     ],
     "name:ces_x_preferred":[
         "Asu\u00e1n"
+    ],
+    "name:ckb_x_preferred":[
+        "\u0626\u06d5\u0633\u0648\u0627\u0646"
     ],
     "name:dan_x_preferred":[
         "Aswan"
@@ -147,8 +165,20 @@
     "name:lit_x_preferred":[
         "Asuanas"
     ],
+    "name:mal_x_preferred":[
+        "\u0d05\u0d38\u0d4d\u0d35\u0d3e\u0d7b"
+    ],
     "name:mar_x_preferred":[
         "\u0906\u0938\u094d\u0935\u093e\u0928"
+    ],
+    "name:mkd_x_preferred":[
+        "\u0410\u0441\u0443\u0430\u043d"
+    ],
+    "name:mlg_x_preferred":[
+        "Aswan"
+    ],
+    "name:mri_x_preferred":[
+        "Hewene"
     ],
     "name:msa_x_preferred":[
         "Aswan"
@@ -164,6 +194,9 @@
     ],
     "name:oci_x_preferred":[
         "Assoan"
+    ],
+    "name:oss_x_preferred":[
+        "\u0410\u0441\u0443\u0430\u043d"
     ],
     "name:pnb_x_preferred":[
         "\u0627\u0633\u0648\u0627\u0646"
@@ -213,11 +246,17 @@
     "name:tel_x_preferred":[
         "\u0c05\u0c38\u0c4d\u0c35\u0c3e\u0c28\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u0410\u0441\u0432\u043e\u043d"
+    ],
     "name:tha_x_preferred":[
         "\u0e2d\u0e31\u0e2a\u0e27\u0e32\u0e19"
     ],
     "name:tur_x_preferred":[
         "Asvan"
+    ],
+    "name:uig_x_preferred":[
+        "\u0626\u06d5\u0633\u06cb\u0627\u0646"
     ],
     "name:ukr_x_preferred":[
         "\u0410\u0441\u0443\u0430\u043d"
@@ -227,6 +266,9 @@
     ],
     "name:uzb_x_preferred":[
         "Asvon"
+    ],
+    "name:vec_x_preferred":[
+        "Assuan"
     ],
     "name:vie_x_preferred":[
         "Aswan"
@@ -242,6 +284,9 @@
     ],
     "name:zho_x_preferred":[
         "\u963f\u65af\u65fa"
+    ],
+    "name:zul_x_preferred":[
+        "Aswan"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Egypt",
@@ -362,7 +407,7 @@
         }
     ],
     "wof:id":1141909239,
-    "wof:lastmodified":1636502271,
+    "wof:lastmodified":1690876081,
     "wof:name":"Aswan",
     "wof:parent_id":1092014635,
     "wof:placetype":"locality",

--- a/data/114/190/924/1/1141909241.geojson
+++ b/data/114/190/924/1/1141909241.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"31.179946654,27.1899798777,31.179946654,27.1899798777",
+    "geom:bbox":"31.179947,27.18998,31.179947,27.18998",
     "geom:latitude":27.18998,
     "geom:longitude":31.179947,
     "iso:country":"EG",
@@ -27,20 +27,35 @@
     "name:arz_x_preferred":[
         "\u0627\u0633\u064a\u0648\u0637"
     ],
+    "name:ast_x_preferred":[
+        "Asyut"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0633\u06cc\u0648\u0637"
+    ],
+    "name:aze_x_preferred":[
+        "Asyut"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0410\u0441\u044c\u044e\u0442"
     ],
+    "name:bel_x_variant":[
+        "\u0410\u0441\u044c\u044e\u0442"
+    ],
     "name:ben_x_preferred":[
         "\u0985\u09cd\u09af\u09be\u09b8\u09be\u09af\u09bc\u09be\u09a4"
+    ],
+    "name:ben_x_variant":[
+        "\u0986\u09b8\u09bf\u0989\u09a4"
     ],
     "name:bul_x_preferred":[
         "\u0410\u0441\u044e\u0442"
     ],
     "name:cat_x_preferred":[
         "Asyut"
+    ],
+    "name:cat_x_variant":[
+        "Assiut"
     ],
     "name:ceb_x_preferred":[
         "Asy\u016b\u0163"
@@ -96,6 +111,9 @@
     "name:hye_x_preferred":[
         "\u0531\u057d\u0575\u0578\u0582\u057f"
     ],
+    "name:ibo_x_preferred":[
+        "Asyut"
+    ],
     "name:ind_x_preferred":[
         "Asyuth"
     ],
@@ -104,6 +122,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30a2\u30b9\u30e6\u30fc\u30c8"
+    ],
+    "name:jpn_x_variant":[
+        "\u30a2\u30b7\u30e5\u30fc\u30c8"
     ],
     "name:kab_x_preferred":[
         "Asyu\u1e6d"
@@ -180,6 +201,9 @@
     "name:swe_x_preferred":[
         "Asyut"
     ],
+    "name:szl_x_preferred":[
+        "Asjut"
+    ],
     "name:tam_x_preferred":[
         "\u0b85\u0bb8\u0bcd\u0baf\u0bc2\u0b9f\u0bcd"
     ],
@@ -207,14 +231,26 @@
     "name:uzb_x_preferred":[
         "Asyut"
     ],
+    "name:vec_x_preferred":[
+        "Asy\u016b\u1e6d"
+    ],
     "name:vie_x_preferred":[
         "Asyut"
     ],
     "name:war_x_preferred":[
         "Asyut"
     ],
+    "name:wuu_x_preferred":[
+        "\u827e\u65af\u5c24\u7279"
+    ],
+    "name:yue_x_preferred":[
+        "\u827e\u65af\u5c24\u7279"
+    ],
     "name:zho_x_preferred":[
         "\u827e\u65af\u5c24\u7279"
+    ],
+    "name:zul_x_preferred":[
+        "Asyut"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Egypt",
@@ -324,7 +360,7 @@
     },
     "wof:country":"EG",
     "wof:created":1499131048,
-    "wof:geomhash":"3dcfc88c19b3e0a72e9537b9b8841547",
+    "wof:geomhash":"b83f853a97c19ee7c12246af90cb6229",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -335,7 +371,7 @@
         }
     ],
     "wof:id":1141909241,
-    "wof:lastmodified":1566586925,
+    "wof:lastmodified":1690876081,
     "wof:name":"Asyut",
     "wof:parent_id":1092017669,
     "wof:placetype":"locality",
@@ -345,10 +381,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    31.17994665398362,
-    27.18997987772934,
-    31.17994665398362,
-    27.18997987772934
+    31.179947,
+    27.18998,
+    31.179947,
+    27.18998
 ],
-  "geometry": {"coordinates":[31.17994665398362,27.18997987772934],"type":"Point"}
+  "geometry": {"coordinates":[31.179947,27.18998],"type":"Point"}
 }

--- a/data/421/166/715/421166715.geojson
+++ b/data/421/166/715/421166715.geojson
@@ -23,11 +23,20 @@
     "name:arz_x_preferred":[
         "\u0628\u0646\u0649 \u0645\u0632\u0627\u0631"
     ],
+    "name:ast_x_preferred":[
+        "Beni Mazar"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0646\u06cc \u0645\u0632\u0627\u0631"
     ],
+    "name:bak_x_preferred":[
+        "\u0411\u0435\u043d\u0438-\u041c\u0430\u0437\u0430\u0440"
+    ],
     "name:ceb_x_preferred":[
         "Markaz Ban\u012b Maz\u0101r"
+    ],
+    "name:ceb_x_variant":[
+        "Ban\u012b Maz\u0101r"
     ],
     "name:deu_x_preferred":[
         "Bani Mazar"
@@ -47,7 +56,13 @@
     "name:kat_x_preferred":[
         "\u10d1\u10d0\u10dc\u10d8-\u10db\u10d0\u10d6\u10d0\u10e0\u10d8"
     ],
+    "name:mlg_x_preferred":[
+        "Ban\u012b Maz\u0101r"
+    ],
     "name:nld_x_preferred":[
+        "Beni Mazar"
+    ],
+    "name:nob_x_preferred":[
         "Beni Mazar"
     ],
     "name:pol_x_preferred":[
@@ -62,11 +77,17 @@
     "name:swe_x_preferred":[
         "Markaz Ban\u012b Maz\u0101r"
     ],
+    "name:swe_x_variant":[
+        "Ban\u012b Maz\u0101r"
+    ],
     "name:und_x_variant":[
         "Beni Maz\u00e2r"
     ],
     "name:zho_x_preferred":[
         "\u8c9d\u5c3c\u9081\u624e\u723e"
+    ],
+    "name:zul_x_preferred":[
+        "Beni Mazar"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Egypt",
@@ -207,7 +228,7 @@
         }
     ],
     "wof:id":421166715,
-    "wof:lastmodified":1566586555,
+    "wof:lastmodified":1690876048,
     "wof:name":"\u0645\u0631\u0643\u0632 \u0628\u0646\u0649 \u0645\u0632\u0627\u0631",
     "wof:parent_id":1092015295,
     "wof:placetype":"locality",

--- a/data/421/166/731/421166731.geojson
+++ b/data/421/166/731/421166731.geojson
@@ -23,6 +23,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u062d\u0631\u0627\u0645"
     ],
+    "name:cym_x_preferred":[
+        "Al Haram"
+    ],
     "name:deu_x_preferred":[
         "Die S\u00fcnde"
     ],
@@ -37,6 +40,12 @@
     ],
     "name:ind_x_preferred":[
         "Al Haram"
+    ],
+    "name:nld_x_preferred":[
+        "El Haram"
+    ],
+    "name:spa_x_preferred":[
+        "The Sin"
     ],
     "name:und_x_variant":[
         "El Haram"
@@ -87,7 +96,7 @@
         }
     ],
     "wof:id":421166731,
-    "wof:lastmodified":1566586555,
+    "wof:lastmodified":1690876048,
     "wof:name":"Al Haram",
     "wof:parent_id":1092020395,
     "wof:placetype":"locality",

--- a/data/421/167/091/421167091.geojson
+++ b/data/421/167/091/421167091.geojson
@@ -23,14 +23,23 @@
     "name:arz_x_preferred":[
         "\u0625\u062e\u0645\u064a\u0645"
     ],
+    "name:ast_x_preferred":[
+        "Akhmim"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u062e\u0645\u06cc\u0645"
+    ],
+    "name:aze_x_preferred":[
+        "Ahmim"
     ],
     "name:cat_x_preferred":[
         "Akhmim"
     ],
     "name:ceb_x_preferred":[
         "Markaz Akhm\u012bm"
+    ],
+    "name:ceb_x_variant":[
+        "Akhm\u012bm"
     ],
     "name:deu_x_preferred":[
         "Achmim"
@@ -47,8 +56,20 @@
     "name:fas_x_preferred":[
         "\u0627\u062e\u0645\u06cc\u0645"
     ],
+    "name:fin_x_preferred":[
+        "Akhmim"
+    ],
     "name:fra_x_preferred":[
         "Akhm\u00eem"
+    ],
+    "name:gle_x_preferred":[
+        "Akhmim"
+    ],
+    "name:hun_x_preferred":[
+        "Akhm\u00edm"
+    ],
+    "name:hye_x_preferred":[
+        "\u0531\u056d\u0574\u056b\u0574"
     ],
     "name:ita_x_preferred":[
         "Akhmim"
@@ -65,8 +86,14 @@
     "name:lit_x_preferred":[
         "Achmimas"
     ],
+    "name:mlg_x_preferred":[
+        "Akhm\u012bm"
+    ],
     "name:nld_x_preferred":[
         "Achmim"
+    ],
+    "name:nob_x_preferred":[
+        "Akhmim"
     ],
     "name:pol_x_preferred":[
         "Achmim"
@@ -80,11 +107,17 @@
     "name:rus_x_preferred":[
         "\u0410\u0445\u043c\u0438\u043c"
     ],
+    "name:slv_x_preferred":[
+        "Ahmim"
+    ],
     "name:spa_x_preferred":[
         "Pan\u00f3polis"
     ],
     "name:srp_x_preferred":[
         "\u0410\u0445\u043c\u0438\u043c"
+    ],
+    "name:swa_x_preferred":[
+        "Akhmim"
     ],
     "name:swe_x_preferred":[
         "Akhmim"
@@ -104,11 +137,17 @@
     "name:urd_x_preferred":[
         "\u0627\u062e\u0645\u06cc\u0645"
     ],
+    "name:vec_x_preferred":[
+        "Akhmim"
+    ],
     "name:vie_x_preferred":[
         "Akhmim"
     ],
     "name:zho_x_preferred":[
         "\u827e\u8d6b\u7c73\u59c6"
+    ],
+    "name:zul_x_preferred":[
+        "Akhmim"
     ],
     "qs:gn_country":"EG",
     "qs:gn_fcode":"PPL",
@@ -157,7 +196,7 @@
         }
     ],
     "wof:id":421167091,
-    "wof:lastmodified":1566586557,
+    "wof:lastmodified":1690876050,
     "wof:name":"\u0627\u062e\u0645\u064a\u0645",
     "wof:parent_id":1092014557,
     "wof:placetype":"locality",

--- a/data/421/168/697/421168697.geojson
+++ b/data/421/168/697/421168697.geojson
@@ -23,11 +23,23 @@
     "name:arz_x_preferred":[
         "\u0633\u0648\u0647\u0627\u062c"
     ],
+    "name:ast_x_preferred":[
+        "Sohag"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u0648\u0647\u0627\u062c"
     ],
+    "name:aze_x_preferred":[
+        "S\u00f6vhac"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09cb\u09b9\u09be\u0997"
+    ],
+    "name:cat_x_preferred":[
+        "Sohag"
+    ],
+    "name:ceb_x_preferred":[
+        "Sohag"
     ],
     "name:ces_x_preferred":[
         "Suhag"
@@ -101,6 +113,9 @@
     "name:mar_x_preferred":[
         "\u0938\u094b\u0939\u093e\u0917"
     ],
+    "name:mlg_x_preferred":[
+        "Sohag"
+    ],
     "name:msa_x_preferred":[
         "Suhaj"
     ],
@@ -143,6 +158,9 @@
     "name:tel_x_preferred":[
         "\u0c38\u0c4b\u0c39\u0c3e\u0c17\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u0421\u0430\u0432\u04b3\u043e\u04b7"
+    ],
     "name:tha_x_preferred":[
         "\u0e0b\u0e32\u0e2d\u0e32\u0e01\u0e38\u0e07"
     ],
@@ -161,6 +179,12 @@
     "name:urd_x_preferred":[
         "\u0633\u0648\u06c1\u0627\u062c"
     ],
+    "name:uzb_x_preferred":[
+        "Savhoj"
+    ],
+    "name:vec_x_preferred":[
+        "Sohag"
+    ],
     "name:vie_x_preferred":[
         "Sohag"
     ],
@@ -169,6 +193,9 @@
     ],
     "name:zho_x_preferred":[
         "\u7d22\u54c8\u5091"
+    ],
+    "name:zul_x_preferred":[
+        "Sohag"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Egypt",
@@ -308,7 +335,7 @@
         }
     ],
     "wof:id":421168697,
-    "wof:lastmodified":1566586555,
+    "wof:lastmodified":1690876047,
     "wof:name":"\u0633\u0648\u0647\u0627\u062c",
     "wof:parent_id":1092015013,
     "wof:placetype":"locality",

--- a/data/421/168/699/421168699.geojson
+++ b/data/421/168/699/421168699.geojson
@@ -20,8 +20,17 @@
     "name:ara_x_preferred":[
         "\u0633\u0645\u0627\u0644\u0648\u0637"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0645\u0627\u0644\u0648\u0637"
+    ],
+    "name:ast_x_preferred":[
+        "Samalut"
+    ],
     "name:ceb_x_preferred":[
         "Markaz Sam\u0101l\u016b\u0163"
+    ],
+    "name:ceb_x_variant":[
+        "Sam\u0101l\u016b\u0163"
     ],
     "name:deu_x_preferred":[
         "Samalut"
@@ -50,7 +59,13 @@
     "name:kaz_x_preferred":[
         "\u0421\u0430\u043c\u0430\u043b\u0443\u0442 \u049b\u0430\u043b\u0430\u0441\u044b"
     ],
+    "name:mlg_x_preferred":[
+        "Sam\u0101l\u016b\u0163"
+    ],
     "name:nld_x_preferred":[
+        "Samalut"
+    ],
+    "name:nob_x_preferred":[
         "Samalut"
     ],
     "name:pol_x_preferred":[
@@ -59,7 +74,13 @@
     "name:rus_x_preferred":[
         "\u0421\u0430\u043c\u0430\u043b\u0443\u0442"
     ],
+    "name:spa_x_preferred":[
+        "Sam\u0101l\u016b\u1e6d"
+    ],
     "name:swe_x_preferred":[
+        "Samalut"
+    ],
+    "name:szl_x_preferred":[
         "Samalut"
     ],
     "name:und_x_variant":[
@@ -67,6 +88,9 @@
     ],
     "name:zho_x_preferred":[
         "\u585e\u99ac\u76e7\u7279"
+    ],
+    "name:zul_x_preferred":[
+        "Samalut"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Egypt",
@@ -207,7 +231,7 @@
         }
     ],
     "wof:id":421168699,
-    "wof:lastmodified":1566586554,
+    "wof:lastmodified":1690876047,
     "wof:name":"\u0645\u0631\u0643\u0632 \u0633\u0645\u0627\u0644\u0648\u0637",
     "wof:parent_id":1092024217,
     "wof:placetype":"locality",

--- a/data/421/168/701/421168701.geojson
+++ b/data/421/168/701/421168701.geojson
@@ -23,6 +23,9 @@
     "name:arz_x_preferred":[
         "\u0645\u0644\u0648\u0649"
     ],
+    "name:ast_x_preferred":[
+        "Mallawi"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0644\u0648\u06cc"
     ],
@@ -47,11 +50,17 @@
     "name:fra_x_preferred":[
         "Mallawi"
     ],
+    "name:gle_x_preferred":[
+        "Mallawi"
+    ],
     "name:ita_x_preferred":[
         "Mallawi"
     ],
     "name:jpn_x_preferred":[
         "\u30de\u30c3\u30e9\u30a6\u30a3\u30fc"
+    ],
+    "name:jpn_x_variant":[
+        "\u30de\u30e9\u30a6\u30a3"
     ],
     "name:kat_x_preferred":[
         "\u10db\u10d0\u10da\u10d0\u10d5\u10d8"
@@ -62,7 +71,13 @@
     "name:lit_x_preferred":[
         "Malavis"
     ],
+    "name:mlg_x_preferred":[
+        "Mallaw\u012b"
+    ],
     "name:nld_x_preferred":[
+        "Mallawi"
+    ],
+    "name:nob_x_preferred":[
         "Mallawi"
     ],
     "name:pol_x_preferred":[
@@ -94,6 +109,9 @@
     ],
     "name:zho_x_preferred":[
         "\u9081\u840a\u7dad"
+    ],
+    "name:zul_x_preferred":[
+        "Mallawi"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Egypt",
@@ -234,7 +252,7 @@
         }
     ],
     "wof:id":421168701,
-    "wof:lastmodified":1566586554,
+    "wof:lastmodified":1690876046,
     "wof:name":"\u0645\u0644\u0648\u0649",
     "wof:parent_id":1092022005,
     "wof:placetype":"locality",

--- a/data/421/168/703/421168703.geojson
+++ b/data/421/168/703/421168703.geojson
@@ -26,8 +26,17 @@
     "name:arz_x_variant":[
         "\u0625\u0633\u0646\u0627"
     ],
+    "name:ast_x_preferred":[
+        "Esna"
+    ],
+    "name:azb_x_preferred":[
+        "\u0627\u0633\u0646\u0627"
+    ],
     "name:aze_x_preferred":[
         "Esna"
+    ],
+    "name:bel_x_preferred":[
+        "\u0406\u0441\u043d\u0430"
     ],
     "name:ben_x_preferred":[
         "\u0987\u09b8\u09a8\u09be"
@@ -42,6 +51,9 @@
         "Markaz Isn\u0101"
     ],
     "name:ceb_x_variant":[
+        "Esna"
+    ],
+    "name:ces_x_preferred":[
         "Esna"
     ],
     "name:deu_x_preferred":[
@@ -74,8 +86,14 @@
     "name:hun_x_preferred":[
         "Eszna"
     ],
+    "name:hye_x_preferred":[
+        "\u053b\u057d\u0576\u0561"
+    ],
     "name:ind_x_preferred":[
         "Isna"
+    ],
+    "name:ind_x_variant":[
+        "Esna"
     ],
     "name:ita_x_preferred":[
         "Esna"
@@ -98,6 +116,12 @@
     "name:lit_x_preferred":[
         "Esna"
     ],
+    "name:mkd_x_preferred":[
+        "\u0415\u0441\u043d\u0430"
+    ],
+    "name:mlg_x_preferred":[
+        "Isn\u0101"
+    ],
     "name:nld_x_preferred":[
         "Esna"
     ],
@@ -113,14 +137,23 @@
     "name:rus_x_variant":[
         "\u042d\u0441\u043d\u0430"
     ],
+    "name:slk_x_preferred":[
+        "Esna"
+    ],
     "name:slv_x_preferred":[
         "Esna"
     ],
     "name:spa_x_preferred":[
         "Esna"
     ],
+    "name:swa_x_preferred":[
+        "Esna"
+    ],
     "name:swe_x_preferred":[
         "Esna"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0418\u0441\u043d\u043e"
     ],
     "name:tur_x_preferred":[
         "Esna"
@@ -139,6 +172,9 @@
     ],
     "name:zho_x_preferred":[
         "\u4f0a\u65af\u7d0d"
+    ],
+    "name:zul_x_preferred":[
+        "Esna"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Egypt",
@@ -284,7 +320,7 @@
         }
     ],
     "wof:id":421168703,
-    "wof:lastmodified":1636502266,
+    "wof:lastmodified":1690876047,
     "wof:name":"Isna",
     "wof:parent_id":1092020721,
     "wof:placetype":"locality",

--- a/data/421/168/705/421168705.geojson
+++ b/data/421/168/705/421168705.geojson
@@ -29,8 +29,14 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0633\u0648\u064a\u0633"
     ],
+    "name:ast_x_preferred":[
+        "Suez"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u0648\u0626\u0632"
+    ],
+    "name:aze_x_preferred":[
+        "S\u00fcvey\u015f"
     ],
     "name:bak_x_preferred":[
         "\u0421\u04af\u04d9\u0439\u0441"
@@ -170,6 +176,12 @@
     "name:mkd_x_preferred":[
         "\u0421\u0443\u0435\u0446"
     ],
+    "name:mlg_x_preferred":[
+        "Suez"
+    ],
+    "name:mlt_x_preferred":[
+        "Suez"
+    ],
     "name:msa_x_preferred":[
         "Suez"
     ],
@@ -184,6 +196,9 @@
     ],
     "name:oci_x_preferred":[
         "Su\u00e8z"
+    ],
+    "name:oss_x_preferred":[
+        "\u0421\u0443\u044d\u0446"
     ],
     "name:pol_x_preferred":[
         "Suez"
@@ -251,11 +266,20 @@
     "name:urd_x_preferred":[
         "\u0633\u0648\u0626\u06cc\u0632"
     ],
+    "name:uzb_x_preferred":[
+        "Suvaysh"
+    ],
+    "name:vec_x_preferred":[
+        "Suez"
+    ],
     "name:vie_x_preferred":[
         "Suez"
     ],
     "name:war_x_preferred":[
         "Suez"
+    ],
+    "name:wuu_x_preferred":[
+        "\u82cf\u4f0a\u58eb"
     ],
     "name:yue_x_preferred":[
         "\u8607\u4f0a\u58eb"
@@ -265,6 +289,9 @@
     ],
     "name:zho_x_preferred":[
         "\u82cf\u4f0a\u58eb"
+    ],
+    "name:zul_x_preferred":[
+        "Suez"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Egypt",
@@ -405,7 +432,7 @@
         }
     ],
     "wof:id":421168705,
-    "wof:lastmodified":1566586554,
+    "wof:lastmodified":1690876047,
     "wof:name":"\u0627\u0644\u0633\u0648\u064a\u0633",
     "wof:parent_id":1092016803,
     "wof:placetype":"locality",

--- a/data/421/168/709/421168709.geojson
+++ b/data/421/168/709/421168709.geojson
@@ -23,8 +23,14 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0645\u0646\u064a\u0627"
     ],
+    "name:ast_x_preferred":[
+        "Minya"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0646\u06cc\u0627"
+    ],
+    "name:aze_x_preferred":[
+        "\u018fl-Minya"
     ],
     "name:ben_x_preferred":[
         "\u09ae\u09bf\u09a8\u0987\u09af\u09bc\u09be"
@@ -152,6 +158,9 @@
     "name:tel_x_preferred":[
         "\u0c2e\u0c3f\u0c28\u0c4d\u0c2f"
     ],
+    "name:tgk_x_preferred":[
+        "\u0410\u043b-\u041c\u0438\u043d\u0451"
+    ],
     "name:tha_x_preferred":[
         "\u0e21\u0e34\u0e19\u0e22\u0e32"
     ],
@@ -173,6 +182,12 @@
     "name:urd_x_variant":[
         "\u0645\u0646\u06cc\u0627"
     ],
+    "name:uzb_x_preferred":[
+        "Minyo"
+    ],
+    "name:vec_x_preferred":[
+        "Minya"
+    ],
     "name:vie_x_preferred":[
         "Minya"
     ],
@@ -181,6 +196,9 @@
     ],
     "name:zho_x_preferred":[
         "\u660e\u4e9a"
+    ],
+    "name:zul_x_preferred":[
+        "Minya"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Egypt",
@@ -321,7 +339,7 @@
         }
     ],
     "wof:id":421168709,
-    "wof:lastmodified":1566586554,
+    "wof:lastmodified":1690876046,
     "wof:name":"\u0627\u0644\u0645\u0646\u064a\u0627",
     "wof:parent_id":1092018557,
     "wof:placetype":"locality",

--- a/data/421/168/711/421168711.geojson
+++ b/data/421/168/711/421168711.geojson
@@ -26,11 +26,20 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0641\u064a\u0648\u0645"
     ],
+    "name:ast_x_preferred":[
+        "Faiyum"
+    ],
     "name:azb_x_preferred":[
         "\u0641\u06cc\u0648\u0645"
     ],
+    "name:aze_x_preferred":[
+        "\u018fl-F\u0259yyum"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u042d\u043b\u044c-\u0424\u0430\u044e\u043c"
+    ],
+    "name:bel_x_variant":[
+        "\u042d\u043b\u044c-\u0424\u0430\u044e\u043c"
     ],
     "name:ben_x_preferred":[
         "\u09ab\u09be\u0987\u0987\u09af\u09bc\u09cb\u09ae"
@@ -45,7 +54,8 @@
         "Faium"
     ],
     "name:cat_x_variant":[
-        "Madinat al-Fayyum"
+        "Madinat al-Fayyum",
+        "El Faium"
     ],
     "name:ceb_x_preferred":[
         "Al Fayy\u016bm"
@@ -177,7 +187,8 @@
         "\u0410\u043b\u044c-\u0424\u0430\u044e\u043c"
     ],
     "name:rus_x_variant":[
-        "\u0424\u0430\u0439\u044e\u043c"
+        "\u0424\u0430\u0439\u044e\u043c",
+        "\u042d\u043b\u044c-\u0424\u0430\u0439\u044e\u043c"
     ],
     "name:sco_x_preferred":[
         "Faiyum"
@@ -209,6 +220,9 @@
     "name:tel_x_preferred":[
         "\u0c2b\u0c3e\u0c2f\u0c41\u0c2e\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u0410\u043b-\u0424\u0430\u0439\u044e\u043c"
+    ],
     "name:tha_x_preferred":[
         "\u0e44\u0e1f\u0e22\u0e31\u0e21"
     ],
@@ -227,6 +241,12 @@
     "name:urd_x_preferred":[
         "\u0641\u06cc\u0648\u0645"
     ],
+    "name:uzb_x_preferred":[
+        "Fayyum"
+    ],
+    "name:vec_x_preferred":[
+        "Fayyum"
+    ],
     "name:vie_x_preferred":[
         "Faiyum"
     ],
@@ -238,6 +258,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6cd5\u5c24\u59c6"
+    ],
+    "name:zul_x_preferred":[
+        "Faiyum"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Egypt",
@@ -379,7 +402,7 @@
         }
     ],
     "wof:id":421168711,
-    "wof:lastmodified":1566586555,
+    "wof:lastmodified":1690876048,
     "wof:name":"\u0627\u0644\u0641\u064a\u0648\u0645",
     "wof:parent_id":1092017705,
     "wof:placetype":"locality",

--- a/data/421/170/481/421170481.geojson
+++ b/data/421/170/481/421170481.geojson
@@ -29,6 +29,12 @@
     "name:arz_x_preferred":[
         "\u0647\u0644\u064a\u0648\u0628\u0648\u0644\u064a\u0633"
     ],
+    "name:ast_x_preferred":[
+        "Heliopolis"
+    ],
+    "name:aze_x_preferred":[
+        "Heliopol"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u0435\u043b\u0456\u0451\u043f\u0430\u043b\u044c"
     ],
@@ -104,8 +110,17 @@
     "name:kor_x_preferred":[
         "\ud5ec\ub9ac\uc624\ud3f4\ub9ac\uc2a4"
     ],
+    "name:lat_x_preferred":[
+        "Heliopolis"
+    ],
     "name:lit_x_preferred":[
         "Heliopolis"
+    ],
+    "name:mar_x_preferred":[
+        "\u0939\u0947\u0932\u093f\u0913\u092a\u094b\u0932\u093f\u0938"
+    ],
+    "name:mlg_x_preferred":[
+        "Heli\u00f4p\u00f4lisy"
     ],
     "name:nld_x_preferred":[
         "Heliopolis"
@@ -137,14 +152,26 @@
     "name:spa_x_preferred":[
         "Heli\u00f3polis"
     ],
+    "name:srp_x_preferred":[
+        "\u0425\u0435\u043b\u0438\u043e\u043f\u043e\u043b\u0438\u0441"
+    ],
     "name:swe_x_preferred":[
         "Heliopolis"
+    ],
+    "name:tam_x_preferred":[
+        "\u0bb9\u0bc6\u0bb2\u0bcd\u0bb2\u0bbf\u0baf\u0bcb\u0baa\u0bcb\u0bb2\u0bbf\u0bb8\u0bcd"
+    ],
+    "name:tgk_x_preferred":[
+        "\u04b2\u0435\u043b\u0438\u044e\u043f\u0443\u043b\u0438\u0441"
     ],
     "name:tgl_x_preferred":[
         "Heliopolis"
     ],
     "name:tha_x_preferred":[
         "\u0e40\u0e2e\u0e25\u0e34\u0e42\u0e2d\u0e42\u0e1b\u0e25\u0e34\u0e2a"
+    ],
+    "name:tha_x_variant":[
+        "\u0e41\u0e2e\u0e25\u0e34\u0e2d\u0e39\u0e42\u0e1b\u0e25\u0e34\u0e2a"
     ],
     "name:tur_x_preferred":[
         "Heliopolis"
@@ -160,6 +187,12 @@
     ],
     "name:vie_x_preferred":[
         "Heliopolis"
+    ],
+    "name:war_x_preferred":[
+        "Heliopolis"
+    ],
+    "name:yue_x_preferred":[
+        "\u5e0c\u91cc\u5967\u6ce2\u91cc\u65af"
     ],
     "name:zho_x_preferred":[
         "\u8d6b\u91cc\u5965\u6ce2\u91cc\u65af"
@@ -210,7 +243,7 @@
         }
     ],
     "wof:id":421170481,
-    "wof:lastmodified":1566586570,
+    "wof:lastmodified":1690876059,
     "wof:name":"Heliopolis",
     "wof:parent_id":1092021387,
     "wof:placetype":"locality",

--- a/data/421/172/915/421172915.geojson
+++ b/data/421/172/915/421172915.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u062f\u0631\u0627\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u0631\u0627\u0648"
+    ],
+    "name:ast_x_preferred":[
+        "Daraw"
+    ],
     "name:deu_x_preferred":[
         "Darau"
     ],
@@ -38,8 +44,14 @@
     "name:pol_x_preferred":[
         "Darau"
     ],
+    "name:rus_x_preferred":[
+        "\u0414\u0430\u0440\u0430\u0443"
+    ],
     "name:spa_x_preferred":[
         "Daraw"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0414\u0430\u0440\u0430\u0432"
     ],
     "qs:gn_country":"EG",
     "qs:gn_fcode":"PPL",
@@ -86,7 +98,7 @@
         }
     ],
     "wof:id":421172915,
-    "wof:lastmodified":1566586566,
+    "wof:lastmodified":1690876057,
     "wof:name":"Daraw",
     "wof:parent_id":1092021927,
     "wof:placetype":"locality",

--- a/data/421/173/839/421173839.geojson
+++ b/data/421/173/839/421173839.geojson
@@ -41,11 +41,23 @@
     "name:eng_x_preferred":[
         "Ain Sukhna"
     ],
+    "name:eng_x_variant":[
+        "Ain Sokhna"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0639\u06cc\u0646 \u0627\u0644\u0633\u062e\u0646\u0629"
     ],
     "name:fra_x_preferred":[
         "Ain Sukhna"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e2\u05d9\u05df \u05e1\u05d5\u05d7\u05e0\u05d4"
+    ],
+    "name:ibo_x_preferred":[
+        "Ain Sokhna"
+    ],
+    "name:ita_x_preferred":[
+        "Ain Sokhna"
     ],
     "name:jpn_x_preferred":[
         "\u30a2\u30a4\u30f3\u30fb\u30b9\u30af\u30ca"
@@ -56,14 +68,23 @@
     "name:kor_x_preferred":[
         "\uc544\uc778 \uc218\ud06c\ub098"
     ],
+    "name:mlg_x_preferred":[
+        "Ain Sukhna"
+    ],
     "name:nld_x_preferred":[
         "Ain Sukhna"
     ],
     "name:pol_x_preferred":[
         "Ajn Suchna"
     ],
+    "name:ron_x_preferred":[
+        "Ain Sokhna"
+    ],
     "name:rus_x_preferred":[
         "\u0410\u0439\u043d-\u0421\u0443\u0445\u043d\u0430"
+    ],
+    "name:rus_x_variant":[
+        "\u0410\u0439\u043d-\u0421\u043e\u0445\u043d\u0430"
     ],
     "name:slv_x_preferred":[
         "Ain Suhna"
@@ -71,14 +92,29 @@
     "name:spa_x_preferred":[
         "Ain Sujna"
     ],
+    "name:swa_x_preferred":[
+        "Ain Sokhna"
+    ],
     "name:swe_x_preferred":[
         "Ain Sokhna"
     ],
     "name:ukr_x_preferred":[
         "\u0414\u0430\u0433\u0430\u0431"
     ],
+    "name:ukr_x_variant":[
+        "\u0410\u0457\u043d \u0421\u043e\u0445\u043d\u0430"
+    ],
     "name:und_x_variant":[
         "Ain El Sukhna"
+    ],
+    "name:urd_x_preferred":[
+        "\u0639\u06cc\u0646 \u0627\u0644\u0633\u062e\u0646\u06c1"
+    ],
+    "name:vie_x_preferred":[
+        "Ain Sokhna"
+    ],
+    "name:zho_x_preferred":[
+        "\u827e\u56e0\u00b7\u8607\u514b\u7d0d"
     ],
     "qs:gn_country":"EG",
     "qs:gn_fcode":"PPL",
@@ -127,7 +163,7 @@
         }
     ],
     "wof:id":421173839,
-    "wof:lastmodified":1566586561,
+    "wof:lastmodified":1690876055,
     "wof:name":"Ayn Sukhnah",
     "wof:parent_id":1092023197,
     "wof:placetype":"locality",

--- a/data/421/174/337/421174337.geojson
+++ b/data/421/174/337/421174337.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0642\u0648\u0635\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0642\u0648\u0635\u064a\u0629"
+    ],
+    "name:ast_x_preferred":[
+        "Cusae"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u0642\u0648\u0635\u06cc\u0647"
     ],
@@ -38,6 +44,9 @@
     "name:eng_x_preferred":[
         "Cusae"
     ],
+    "name:eng_x_variant":[
+        "El Quseyya"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0642\u0648\u0635\u06cc\u0647"
     ],
@@ -55,6 +64,9 @@
     ],
     "name:lit_x_preferred":[
         "Kusai"
+    ],
+    "name:mlg_x_preferred":[
+        "Al Q\u016b\u015f\u012byah"
     ],
     "name:nld_x_preferred":[
         "Cusae"
@@ -124,7 +136,7 @@
         }
     ],
     "wof:id":421174337,
-    "wof:lastmodified":1566586559,
+    "wof:lastmodified":1690876052,
     "wof:name":"Al Qusiyah",
     "wof:parent_id":1092019229,
     "wof:placetype":"locality",

--- a/data/421/174/339/421174339.geojson
+++ b/data/421/174/339/421174339.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0643\u0641\u0631 \u0635\u0642\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0641\u0631 \u0635\u0642\u0631"
+    ],
     "name:azb_x_preferred":[
         "\u06a9\u0641\u0631 \u0635\u0642\u0631"
     ],
@@ -41,6 +44,9 @@
     "name:pol_x_preferred":[
         "Kafr Sakr"
     ],
+    "name:rus_x_preferred":[
+        "\u041a\u0430\u0444\u0440-\u0421\u0430\u043a\u0440"
+    ],
     "name:swe_x_preferred":[
         "Kafr \u015eaqr"
     ],
@@ -49,6 +55,9 @@
     ],
     "name:und_x_variant":[
         "Kafr \u1e62aqr"
+    ],
+    "name:zul_x_preferred":[
+        "Kafr Saqr"
     ],
     "qs:gn_country":"EG",
     "qs:gn_fcode":"PPL",
@@ -98,7 +107,7 @@
         }
     ],
     "wof:id":421174339,
-    "wof:lastmodified":1566586559,
+    "wof:lastmodified":1690876052,
     "wof:name":"Kafr Saqr",
     "wof:parent_id":1092021715,
     "wof:placetype":"locality",

--- a/data/421/174/399/421174399.geojson
+++ b/data/421/174/399/421174399.geojson
@@ -35,11 +35,17 @@
     "name:amh_x_preferred":[
         "\u12ab\u12ed\u122e"
     ],
+    "name:anp_x_preferred":[
+        "\u0915\u093e\u0939\u093f\u0930\u093e"
+    ],
     "name:ara_x_preferred":[
         "\u0627\u0644\u0642\u0627\u0647\u0631\u0629"
     ],
     "name:arg_x_preferred":[
         "O Caire"
+    ],
+    "name:ary_x_preferred":[
+        "\u0644\u0642\u0627\u0647\u0631\u0629"
     ],
     "name:arz_x_preferred":[
         "\u0627\u0644\u0642\u0627\u0647\u0631\u0647"
@@ -50,6 +56,12 @@
     "name:ava_x_preferred":[
         "\u041a\u0430\u0438\u0440"
     ],
+    "name:avk_x_preferred":[
+        "Alkaira"
+    ],
+    "name:awa_x_preferred":[
+        "\u0915\u093e\u0907\u0930\u094b"
+    ],
     "name:azb_x_preferred":[
         "\u0642\u0627\u0647\u06cc\u0631\u0647"
     ],
@@ -58,6 +70,12 @@
     ],
     "name:bak_x_preferred":[
         "\u04a0\u04d9\u04bb\u0438\u0440"
+    ],
+    "name:bak_x_variant":[
+        "\u04a0\u0430\u04bb\u0438\u0440\u04d9"
+    ],
+    "name:ban_x_preferred":[
+        "Kairo"
     ],
     "name:bcl_x_preferred":[
         "Cairo"
@@ -110,11 +128,17 @@
     "name:chv_x_preferred":[
         "\u041a\u0430\u0438\u0440"
     ],
+    "name:chy_x_preferred":[
+        "Cairo"
+    ],
     "name:ckb_x_preferred":[
         "\u0642\u0627\u06be\u06cc\u0631\u06d5"
     ],
     "name:cor_x_preferred":[
         "Cairo"
+    ],
+    "name:cos_x_preferred":[
+        "U Cairu"
     ],
     "name:crh_x_preferred":[
         "Qaire"
@@ -188,6 +212,9 @@
     "name:fry_x_preferred":[
         "Kairo"
     ],
+    "name:fur_x_preferred":[
+        "El Cairo"
+    ],
     "name:gcr_x_preferred":[
         "K\u00e8ro"
     ],
@@ -205,6 +232,12 @@
     ],
     "name:glv_x_preferred":[
         "Cairo"
+    ],
+    "name:gpe_x_preferred":[
+        "Cairo"
+    ],
+    "name:grn_x_preferred":[
+        "K\u00e1iro"
     ],
     "name:gsw_x_preferred":[
         "Kairo"
@@ -299,6 +332,9 @@
     "name:kaz_x_preferred":[
         "\u04d8\u043b-\u049a\u0430\u04bb\u0438\u0440\u0430"
     ],
+    "name:kaz_x_variant":[
+        "\u041a\u0430\u0438\u0440"
+    ],
     "name:kbp_x_preferred":[
         "K\u025b\u025br\u0269"
     ],
@@ -319,6 +355,9 @@
     ],
     "name:lad_x_preferred":[
         "El Kairo"
+    ],
+    "name:lao_x_preferred":[
+        "\u0ec4\u0e84\u0ec2\u0ea3"
     ],
     "name:lat_x_preferred":[
         "Cairus"
@@ -347,6 +386,9 @@
     "name:lit_x_preferred":[
         "Kairas"
     ],
+    "name:lld_x_preferred":[
+        "L Cairo"
+    ],
     "name:lmo_x_preferred":[
         "El Cairo"
     ],
@@ -354,6 +396,9 @@
         "\u0642\u0627\u0647\u0631\u0647"
     ],
     "name:ltz_x_preferred":[
+        "Kairo"
+    ],
+    "name:mad_x_preferred":[
         "Kairo"
     ],
     "name:mai_x_preferred":[
@@ -379,6 +424,12 @@
     ],
     "name:mlg_x_preferred":[
         "Kairo"
+    ],
+    "name:mlt_x_preferred":[
+        "Kajr"
+    ],
+    "name:mni_x_preferred":[
+        "\uabc0\uabe5\uabcf\uabd4\uabe3"
     ],
     "name:mon_x_preferred":[
         "\u041a\u0430\u0438\u0440"
@@ -415,6 +466,9 @@
     ],
     "name:nau_x_preferred":[
         "Cairo"
+    ],
+    "name:nav_x_preferred":[
+        "Yadaaz\u02bc\u00e1h\u00ed\u0142\u00e1n\u00ed"
     ],
     "name:nds_x_preferred":[
         "Kairo"
@@ -533,6 +587,12 @@
     "name:sme_x_preferred":[
         "Cairo"
     ],
+    "name:smn_x_preferred":[
+        "Kairo"
+    ],
+    "name:sms_x_preferred":[
+        "Kairo"
+    ],
     "name:sna_x_preferred":[
         "Cairo"
     ],
@@ -556,6 +616,9 @@
     ],
     "name:srp_x_preferred":[
         "\u041a\u0430\u0438\u0440\u043e"
+    ],
+    "name:ssw_x_preferred":[
+        "Cairo"
     ],
     "name:sun_x_preferred":[
         "Kairo"
@@ -677,6 +740,9 @@
     ],
     "name:zho_x_preferred":[
         "\u958b\u7f85"
+    ],
+    "name:zul_x_preferred":[
+        "Cairo"
     ],
     "ne:ADM0CAP":1.0,
     "ne:ADM0NAME":"Egypt",
@@ -829,7 +895,7 @@
         }
     ],
     "wof:id":421174399,
-    "wof:lastmodified":1617131298,
+    "wof:lastmodified":1690876052,
     "wof:megacity":1,
     "wof:name":"\u0627\u0644\u0642\u0627\u0647\u0631\u0629",
     "wof:parent_id":1092016929,

--- a/data/421/174/879/421174879.geojson
+++ b/data/421/174/879/421174879.geojson
@@ -26,6 +26,12 @@
     "name:arz_x_preferred":[
         "\u0637\u0627\u0628\u0627"
     ],
+    "name:ast_x_preferred":[
+        "Taba"
+    ],
+    "name:azb_x_preferred":[
+        "\u0637\u0627\u0628\u0627"
+    ],
     "name:bul_x_preferred":[
         "\u0422\u0430\u0431\u0430"
     ],
@@ -50,6 +56,9 @@
     "name:fas_x_preferred":[
         "\u0637\u0627\u0628\u0627"
     ],
+    "name:fin_x_preferred":[
+        "Taba"
+    ],
     "name:fra_x_preferred":[
         "Taba"
     ],
@@ -58,6 +67,9 @@
     ],
     "name:heb_x_preferred":[
         "\u05d8\u05d0\u05d1\u05d4"
+    ],
+    "name:ibo_x_preferred":[
+        "Taba"
     ],
     "name:ita_x_preferred":[
         "Taba"
@@ -101,11 +113,17 @@
     "name:srp_x_preferred":[
         "\u0422\u0430\u0431\u0430"
     ],
+    "name:swa_x_preferred":[
+        "Taba"
+    ],
     "name:swe_x_preferred":[
         "Taba"
     ],
     "name:ukr_x_preferred":[
         "\u0422\u0430\u0431\u0430"
+    ],
+    "name:urd_x_preferred":[
+        "\u0637\u0627\u0628\u0627"
     ],
     "name:zho_x_preferred":[
         "\u5854\u5df4"
@@ -155,7 +173,7 @@
         }
     ],
     "wof:id":421174879,
-    "wof:lastmodified":1566586560,
+    "wof:lastmodified":1690876053,
     "wof:name":"Taba",
     "wof:parent_id":85672531,
     "wof:placetype":"locality",

--- a/data/421/175/063/421175063.geojson
+++ b/data/421/175/063/421175063.geojson
@@ -20,8 +20,14 @@
     "name:ara_x_preferred":[
         "\u062f\u0643\u0631\u0646\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u0643\u0631\u0646\u0633"
+    ],
     "name:azb_x_preferred":[
         "\u062f\u06a9\u0631\u0646\u0633"
+    ],
+    "name:bul_x_preferred":[
+        "\u0414\u0438\u043a\u0438\u0440\u043d\u0438\u0441"
     ],
     "name:ceb_x_preferred":[
         "Markaz Dikirnis"
@@ -41,6 +47,9 @@
     "name:kaz_x_preferred":[
         "\u0414\u0438\u043a\u0438\u0440\u043d\u0438\u0441 \u049b\u0430\u043b\u0430\u0441\u044b"
     ],
+    "name:mlg_x_preferred":[
+        "Dikirnis"
+    ],
     "name:nld_x_preferred":[
         "Dikirnis"
     ],
@@ -56,6 +65,9 @@
     "name:sco_x_preferred":[
         "Dikirnis"
     ],
+    "name:spa_x_preferred":[
+        "Dikirnis"
+    ],
     "name:swe_x_preferred":[
         "Markaz Dikirnis"
     ],
@@ -67,6 +79,9 @@
     ],
     "name:urd_x_preferred":[
         "\u062f\u06a9\u0631\u0646\u0633"
+    ],
+    "name:zul_x_preferred":[
+        "Dekernes"
     ],
     "qs:gn_country":"EG",
     "qs:gn_fcode":"PPL",
@@ -115,7 +130,7 @@
         }
     ],
     "wof:id":421175063,
-    "wof:lastmodified":1566586567,
+    "wof:lastmodified":1690876057,
     "wof:name":"Dikirnis",
     "wof:parent_id":1092016227,
     "wof:placetype":"locality",

--- a/data/421/175/733/421175733.geojson
+++ b/data/421/175/733/421175733.geojson
@@ -20,8 +20,23 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0642\u0627\u0647\u0631\u0629 \u0627\u0644\u062c\u062f\u064a\u062f\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0642\u0627\u0647\u0631\u0647 \u0627\u0644\u062c\u062f\u064a\u062f\u0647"
+    ],
+    "name:ast_x_preferred":[
+        "New Cairo"
+    ],
+    "name:aze_x_preferred":[
+        "Yeni Qahir\u0259"
+    ],
     "name:ben_x_preferred":[
         "\u09a8\u09bf\u0989 \u0995\u09be\u09af\u09bc\u09b0\u09cb"
+    ],
+    "name:ben_x_variant":[
+        "\u09a8\u09a4\u09c1\u09a8 \u0995\u09be\u09af\u09bc\u09b0\u09cb"
+    ],
+    "name:ces_x_preferred":[
+        "Nov\u00e1 K\u00e1hira"
     ],
     "name:dan_x_preferred":[
         "New Cairo"
@@ -44,17 +59,29 @@
     "name:fra_x_preferred":[
         "Nouveau Caire"
     ],
+    "name:gle_x_preferred":[
+        "New Cairo"
+    ],
     "name:guj_x_preferred":[
         "\u0aa8\u0acd\u0aaf\u0ac2 \u0a95\u0ac8\u0ab0\u0acb"
     ],
+    "name:heb_x_preferred":[
+        "\u05e7\u05d4\u05d9\u05e8 \u05d4\u05d7\u05d3\u05e9\u05d4"
+    ],
     "name:hin_x_preferred":[
         "\u0928\u094d\u092f\u0942 \u0915\u093e\u0907\u0930\u094b"
+    ],
+    "name:hye_x_preferred":[
+        "\u0546\u0578\u0580 \u053f\u0561\u0570\u056b\u0580\u0565"
     ],
     "name:ind_x_preferred":[
         "New Cairo"
     ],
     "name:ita_x_preferred":[
         "New Cairo"
+    ],
+    "name:ita_x_variant":[
+        "Nuovo Cairo"
     ],
     "name:jpn_x_preferred":[
         "\u30cb\u30e5\u30fc\u30ab\u30a4\u30ed"
@@ -64,6 +91,9 @@
     ],
     "name:kor_x_preferred":[
         "\ub274 \uce74\uc774\ub85c"
+    ],
+    "name:kor_x_variant":[
+        "\ub274\uce74\uc774\ub85c"
     ],
     "name:lav_x_preferred":[
         "\u0145ukairo"
@@ -76,6 +106,9 @@
     ],
     "name:mar_x_preferred":[
         "\u0928\u094d\u092f\u0942 \u0915\u0945\u0930\u094b"
+    ],
+    "name:mlg_x_preferred":[
+        "New Cairo"
     ],
     "name:msa_x_preferred":[
         "New Cairo"
@@ -91,6 +124,9 @@
     ],
     "name:rus_x_preferred":[
         "\u041d\u044c\u044e-\u041a\u0430\u0439\u0440\u043e"
+    ],
+    "name:rus_x_variant":[
+        "\u041d\u044c\u044e-\u041a\u0430\u0438\u0440"
     ],
     "name:sin_x_preferred":[
         "\u0db1\u0dc0 \u0d9a\u0dba\u0dd2\u0dbb\u0ddd"
@@ -122,11 +158,17 @@
     "name:urd_x_preferred":[
         "\u0646\u06cc\u0648 \u06a9\u0627\u06cc\u0631\u0648"
     ],
+    "name:vec_x_preferred":[
+        "New Cairo"
+    ],
     "name:vie_x_preferred":[
         "New Cairo"
     ],
     "name:zho_x_preferred":[
         "\u65b0\u5f00\u7f57"
+    ],
+    "name:zul_x_preferred":[
+        "New Cairo"
     ],
     "qs:gn_country":"EG",
     "qs:gn_fcode":"PPL",
@@ -186,7 +228,7 @@
         }
     ],
     "wof:id":421175733,
-    "wof:lastmodified":1566586567,
+    "wof:lastmodified":1690876058,
     "wof:name":"New Cairo",
     "wof:parent_id":1092022997,
     "wof:placetype":"locality",

--- a/data/421/176/919/421176919.geojson
+++ b/data/421/176/919/421176919.geojson
@@ -35,8 +35,14 @@
     "name:azb_x_preferred":[
         "\u062f\u0645\u06cc\u0627\u0637"
     ],
+    "name:aze_x_preferred":[
+        "D\u00fcmyat"
+    ],
     "name:bel_x_preferred":[
         "\u0414\u0443\u043c'\u044f\u0442"
+    ],
+    "name:ben_x_preferred":[
+        "\u09a6\u09ae\u0987\u09af\u09bc\u09be\u09a4"
     ],
     "name:bul_x_preferred":[
         "\u0414\u0430\u043c\u0438\u0435\u0442\u0430"
@@ -44,8 +50,14 @@
     "name:cat_x_preferred":[
         "Damieta"
     ],
+    "name:cat_x_variant":[
+        "Damiata"
+    ],
     "name:ceb_x_preferred":[
         "Mu\u1e29\u0101faz\u0327at Dumy\u0101\u0163"
+    ],
+    "name:ceb_x_variant":[
+        "Dumy\u0101\u0163"
     ],
     "name:ces_x_preferred":[
         "Damietta"
@@ -76,6 +88,9 @@
     ],
     "name:fra_x_preferred":[
         "Damiette"
+    ],
+    "name:gle_x_preferred":[
+        "Damietta"
     ],
     "name:heb_x_preferred":[
         "\u05d3\u05d5\u05de\u05d9\u05d0\u05d8"
@@ -116,11 +131,20 @@
     "name:lit_x_preferred":[
         "Dumjatas"
     ],
+    "name:mkd_x_preferred":[
+        "\u0414\u0430\u043c\u0438\u0458\u0435\u0442\u0430"
+    ],
+    "name:mlg_x_preferred":[
+        "Damietta"
+    ],
     "name:nld_x_preferred":[
         "Damietta"
     ],
     "name:nob_x_preferred":[
         "Damietta"
+    ],
+    "name:oci_x_preferred":[
+        "Damieta"
     ],
     "name:pan_x_preferred":[
         "\u0a26\u0a2e\u0a40\u0a06\u0a24"
@@ -155,11 +179,17 @@
     "name:swe_x_preferred":[
         "Damietta"
     ],
+    "name:tgk_x_preferred":[
+        "\u0414\u0443\u043c\u0451\u0442"
+    ],
     "name:tha_x_preferred":[
         "\u0e14\u0e32\u0e40\u0e21\u0e35\u0e22\u0e15\u0e15\u0e32"
     ],
     "name:tur_x_preferred":[
         "Dimyat"
+    ],
+    "name:uig_x_preferred":[
+        "\u062f\u06c7\u0645\u064a\u0627\u062a"
     ],
     "name:ukr_x_preferred":[
         "\u0414\u0443\u043c\u044f\u0442"
@@ -169,6 +199,12 @@
     ],
     "name:urd_x_preferred":[
         "\u062f\u0645\u06cc\u0627\u0637"
+    ],
+    "name:uzb_x_preferred":[
+        "Dumyot"
+    ],
+    "name:vec_x_preferred":[
+        "Damietta"
     ],
     "name:vie_x_preferred":[
         "Damiat"
@@ -181,6 +217,9 @@
     ],
     "name:zho_x_preferred":[
         "\u675c\u59c6\u4e9a\u7279"
+    ],
+    "name:zul_x_preferred":[
+        "Damietta"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Egypt",
@@ -321,7 +360,7 @@
         }
     ],
     "wof:id":421176919,
-    "wof:lastmodified":1636502267,
+    "wof:lastmodified":1690876060,
     "wof:name":"Dumyat",
     "wof:parent_id":1092016349,
     "wof:placetype":"locality",

--- a/data/421/177/745/421177745.geojson
+++ b/data/421/177/745/421177745.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0639\u0632\u0628\u0629 \u0627\u0644\u0628\u0631\u062c"
     ],
+    "name:ast_x_preferred":[
+        "Ezbet El Borg"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u0632\u0628\u0647 \u0627\u0644\u0628\u0631\u062c"
     ],
@@ -61,6 +64,9 @@
     ],
     "name:und_x_variant":[
         "\u2018Ezbet el-Burg"
+    ],
+    "name:zul_x_preferred":[
+        "Ezbet El Borg"
     ],
     "qs:gn_country":"EG",
     "qs:gn_fcode":"PPL",
@@ -108,7 +114,7 @@
         }
     ],
     "wof:id":421177745,
-    "wof:lastmodified":1566586571,
+    "wof:lastmodified":1690876059,
     "wof:name":"Izbat al Burj",
     "wof:parent_id":1092016349,
     "wof:placetype":"locality",

--- a/data/421/181/323/421181323.geojson
+++ b/data/421/181/323/421181323.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u062f\u064a\u0631 \u0645\u0648\u0627\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u064a\u0631 \u0645\u0648\u0627\u0633"
+    ],
+    "name:ast_x_preferred":[
+        "Deir Mawas"
+    ],
     "name:azb_x_preferred":[
         "\u062f\u06cc\u0631 \u0645\u0648\u0627\u0633"
     ],
@@ -41,6 +47,9 @@
     "name:kat_x_preferred":[
         "\u10d3\u10d4\u10d8\u10e0-\u10db\u10d0\u10d5\u10d0\u10e1\u10d8"
     ],
+    "name:mlg_x_preferred":[
+        "Dayr Maw\u0101s"
+    ],
     "name:nld_x_preferred":[
         "Deir Mawas"
     ],
@@ -52,6 +61,9 @@
     ],
     "name:swe_x_preferred":[
         "Dayr Maw\u0101s"
+    ],
+    "name:zul_x_preferred":[
+        "Dir Mawas"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -103,7 +115,7 @@
         }
     ],
     "wof:id":421181323,
-    "wof:lastmodified":1566586567,
+    "wof:lastmodified":1690876057,
     "wof:name":"Deir Mawas",
     "wof:parent_id":1092016033,
     "wof:placetype":"locality",

--- a/data/421/183/509/421183509.geojson
+++ b/data/421/183/509/421183509.geojson
@@ -23,6 +23,9 @@
     "name:arz_x_preferred":[
         "\u0642\u0641\u0637"
     ],
+    "name:ast_x_preferred":[
+        "Qift"
+    ],
     "name:azb_x_preferred":[
         "\u0642\u0641\u0637"
     ],
@@ -49,6 +52,9 @@
     ],
     "name:fas_x_preferred":[
         "\u0642\u0641\u0637"
+    ],
+    "name:fin_x_preferred":[
+        "Koptos"
     ],
     "name:fra_x_preferred":[
         "Coptos"
@@ -92,8 +98,14 @@
     "name:spa_x_preferred":[
         "Coptos"
     ],
+    "name:srp_x_preferred":[
+        "\u041a\u043e\u043f\u0442\u043e\u0441"
+    ],
     "name:swe_x_preferred":[
         "Koptos"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e01\u0e34\u0e1f\u0e0f\u0e4c"
     ],
     "name:ukr_x_preferred":[
         "\u041a\u043e\u043f\u0442\u043e\u0441"
@@ -103,6 +115,9 @@
     ],
     "name:vie_x_preferred":[
         "Coptos"
+    ],
+    "name:zul_x_preferred":[
+        "Qift"
     ],
     "qs:gn_country":"EG",
     "qs:gn_fcode":"PPL",
@@ -156,7 +171,7 @@
         }
     ],
     "wof:id":421183509,
-    "wof:lastmodified":1566586571,
+    "wof:lastmodified":1690876060,
     "wof:name":"Qift",
     "wof:parent_id":1092020789,
     "wof:placetype":"locality",

--- a/data/421/187/133/421187133.geojson
+++ b/data/421/187/133/421187133.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0635\u0641\u0637 \u0627\u0644\u0644\u0628\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0635\u0641\u0637 \u0627\u0644\u0644\u0628\u0646"
+    ],
+    "name:azb_x_preferred":[
+        "\u0635\u0641\u0637 \u0627\u0644\u0644\u0628\u0646"
+    ],
     "name:eng_x_preferred":[
         "Saft El Laban"
     ],
@@ -83,7 +89,7 @@
         }
     ],
     "wof:id":421187133,
-    "wof:lastmodified":1566586561,
+    "wof:lastmodified":1690876053,
     "wof:name":"\u0635\u0641\u0637 \u0627\u0644\u0644\u0628\u0646",
     "wof:parent_id":1092020631,
     "wof:placetype":"locality",

--- a/data/421/187/135/421187135.geojson
+++ b/data/421/187/135/421187135.geojson
@@ -77,6 +77,9 @@
     "name:glg_x_preferred":[
         "Saqqara"
     ],
+    "name:hau_x_preferred":[
+        "Saqqara"
+    ],
     "name:hbs_x_preferred":[
         "Saqqara"
     ],
@@ -89,6 +92,12 @@
     "name:hun_x_preferred":[
         "Szakkara"
     ],
+    "name:hye_x_preferred":[
+        "\u054d\u0561\u056f\u056f\u0561\u0580\u0561"
+    ],
+    "name:ibo_x_preferred":[
+        "Saqqara"
+    ],
     "name:ind_x_preferred":[
         "Saqqara"
     ],
@@ -100,6 +109,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30b5\u30c3\u30ab\u30e9"
+    ],
+    "name:kor_x_preferred":[
+        "\uc0ac\uce74\ub77c"
     ],
     "name:lat_x_preferred":[
         "Necropolis Saqq\u0101ra"
@@ -150,6 +162,9 @@
     "name:sco_x_preferred":[
         "Saqqara"
     ],
+    "name:sin_x_preferred":[
+        "\u0dc3\u0d9a\u0dcf\u0dbb\u0dcf"
+    ],
     "name:slk_x_preferred":[
         "Sakk\u00e1ra"
     ],
@@ -168,6 +183,15 @@
     "name:swe_x_preferred":[
         "Sakkara"
     ],
+    "name:tam_x_preferred":[
+        "\u0b9a\u0b95\u0bcd\u0b95\u0bbe\u0bb0\u0bbe"
+    ],
+    "name:tgl_x_preferred":[
+        "Saqqara"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e0b\u0e31\u0e01\u0e01\u0e2d\u0e40\u0e23\u0e32\u0e30\u0e2e\u0e4c"
+    ],
     "name:tur_x_preferred":[
         "Sakkara piramidi"
     ],
@@ -182,6 +206,9 @@
     ],
     "name:war_x_preferred":[
         "Saqqara"
+    ],
+    "name:wuu_x_preferred":[
+        "\u8428\u5361\u62c9"
     ],
     "name:zho_x_preferred":[
         "\u85a9\u5361\u62c9"
@@ -236,7 +263,7 @@
         }
     ],
     "wof:id":421187135,
-    "wof:lastmodified":1566586560,
+    "wof:lastmodified":1690876053,
     "wof:name":"Saqqarah",
     "wof:parent_id":1092017019,
     "wof:placetype":"locality",

--- a/data/421/187/559/421187559.geojson
+++ b/data/421/187/559/421187559.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0631\u0641\u062d"
     ],
+    "name:arz_x_preferred":[
+        "\u0631\u0641\u062d"
+    ],
     "name:azb_x_preferred":[
         "\u0631\u0641\u062d"
     ],
@@ -37,6 +40,9 @@
     ],
     "name:fra_x_preferred":[
         "Rafah"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e8\u05e4\u05d9\u05d7 \u05d4\u05de\u05e6\u05e8\u05d9\u05ea"
     ],
     "name:ita_x_preferred":[
         "Rafah"
@@ -67,6 +73,9 @@
     ],
     "name:zho_x_variant":[
         "\u62c9\u6cd5\u8d6b"
+    ],
+    "name:zul_x_preferred":[
+        "Rafah"
     ],
     "qs:gn_country":"EG",
     "qs:gn_fcode":"PPL",
@@ -114,7 +123,7 @@
         }
     ],
     "wof:id":421187559,
-    "wof:lastmodified":1566586560,
+    "wof:lastmodified":1690876053,
     "wof:name":"Raf\u012bah",
     "wof:parent_id":1092023763,
     "wof:placetype":"locality",

--- a/data/421/187/713/421187713.geojson
+++ b/data/421/187/713/421187713.geojson
@@ -20,11 +20,23 @@
     "name:ara_x_preferred":[
         "\u062d\u0644\u0648\u0627\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u062d\u0644\u0648\u0627\u0646"
+    ],
+    "name:ast_x_preferred":[
+        "Helwan"
+    ],
     "name:azb_x_preferred":[
         "\u062d\u0644\u0648\u0627\u0646"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0425\u0435\u043b\u0443\u0430\u043d"
+    ],
+    "name:bel_x_variant":[
+        "\u0425\u0435\u043b\u0443\u0430\u043d"
+    ],
+    "name:ben_x_preferred":[
+        "\u09b9\u09c7\u09b2\u0993\u09af\u09bc\u09be\u09a8"
     ],
     "name:cat_x_preferred":[
         "Helwan"
@@ -56,6 +68,9 @@
     "name:fra_x_preferred":[
         "Helwan"
     ],
+    "name:gle_x_preferred":[
+        "Helwan"
+    ],
     "name:heb_x_preferred":[
         "\u05d7\u05dc\u05d5\u05d0\u05df"
     ],
@@ -63,6 +78,12 @@
         "\u0939\u0947\u0932\u0935\u093e\u0928"
     ],
     "name:hrv_x_preferred":[
+        "Helwan"
+    ],
+    "name:hye_x_preferred":[
+        "\u0540\u0565\u056c\u0578\u0582\u0561\u0576"
+    ],
+    "name:ind_x_preferred":[
         "Helwan"
     ],
     "name:ita_x_preferred":[
@@ -79,6 +100,9 @@
     ],
     "name:lit_x_preferred":[
         "Heluanas"
+    ],
+    "name:mri_x_preferred":[
+        "Herewana"
     ],
     "name:nld_x_preferred":[
         "Helwan"
@@ -104,6 +128,9 @@
     "name:swe_x_preferred":[
         "Helwan"
     ],
+    "name:tha_x_preferred":[
+        "\u0e40\u0e2e\u0e25\u0e27\u0e32\u0e19"
+    ],
     "name:tur_x_preferred":[
         "Helvan"
     ],
@@ -112,6 +139,12 @@
     ],
     "name:und_x_variant":[
         "H\u00e9louan-les-Bains"
+    ],
+    "name:urd_x_preferred":[
+        "\u062d\u0644\u0648\u0627\u0646"
+    ],
+    "name:vec_x_preferred":[
+        "Helwan"
     ],
     "name:war_x_preferred":[
         "Helwan"
@@ -166,7 +199,7 @@
         }
     ],
     "wof:id":421187713,
-    "wof:lastmodified":1566586561,
+    "wof:lastmodified":1690876054,
     "wof:name":"\u062d\u0644\u0648\u0627\u0646",
     "wof:parent_id":1092021427,
     "wof:placetype":"locality",

--- a/data/421/187/717/421187717.geojson
+++ b/data/421/187/717/421187717.geojson
@@ -86,6 +86,12 @@
     "name:hun_x_preferred":[
         "Dahab"
     ],
+    "name:hye_x_preferred":[
+        "\u0534\u0561\u0570\u0561\u0562"
+    ],
+    "name:ibo_x_preferred":[
+        "Dahab"
+    ],
     "name:ind_x_preferred":[
         "Dahab"
     ],
@@ -143,6 +149,9 @@
     "name:spa_x_preferred":[
         "Dahab"
     ],
+    "name:swa_x_preferred":[
+        "Dahab"
+    ],
     "name:swe_x_preferred":[
         "Dahab"
     ],
@@ -151,6 +160,9 @@
     ],
     "name:tel_x_preferred":[
         "\u0c26\u0c3e\u0c39\u0c2c\u0c4d"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0414\u0430\u04b3\u0430\u0431"
     ],
     "name:tha_x_preferred":[
         "\u0e14\u0e32\u0e2e\u0e31\u0e1a"
@@ -168,6 +180,9 @@
         "\u062f\u0627\u062d\u0627\u0628"
     ],
     "name:vie_x_preferred":[
+        "Dahab"
+    ],
+    "name:zul_x_preferred":[
         "Dahab"
     ],
     "qs:gn_country":"EG",
@@ -218,7 +233,7 @@
         }
     ],
     "wof:id":421187717,
-    "wof:lastmodified":1566586561,
+    "wof:lastmodified":1690876055,
     "wof:name":"Dhahab",
     "wof:parent_id":1092015881,
     "wof:placetype":"locality",

--- a/data/421/187/719/421187719.geojson
+++ b/data/421/187/719/421187719.geojson
@@ -20,11 +20,20 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0642\u0635\u064a\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0642\u0635\u064a\u0631"
+    ],
+    "name:ast_x_preferred":[
+        "El-Quseir"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u0642\u0635\u06cc\u0631"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u042d\u043b\u044c-\u041a\u0443\u0441\u0435\u0439\u0440"
+    ],
+    "name:bel_x_variant":[
+        "\u042d\u043b\u044c-\u041a\u0443\u0441\u0435\u0439\u0440"
     ],
     "name:ceb_x_preferred":[
         "Al Qu\u015fayr"
@@ -41,6 +50,9 @@
     "name:eng_x_preferred":[
         "Al-Qusayr"
     ],
+    "name:eng_x_variant":[
+        "El-Quseir"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0642\u0635\u06cc\u0631"
     ],
@@ -52,6 +64,9 @@
     ],
     "name:hun_x_preferred":[
         "Kuszeir"
+    ],
+    "name:hye_x_preferred":[
+        "\u0537\u056c-\u0554\u0578\u0582\u057d\u0565\u0575\u0580"
     ],
     "name:ita_x_preferred":[
         "Quseir"
@@ -80,11 +95,17 @@
     "name:sco_x_preferred":[
         "Al Qusayr"
     ],
+    "name:spa_x_preferred":[
+        "El-Qoseir"
+    ],
     "name:swe_x_preferred":[
         "El Quseir"
     ],
     "name:ukr_x_preferred":[
         "\u041a\u0443\u0441\u0435\u0439\u0440"
+    ],
+    "name:zul_x_preferred":[
+        "El Qoseir"
     ],
     "qs:gn_country":"EG",
     "qs:gn_fcode":"PPL",
@@ -138,7 +159,7 @@
         }
     ],
     "wof:id":421187719,
-    "wof:lastmodified":1566586561,
+    "wof:lastmodified":1690876054,
     "wof:name":"Al Qusayr",
     "wof:parent_id":1092019193,
     "wof:placetype":"locality",

--- a/data/421/187/721/421187721.geojson
+++ b/data/421/187/721/421187721.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0628\u0644\u064a\u0646\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0628\u0644\u064a\u0646\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "El-Balyana"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0644\u06cc\u0646\u0627"
     ],
@@ -28,6 +34,9 @@
     ],
     "name:deu_x_preferred":[
         "al-Balyana"
+    ],
+    "name:ell_x_preferred":[
+        "\u0395\u03bb \u039c\u03c0\u03b1\u03bb\u03b9\u03ac\u03bd\u03b1"
     ],
     "name:eng_x_preferred":[
         "El-Balyana"
@@ -43,6 +52,9 @@
     ],
     "name:kat_x_preferred":[
         "\u10d4\u10da-\u10d1\u10d0\u10da\u10e3\u10d0\u10dc\u10d0"
+    ],
+    "name:mlg_x_preferred":[
+        "Al Balyan\u0101"
     ],
     "name:nld_x_preferred":[
         "Balyana"
@@ -61,6 +73,9 @@
     ],
     "name:vie_x_preferred":[
         "Balyana"
+    ],
+    "name:zul_x_preferred":[
+        "El Balyana"
     ],
     "qs:gn_country":"EG",
     "qs:gn_fcode":"PPL",
@@ -114,7 +129,7 @@
         }
     ],
     "wof:id":421187721,
-    "wof:lastmodified":1566586561,
+    "wof:lastmodified":1690876054,
     "wof:name":"El Balyana",
     "wof:parent_id":1092017143,
     "wof:placetype":"locality",

--- a/data/421/187/723/421187723.geojson
+++ b/data/421/187/723/421187723.geojson
@@ -26,11 +26,17 @@
     "name:arz_x_preferred":[
         "\u0642\u0646\u0627"
     ],
+    "name:ast_x_preferred":[
+        "Qena"
+    ],
     "name:azb_x_preferred":[
         "\u0642\u0646\u0627"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041a\u0435\u043d\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u041a\u0435\u043d\u0430"
     ],
     "name:ben_x_preferred":[
         "\u0995\u09c1\u09af\u09bc\u09c7\u09a8\u09be"
@@ -182,6 +188,9 @@
     "name:urd_x_preferred":[
         "\u0642\u0646\u0627"
     ],
+    "name:vec_x_preferred":[
+        "Qena"
+    ],
     "name:vie_x_preferred":[
         "Qena"
     ],
@@ -190,6 +199,9 @@
     ],
     "name:zho_x_preferred":[
         "\u57fa\u7d0d"
+    ],
+    "name:zul_x_preferred":[
+        "Qena"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Egypt",
@@ -330,7 +342,7 @@
         }
     ],
     "wof:id":421187723,
-    "wof:lastmodified":1566586561,
+    "wof:lastmodified":1690876054,
     "wof:name":"\u0642\u0646\u0627",
     "wof:parent_id":1092023527,
     "wof:placetype":"locality",

--- a/data/421/188/303/421188303.geojson
+++ b/data/421/188/303/421188303.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0637\u0645\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0637\u0645\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Tima"
+    ],
     "name:azb_x_preferred":[
         "\u0637\u0645\u0627"
     ],
@@ -53,8 +59,14 @@
     "name:rus_x_preferred":[
         "\u0422\u0438\u043c\u0430"
     ],
+    "name:tha_x_preferred":[
+        "\u0e0f\u0e34\u0e21\u0e32"
+    ],
     "name:und_x_variant":[
         "\u0162im\u0101"
+    ],
+    "name:zul_x_preferred":[
+        "Tima"
     ],
     "qs:gn_country":"EG",
     "qs:gn_fcode":"PPL",
@@ -102,7 +114,7 @@
         }
     ],
     "wof:id":421188303,
-    "wof:lastmodified":1566586566,
+    "wof:lastmodified":1690876057,
     "wof:name":"\u0637\u0645\u0627",
     "wof:parent_id":1092025329,
     "wof:placetype":"locality",

--- a/data/421/189/899/421189899.geojson
+++ b/data/421/189/899/421189899.geojson
@@ -59,6 +59,9 @@
     "name:fra_x_variant":[
         "s\u00e9rap\u00e9um"
     ],
+    "name:grc_x_preferred":[
+        "\u03a3\u03b5\u03c1\u03b1\u03c0\u03b5\u1fd6\u03bf\u03bd"
+    ],
     "name:hbs_x_preferred":[
         "Serapeum"
     ],
@@ -77,8 +80,17 @@
     "name:jpn_x_preferred":[
         "\u30bb\u30e9\u30da\u30a6\u30e0"
     ],
+    "name:lat_x_preferred":[
+        "Serapeum"
+    ],
     "name:nld_x_preferred":[
         "Serapeum"
+    ],
+    "name:nld_x_variant":[
+        "serapeum"
+    ],
+    "name:nob_x_preferred":[
+        "Serapeion"
     ],
     "name:pol_x_preferred":[
         "Serapejon"
@@ -149,7 +161,7 @@
         }
     ],
     "wof:id":421189899,
-    "wof:lastmodified":1566586565,
+    "wof:lastmodified":1690876056,
     "wof:name":"Sarapeum",
     "wof:parent_id":1092020945,
     "wof:placetype":"locality",

--- a/data/421/189/901/421189901.geojson
+++ b/data/421/189/901/421189901.geojson
@@ -23,6 +23,9 @@
     "name:arn_x_preferred":[
         "abu simbel"
     ],
+    "name:arz_x_preferred":[
+        "\u0623\u0628\u0648 \u0633\u0645\u0628\u0644"
+    ],
     "name:ceb_x_preferred":[
         "Ab\u016b Sunbul"
     ],
@@ -46,6 +49,12 @@
     ],
     "name:hun_x_preferred":[
         "Abu Szimbel"
+    ],
+    "name:ibo_x_preferred":[
+        "Ab\u1ee5 Simbel"
+    ],
+    "name:ita_x_preferred":[
+        "Abu Simbel"
     ],
     "name:jpn_x_preferred":[
         "\u30a2\u30d6\u30fb\u30b7\u30f3\u30d9\u30eb"
@@ -71,14 +80,23 @@
     "name:spa_x_preferred":[
         "Abu Simbel"
     ],
+    "name:swa_x_preferred":[
+        "Abu Simbel"
+    ],
     "name:swe_x_preferred":[
         "Abu Simbel"
+    ],
+    "name:tam_x_preferred":[
+        "\u0b85\u0baa\u0bc1 \u0b9a\u0bbf\u0bae\u0bcd\u0baa\u0bc6\u0bb2\u0bcd"
     ],
     "name:ukr_x_preferred":[
         "\u0410\u0431\u0443-\u0421\u0456\u043c\u0431\u0435\u043b"
     ],
     "name:war_x_preferred":[
         "Abu Simbel"
+    ],
+    "name:zho_x_preferred":[
+        "\u963f\u5e03\u8f9b\u8d1d"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -124,7 +142,7 @@
         }
     ],
     "wof:id":421189901,
-    "wof:lastmodified":1566586562,
+    "wof:lastmodified":1690876055,
     "wof:name":"Abu Simbel",
     "wof:parent_id":1092022915,
     "wof:placetype":"locality",

--- a/data/421/189/939/421189939.geojson
+++ b/data/421/189/939/421189939.geojson
@@ -23,6 +23,9 @@
     "name:arz_x_preferred":[
         "\u0646\u0648\u064a\u0628\u0639"
     ],
+    "name:ast_x_preferred":[
+        "Nuweiba"
+    ],
     "name:azb_x_preferred":[
         "\u0646\u0648\u06cc\u0628\u0639"
     ],
@@ -65,11 +68,17 @@
     "name:guj_x_preferred":[
         "\u0aa8\u0ac1\u0ab5\u0ac7\u0a87\u0aac\u0abe"
     ],
+    "name:hau_x_preferred":[
+        "Nuweiba"
+    ],
     "name:heb_x_preferred":[
         "\u05e0\u05d5\u05d0\u05d9\u05d1\u05d4"
     ],
     "name:hin_x_preferred":[
         "\u0928\u0941\u0935\u0947\u0907\u092c\u093e"
+    ],
+    "name:ibo_x_preferred":[
+        "Nuweiba"
     ],
     "name:ind_x_preferred":[
         "Nuweiba"
@@ -118,6 +127,9 @@
     ],
     "name:sin_x_preferred":[
         "\u0db1\u0dd4\u0dc0\u0dd9\u0dba\u0dd2\u0db6\u0dcf"
+    ],
+    "name:spa_x_preferred":[
+        "Nuweiba"
     ],
     "name:swe_x_preferred":[
         "Nueiba"
@@ -187,7 +199,7 @@
         }
     ],
     "wof:id":421189939,
-    "wof:lastmodified":1566586562,
+    "wof:lastmodified":1690876055,
     "wof:name":"Nuwaiba",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/189/943/421189943.geojson
+++ b/data/421/189/943/421189943.geojson
@@ -77,6 +77,9 @@
     "name:hun_x_variant":[
         "Farafra-o\u00e1zis"
     ],
+    "name:hye_x_preferred":[
+        "\u0556\u0561\u0580\u0561\u0586\u0580\u0561"
+    ],
     "name:ind_x_preferred":[
         "Kalender Ayam"
     ],
@@ -137,6 +140,9 @@
     "name:spa_x_preferred":[
         "Depresi\u00f3n de Farafra"
     ],
+    "name:sqi_x_preferred":[
+        "Farafra"
+    ],
     "name:srp_x_preferred":[
         "\u0411\u0435\u043b\u0430 \u043f\u0443\u0441\u0442\u0438\u045a\u0430"
     ],
@@ -145,6 +151,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0baa\u0bb0\u0bbe\u0baa\u0bbf\u0bb0\u0bbe"
+    ],
+    "name:tam_x_variant":[
+        "\u0baa\u0bb0\u0bbe\u0baa\u0bbf\u0bb0\u0bbe  "
     ],
     "name:tel_x_preferred":[
         "\u0c2b\u0c30\u0c3e\u0c2b\u0c4d\u0c30\u0c3e"
@@ -160,6 +169,9 @@
     ],
     "name:urd_x_preferred":[
         "\u0641\u0627\u0631\u0627\u0641\u0631\u0627"
+    ],
+    "name:urd_x_variant":[
+        "\u0641\u0627\u0631\u0627\u0641\u0631\u0627 "
     ],
     "name:vie_x_preferred":[
         "Farafra"
@@ -190,8 +202,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        1092017585,
-        85671071
+        85671071,
+        1092017585
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -212,7 +224,7 @@
         }
     ],
     "wof:id":421189943,
-    "wof:lastmodified":1587163137,
+    "wof:lastmodified":1690876056,
     "wof:name":"Qasr Farafra",
     "wof:parent_id":1092017585,
     "wof:placetype":"locality",

--- a/data/421/189/945/421189945.geojson
+++ b/data/421/189/945/421189945.geojson
@@ -26,6 +26,9 @@
     "name:arz_x_preferred":[
         "\u0631\u0634\u064a\u062f"
     ],
+    "name:ast_x_preferred":[
+        "Rosetta"
+    ],
     "name:aze_x_preferred":[
         "R\u0259\u015fid"
     ],
@@ -68,11 +71,17 @@
     "name:fas_x_preferred":[
         "\u0631\u0634\u06cc\u062f"
     ],
+    "name:fin_x_preferred":[
+        "Rosetta"
+    ],
     "name:fra_x_preferred":[
         "Rachid"
     ],
     "name:fra_x_variant":[
         "Rosette"
+    ],
+    "name:gle_x_preferred":[
+        "Rosetta"
     ],
     "name:hbs_x_preferred":[
         "Rashid"
@@ -91,6 +100,9 @@
     ],
     "name:ind_x_preferred":[
         "Rashid"
+    ],
+    "name:ind_x_variant":[
+        "Rasyid"
     ],
     "name:isl_x_preferred":[
         "Rosetta"
@@ -115,6 +127,12 @@
     ],
     "name:lat_x_preferred":[
         "Rosetta"
+    ],
+    "name:mlg_x_preferred":[
+        "Rosetta"
+    ],
+    "name:msa_x_preferred":[
+        "Rasyid"
     ],
     "name:nld_x_preferred":[
         "Rosetta"
@@ -158,11 +176,23 @@
     "name:ukr_x_preferred":[
         "\u0420\u0430\u0448\u0438\u0434"
     ],
+    "name:urd_x_preferred":[
+        "\u0631\u0634\u064a\u062f"
+    ],
     "name:vie_x_preferred":[
         "Rashid"
     ],
+    "name:war_x_preferred":[
+        "Rosetta"
+    ],
+    "name:wuu_x_preferred":[
+        "\u7f57\u585e\u5854"
+    ],
     "name:zho_x_preferred":[
         "\u7f85\u585e\u5854"
+    ],
+    "name:zul_x_preferred":[
+        "Rosetta"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -209,7 +239,7 @@
         }
     ],
     "wof:id":421189945,
-    "wof:lastmodified":1636502267,
+    "wof:lastmodified":1690876056,
     "wof:name":"Rashid",
     "wof:parent_id":1092023921,
     "wof:placetype":"locality",

--- a/data/421/189/957/421189957.geojson
+++ b/data/421/189/957/421189957.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"32.924652,24.7423095,32.924652,24.7423095",
+    "geom:bbox":"32.924652,24.74231,32.924652,24.74231",
     "geom:latitude":24.74231,
     "geom:longitude":32.924652,
     "iso:country":"EG",
@@ -19,6 +19,9 @@
     "mz:note":"quattroshapes points import (201603)",
     "name:eng_x_preferred":[
         "Silwa Bahari"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e1\u05d9\u05dc\u05d5\u05d5\u05d4 \u05d1\u05d4\u05e8\u05d9"
     ],
     "name:pol_x_preferred":[
         "Salwa Bahri"
@@ -57,7 +60,7 @@
     },
     "wof:country":"EG",
     "wof:created":1459009642,
-    "wof:geomhash":"59beb8dd40fb9322eb0e44359a6d495e",
+    "wof:geomhash":"f8ac1d99d19e9133561bf31a1cb8441e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":421189957,
-    "wof:lastmodified":1566586564,
+    "wof:lastmodified":1690876056,
     "wof:name":"Silwa Bahari",
     "wof:parent_id":1092016437,
     "wof:placetype":"locality",
@@ -79,9 +82,9 @@
 },
   "bbox": [
     32.924652,
-    24.7423095,
+    24.74231,
     32.924652,
-    24.7423095
+    24.74231
 ],
-  "geometry": {"coordinates":[32.924652,24.7423095],"type":"Point"}
+  "geometry": {"coordinates":[32.924652,24.74231],"type":"Point"}
 }

--- a/data/421/189/959/421189959.geojson
+++ b/data/421/189/959/421189959.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0645\u062f\u064a\u0646\u0629 \u0633\u064a\u0648\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u062f\u064a\u0646\u0629 \u0633\u064a\u0648\u0647"
+    ],
     "name:cat_x_preferred":[
         "Siwa"
     ],
@@ -217,7 +220,7 @@
         }
     ],
     "wof:id":421189959,
-    "wof:lastmodified":1582352376,
+    "wof:lastmodified":1690876056,
     "wof:name":"Siwa",
     "wof:parent_id":1092025019,
     "wof:placetype":"locality",

--- a/data/421/190/765/421190765.geojson
+++ b/data/421/190/765/421190765.geojson
@@ -26,8 +26,17 @@
     "name:azb_x_preferred":[
         "\u062f\u0646\u062f\u0631\u0647"
     ],
+    "name:bel_x_preferred":[
+        "\u0414\u044d\u043d\u0434\u044d\u0440\u0430"
+    ],
+    "name:ben_x_preferred":[
+        "\u09a6\u09c7\u09a8\u09a6\u09c7\u09b0\u09be"
+    ],
     "name:cat_x_preferred":[
         "Denderah"
+    ],
+    "name:cat_x_variant":[
+        "Dandara"
     ],
     "name:ces_x_preferred":[
         "Dendera"
@@ -64,6 +73,9 @@
     ],
     "name:hrv_x_preferred":[
         "Dendera"
+    ],
+    "name:hye_x_preferred":[
+        "\u0534\u0561\u0576\u0564\u0561\u0580\u0561"
     ],
     "name:ind_x_preferred":[
         "Dendera"
@@ -137,6 +149,9 @@
     "name:zho_x_preferred":[
         "\u4e39\u5fb7\u62c9"
     ],
+    "name:zul_x_preferred":[
+        "Dendera"
+    ],
     "qs:gn_country":"EG",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":358422,
@@ -189,7 +204,7 @@
         }
     ],
     "wof:id":421190765,
-    "wof:lastmodified":1566586568,
+    "wof:lastmodified":1690876058,
     "wof:name":"Dandarah",
     "wof:parent_id":1092023527,
     "wof:placetype":"locality",

--- a/data/421/191/839/421191839.geojson
+++ b/data/421/191/839/421191839.geojson
@@ -23,6 +23,9 @@
     "name:arz_x_preferred":[
         "\u0645\u064a\u062a \u063a\u0645\u0631"
     ],
+    "name:ast_x_preferred":[
+        "Mit Ghamr"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u06cc\u062a \u063a\u0645\u0631"
     ],
@@ -44,6 +47,12 @@
     "name:fra_x_preferred":[
         "Mit Ghamr"
     ],
+    "name:gle_x_preferred":[
+        "Mit Ghamr"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d9\u05ea-\u05e2'\u05de\u05e8"
+    ],
     "name:ita_x_preferred":[
         "Mit Ghamr"
     ],
@@ -54,6 +63,9 @@
         "\u041c\u0438\u0442-\u0413\u0430\u043c\u0440"
     ],
     "name:nld_x_preferred":[
+        "Mit Ghamr"
+    ],
+    "name:nob_x_preferred":[
         "Mit Ghamr"
     ],
     "name:pol_x_preferred":[
@@ -79,6 +91,9 @@
     ],
     "name:zho_x_preferred":[
         "\u7c73\u7279\u52a0\u7a46\u723e"
+    ],
+    "name:zul_x_preferred":[
+        "Mit Ghamr"
     ],
     "qs:gn_country":"EG",
     "qs:gn_fcode":"PPL",
@@ -126,7 +141,7 @@
         }
     ],
     "wof:id":421191839,
-    "wof:lastmodified":1566586568,
+    "wof:lastmodified":1690876058,
     "wof:name":"\u0645\u064a\u062a \u063a\u0645\u0631",
     "wof:parent_id":1092022277,
     "wof:placetype":"locality",

--- a/data/421/191/949/421191949.geojson
+++ b/data/421/191/949/421191949.geojson
@@ -35,6 +35,9 @@
     "name:eus_x_preferred":[
         "Xois"
     ],
+    "name:fin_x_preferred":[
+        "Ksois"
+    ],
     "name:fra_x_preferred":[
         "Xo\u00efs"
     ],
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421191949,
-    "wof:lastmodified":1566586568,
+    "wof:lastmodified":1690876058,
     "wof:name":"\u0633\u062e\u0627",
     "wof:parent_id":1092021581,
     "wof:placetype":"locality",

--- a/data/421/192/405/421192405.geojson
+++ b/data/421/192/405/421192405.geojson
@@ -26,6 +26,9 @@
     "name:deu_x_preferred":[
         "Al-Amiriya"
     ],
+    "name:deu_x_variant":[
+        "Amreya"
+    ],
     "name:ell_x_preferred":[
         "\u0391\u03bc\u03c1\u03ad\u03c5\u03b1"
     ],
@@ -37,6 +40,9 @@
     ],
     "name:fas_x_variant":[
         "Al Maks"
+    ],
+    "name:nld_x_preferred":[
+        "Amreya"
     ],
     "name:und_x_variant":[
         "Mary\u016b\u0163"
@@ -87,7 +93,7 @@
         }
     ],
     "wof:id":421192405,
-    "wof:lastmodified":1566586556,
+    "wof:lastmodified":1690876049,
     "wof:name":"Al Amiriyah",
     "wof:parent_id":1092016715,
     "wof:placetype":"locality",

--- a/data/421/192/679/421192679.geojson
+++ b/data/421/192/679/421192679.geojson
@@ -27,14 +27,26 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0645\u0643\u0633"
     ],
+    "name:azb_x_preferred":[
+        "\u0627\u0644\u0645\u06a9\u0633"
+    ],
+    "name:deu_x_preferred":[
+        "el-Max"
+    ],
     "name:ell_x_preferred":[
         "\u039c\u03b5\u03be"
     ],
     "name:eng_x_preferred":[
         "Max"
     ],
+    "name:eng_x_variant":[
+        "El Max"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0645\u06a9\u0633"
+    ],
+    "name:nld_x_preferred":[
+        "Max"
     ],
     "name:und_x_variant":[
         "Mex"
@@ -84,7 +96,7 @@
         }
     ],
     "wof:id":421192679,
-    "wof:lastmodified":1566586556,
+    "wof:lastmodified":1690876049,
     "wof:name":"Al Maks",
     "wof:parent_id":1092022499,
     "wof:placetype":"locality",

--- a/data/421/193/767/421193767.geojson
+++ b/data/421/193/767/421193767.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0645\u062f\u064a\u0646\u0629 \u0627\u0644\u0633\u0627\u062f\u0627\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u062f\u064a\u0646\u0629 \u0627\u0644\u0633\u0627\u062f\u0627\u062a"
+    ],
+    "name:ast_x_preferred":[
+        "Sadat City"
+    ],
     "name:azb_x_preferred":[
         "\u0634\u0647\u0631 \u0633\u0627\u062f\u0627\u062a"
     ],
@@ -41,6 +47,9 @@
     "name:eng_x_preferred":[
         "Sadat City"
     ],
+    "name:epo_x_preferred":[
+        "Sadat Urbo"
+    ],
     "name:fas_x_preferred":[
         "\u0634\u0647\u0631 \u0633\u0627\u062f\u0627\u062a"
     ],
@@ -52,6 +61,9 @@
     ],
     "name:guj_x_preferred":[
         "\u0ab8\u0aa6\u0aa4 \u0ab6\u0ab9\u0ac7\u0ab0"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d3\u05d9\u05e0\u05ea \u05d0-\u05e1\u05d0\u05d3\u05d0\u05ea"
     ],
     "name:hin_x_preferred":[
         "\u0938\u093e\u0926\u093e\u0924 \u0938\u093f\u091f\u0940"
@@ -131,6 +143,12 @@
     "name:vie_x_preferred":[
         "Th\u00e0nh ph\u1ed1 Sadat"
     ],
+    "name:zho_x_preferred":[
+        "\u8428\u8fbe\u7279\u57ce"
+    ],
+    "name:zul_x_preferred":[
+        "Sadat City"
+    ],
     "qs:gn_country":"EG",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":353223,
@@ -177,7 +195,7 @@
         }
     ],
     "wof:id":421193767,
-    "wof:lastmodified":1566586557,
+    "wof:lastmodified":1690876050,
     "wof:name":"Madinat as Sadat",
     "wof:parent_id":1092018763,
     "wof:placetype":"locality",

--- a/data/421/193/789/421193789.geojson
+++ b/data/421/193/789/421193789.geojson
@@ -32,6 +32,9 @@
     "name:ceb_x_preferred":[
         "Bilq\u0101s"
     ],
+    "name:deu_x_preferred":[
+        "Belqas"
+    ],
     "name:eng_x_preferred":[
         "Belqas"
     ],
@@ -44,7 +47,13 @@
     "name:kaz_x_preferred":[
         "\u0411\u0438\u043b\u043a\u0430\u0441"
     ],
+    "name:mlg_x_preferred":[
+        "Bilq\u0101s"
+    ],
     "name:nld_x_preferred":[
+        "Belqas"
+    ],
+    "name:nob_x_preferred":[
         "Belqas"
     ],
     "name:pol_x_preferred":[
@@ -61,6 +70,9 @@
     ],
     "name:und_x_variant":[
         "Bilq\u00e2s"
+    ],
+    "name:zul_x_preferred":[
+        "Belqas"
     ],
     "qs:gn_country":"EG",
     "qs:gn_fcode":"PPL",
@@ -109,7 +121,7 @@
         }
     ],
     "wof:id":421193789,
-    "wof:lastmodified":1566586557,
+    "wof:lastmodified":1690876050,
     "wof:name":"Bilqas Qism Awwal",
     "wof:parent_id":1092015611,
     "wof:placetype":"locality",

--- a/data/421/194/135/421194135.geojson
+++ b/data/421/194/135/421194135.geojson
@@ -23,11 +23,29 @@
     "name:arz_x_preferred":[
         "\u0641\u0644\u0645\u0646\u062c"
     ],
+    "name:azb_x_preferred":[
+        "\u0641\u0644\u0645\u0646\u062c"
+    ],
+    "name:deu_x_preferred":[
+        "Fleming"
+    ],
     "name:eng_x_preferred":[
         "Flemeng"
     ],
+    "name:eng_x_variant":[
+        "Fleming"
+    ],
     "name:fas_x_preferred":[
         "\u0641\u0644\u0645\u0646\u062c"
+    ],
+    "name:ita_x_preferred":[
+        "Fleming"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30d5\u30ec\u30df\u30f3\u30b0"
+    ],
+    "name:nld_x_preferred":[
+        "Flemeng"
     ],
     "name:und_x_variant":[
         "Flaminj"
@@ -77,7 +95,7 @@
         }
     ],
     "wof:id":421194135,
-    "wof:lastmodified":1566586556,
+    "wof:lastmodified":1690876049,
     "wof:name":"\u0641\u0644\u0645\u0646\u062c",
     "wof:parent_id":1092019315,
     "wof:placetype":"locality",

--- a/data/421/194/525/421194525.geojson
+++ b/data/421/194/525/421194525.geojson
@@ -26,11 +26,17 @@
     "name:arz_x_preferred":[
         "\u0637\u0644\u062e\u0627"
     ],
+    "name:ast_x_preferred":[
+        "Talkha"
+    ],
     "name:azb_x_preferred":[
         "\u0637\u0644\u062e\u0627"
     ],
     "name:ceb_x_preferred":[
         "\u0162alkh\u0101"
+    ],
+    "name:deu_x_preferred":[
+        "Talcha"
     ],
     "name:ell_x_preferred":[
         "\u03a4\u03ac\u03bb\u03c7\u03b1"
@@ -47,7 +53,13 @@
     "name:kaz_x_preferred":[
         "\u0422\u0430\u043b\u044c\u0445\u0430 \u049b\u0430\u043b\u0430\u0441\u044b"
     ],
+    "name:mlg_x_preferred":[
+        "\u0162alkh\u0101"
+    ],
     "name:nld_x_preferred":[
+        "Talkha"
+    ],
+    "name:nob_x_preferred":[
         "Talkha"
     ],
     "name:pol_x_preferred":[
@@ -67,6 +79,9 @@
     ],
     "name:urd_x_preferred":[
         "\u0637\u0644\u062e\u0627"
+    ],
+    "name:zul_x_preferred":[
+        "Talkha"
     ],
     "qs:gn_country":"EG",
     "qs:gn_fcode":"PPL",
@@ -115,7 +130,7 @@
         }
     ],
     "wof:id":421194525,
-    "wof:lastmodified":1566586556,
+    "wof:lastmodified":1690876050,
     "wof:name":"\u0645\u0631\u0643\u0632 \u0637\u0644\u062e\u0627",
     "wof:parent_id":1092025681,
     "wof:placetype":"locality",

--- a/data/421/195/823/421195823.geojson
+++ b/data/421/195/823/421195823.geojson
@@ -20,11 +20,20 @@
     "name:ara_x_preferred":[
         "\u062a\u0644\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u0644\u0627"
+    ],
     "name:ceb_x_preferred":[
         "Tal\u0101"
     ],
     "name:eng_x_preferred":[
         "Tala"
+    ],
+    "name:ita_x_preferred":[
+        "Tala"
+    ],
+    "name:mlg_x_preferred":[
+        "Tal\u0101"
     ],
     "name:nld_x_preferred":[
         "Tala"
@@ -43,6 +52,9 @@
     ],
     "name:und_x_variant":[
         "Talla"
+    ],
+    "name:zul_x_preferred":[
+        "Tala"
     ],
     "qs:gn_country":"EG",
     "qs:gn_fcode":"PPL",
@@ -91,7 +103,7 @@
         }
     ],
     "wof:id":421195823,
-    "wof:lastmodified":1566586556,
+    "wof:lastmodified":1690876049,
     "wof:name":"\u0645\u0631\u0643\u0632 \u062a\u0644\u0627",
     "wof:parent_id":1092025145,
     "wof:placetype":"locality",

--- a/data/421/195/825/421195825.geojson
+++ b/data/421/195/825/421195825.geojson
@@ -20,17 +20,26 @@
     "name:ara_x_preferred":[
         "\u0633\u064a\u062f\u064a \u0633\u0627\u0644\u0645"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u064a\u062f\u0649 \u0633\u0627\u0644\u0645"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u06cc\u062f\u06cc \u0633\u0627\u0644\u0645"
     ],
     "name:ceb_x_preferred":[
         "Markaz S\u012bd\u012b S\u0101lim"
     ],
+    "name:ceb_x_variant":[
+        "S\u012bd\u012b S\u0101lim"
+    ],
     "name:eng_x_preferred":[
         "Sidi Salem"
     ],
     "name:fas_x_preferred":[
         "\u0633\u06cc\u062f\u06cc \u0633\u0627\u0644\u0645"
+    ],
+    "name:mlg_x_preferred":[
+        "S\u012bd\u012b S\u0101lim"
     ],
     "name:nld_x_preferred":[
         "Sidi Salem"
@@ -44,8 +53,14 @@
     "name:swe_x_preferred":[
         "Markaz S\u012bd\u012b S\u0101lim"
     ],
+    "name:swe_x_variant":[
+        "S\u012bd\u012b S\u0101lim"
+    ],
     "name:und_x_variant":[
         "S\u012bd\u012b S\u0101lim"
+    ],
+    "name:zul_x_preferred":[
+        "Sidi Salem"
     ],
     "qs:gn_country":"EG",
     "qs:gn_fcode":"PPL",
@@ -93,7 +108,7 @@
         }
     ],
     "wof:id":421195825,
-    "wof:lastmodified":1566586556,
+    "wof:lastmodified":1690876049,
     "wof:name":"\u0645\u0631\u0643\u0632 \u0633\u064a\u062f\u064a \u0633\u0627\u0644\u0645",
     "wof:parent_id":1092024971,
     "wof:placetype":"locality",

--- a/data/421/198/061/421198061.geojson
+++ b/data/421/198/061/421198061.geojson
@@ -26,11 +26,17 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0639\u0644\u0645\u064a\u0646"
     ],
+    "name:ast_x_preferred":[
+        "El Alamein"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u0639\u0644\u0645\u06cc\u0646"
     ],
     "name:aze_x_preferred":[
         "\u018fl-\u018flameyn"
+    ],
+    "name:aze_x_variant":[
+        "\u0259l-\u018fl\u0259meyn"
     ],
     "name:ben_x_preferred":[
         "\u098f\u09b2 \u0986\u09b2\u09be\u09ae\u09c7\u0987\u09a8"
@@ -131,6 +137,9 @@
     "name:mar_x_preferred":[
         "\u090f\u0932 \u0905\u0932\u0945\u092e\u0940\u0928"
     ],
+    "name:mri_x_preferred":[
+        "Arameina"
+    ],
     "name:msa_x_preferred":[
         "El Alamein"
     ],
@@ -191,8 +200,14 @@
     "name:tel_x_preferred":[
         "\u0c0e\u0c32\u0c4d \u0c05\u0c32\u0c2e\u0c47\u0c2f\u0c3f\u0c28\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u0410\u043b-\u0410\u043b\u0430\u043c\u0430\u0439\u043d"
+    ],
     "name:tha_x_preferred":[
         "\u0e40\u0e2d\u0e25 \u0e2d\u0e25\u0e32\u0e40\u0e21\u0e19"
+    ],
+    "name:tha_x_variant":[
+        "\u0e2d\u0e31\u0e25\u0e2d\u0e30\u0e25\u0e30\u0e21\u0e31\u0e22\u0e19\u0e4c"
     ],
     "name:tur_x_preferred":[
         "El-Alameyn"
@@ -209,11 +224,17 @@
     "name:urd_x_preferred":[
         "\u0627\u0644 \u0627\u0644\u0627\u0645\u06cc\u06ba"
     ],
+    "name:urd_x_variant":[
+        "\u0627\u0644\u0639\u0627\u0644\u0645\u06cc\u0646"
+    ],
     "name:vie_x_preferred":[
         "El Alamein"
     ],
     "name:zho_x_preferred":[
         "\u963f\u83b1\u66fc"
+    ],
+    "name:zul_x_preferred":[
+        "El Alamein"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Egypt",
@@ -359,7 +380,7 @@
         }
     ],
     "wof:id":421198061,
-    "wof:lastmodified":1566586567,
+    "wof:lastmodified":1690876058,
     "wof:name":"Al Alamayn",
     "wof:parent_id":1092016623,
     "wof:placetype":"locality",

--- a/data/421/199/105/421199105.geojson
+++ b/data/421/199/105/421199105.geojson
@@ -23,6 +23,9 @@
     "name:arz_x_preferred":[
         "\u062c\u0631\u062c\u0627"
     ],
+    "name:ast_x_preferred":[
+        "Girga"
+    ],
     "name:azb_x_preferred":[
         "\u062c\u0631\u062c\u0627"
     ],
@@ -34,6 +37,9 @@
     ],
     "name:ceb_x_preferred":[
         "Markaz Jirj\u0101"
+    ],
+    "name:ceb_x_variant":[
+        "Jirj\u0101"
     ],
     "name:deu_x_preferred":[
         "Girga"
@@ -53,7 +59,13 @@
     "name:fas_x_preferred":[
         "\u062c\u0631\u062c\u0627"
     ],
+    "name:fin_x_preferred":[
+        "Girga"
+    ],
     "name:fra_x_preferred":[
+        "Girga"
+    ],
+    "name:gle_x_preferred":[
         "Girga"
     ],
     "name:hye_x_preferred":[
@@ -73,6 +85,9 @@
     ],
     "name:kaz_x_preferred":[
         "\u0413\u0438\u0440\u0433\u0430"
+    ],
+    "name:mlg_x_preferred":[
+        "Jirj\u0101"
     ],
     "name:nld_x_preferred":[
         "Girga"
@@ -104,8 +119,14 @@
     "name:urd_x_preferred":[
         "\u062c\u0631\u062c\u0627"
     ],
+    "name:vec_x_preferred":[
+        "Girga"
+    ],
     "name:zho_x_preferred":[
         "\u5409\u723e\u8cc8"
+    ],
+    "name:zul_x_preferred":[
+        "Girga"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Egypt",
@@ -246,7 +267,7 @@
         }
     ],
     "wof:id":421199105,
-    "wof:lastmodified":1566586569,
+    "wof:lastmodified":1690876059,
     "wof:name":"Jirja",
     "wof:parent_id":1092021083,
     "wof:placetype":"locality",

--- a/data/421/199/111/421199111.geojson
+++ b/data/421/199/111/421199111.geojson
@@ -23,6 +23,9 @@
     "name:arz_x_preferred":[
         "\u0632\u0641\u062a\u0627"
     ],
+    "name:ast_x_preferred":[
+        "Zefta"
+    ],
     "name:ceb_x_preferred":[
         "Zift\u00e1"
     ],
@@ -53,8 +56,14 @@
     "name:kaz_x_preferred":[
         "\u0417\u0438\u0444\u0442\u0430"
     ],
+    "name:mlg_x_preferred":[
+        "Zefta"
+    ],
     "name:nld_x_preferred":[
         "Zefta"
+    ],
+    "name:nob_x_preferred":[
+        "Zifta"
     ],
     "name:pol_x_preferred":[
         "Zifta"
@@ -76,6 +85,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6fdf\u592b\u5854"
+    ],
+    "name:zul_x_preferred":[
+        "Zefta"
     ],
     "qs:gn_country":"EG",
     "qs:gn_fcode":"PPL",
@@ -124,7 +136,7 @@
         }
     ],
     "wof:id":421199111,
-    "wof:lastmodified":1566586569,
+    "wof:lastmodified":1690876059,
     "wof:name":"\u0645\u0631\u0643\u0632 \u0632\u0641\u062a\u0649",
     "wof:parent_id":1092026069,
     "wof:placetype":"locality",

--- a/data/421/202/337/421202337.geojson
+++ b/data/421/202/337/421202337.geojson
@@ -23,6 +23,9 @@
     "name:arz_x_preferred":[
         "\u0628\u0627\u0648\u064a\u0637"
     ],
+    "name:ast_x_preferred":[
+        "Bawiti"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u0628\u0627\u0648\u06cc\u0637\u06cc"
     ],
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":421202337,
-    "wof:lastmodified":1566586558,
+    "wof:lastmodified":1690876051,
     "wof:name":"Bawiti",
     "wof:parent_id":1092022885,
     "wof:placetype":"locality",

--- a/data/421/202/495/421202495.geojson
+++ b/data/421/202/495/421202495.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0631\u0633\u0649 \u0639\u0644\u0645"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0631\u0633\u0649 \u0639\u0644\u0645"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0631\u0633\u06cc \u0639\u0644\u0645"
     ],
@@ -59,11 +62,17 @@
     "name:guj_x_preferred":[
         "\u0aae\u0abe\u0ab0\u0ab8\u0abe \u0a86\u0ab2\u0aae"
     ],
+    "name:heb_x_preferred":[
+        "\u05de\u05e8\u05e1\u05d0 \u05e2\u05dc\u05dd"
+    ],
     "name:hin_x_preferred":[
         "\u092e\u093e\u0930\u094d\u0938 \u0906\u0932\u092e"
     ],
     "name:hun_x_preferred":[
         "Marsza Alam"
+    ],
+    "name:hye_x_preferred":[
+        "\u0544\u0561\u0580\u057d\u0561 \u0531\u056c\u0561\u0574"
     ],
     "name:ind_x_preferred":[
         "Marsa Alam"
@@ -102,6 +111,9 @@
         "Marsa Alam"
     ],
     "name:por_x_preferred":[
+        "Marsa Alam"
+    ],
+    "name:ron_x_preferred":[
         "Marsa Alam"
     ],
     "name:rus_x_preferred":[
@@ -145,6 +157,9 @@
     ],
     "name:zho_x_preferred":[
         "\u99ac\u85a9\u963f\u62c9\u59c6"
+    ],
+    "name:zul_x_preferred":[
+        "Marsa Alam"
     ],
     "qs:gn_country":"EG",
     "qs:gn_fcode":"PPL",
@@ -193,7 +208,7 @@
         }
     ],
     "wof:id":421202495,
-    "wof:lastmodified":1566586559,
+    "wof:lastmodified":1690876051,
     "wof:name":"Mars\u00e1 Al \u2018alam",
     "wof:parent_id":1092022093,
     "wof:placetype":"locality",

--- a/data/421/202/571/421202571.geojson
+++ b/data/421/202/571/421202571.geojson
@@ -23,14 +23,23 @@
     "name:arz_x_preferred":[
         "\u0643\u0641\u0631 \u0627\u0644\u0634\u064a\u062e"
     ],
+    "name:ast_x_preferred":[
+        "Kafr el-Sheikh"
+    ],
     "name:azb_x_preferred":[
         "\u06a9\u0641\u0631 \u0627\u0644\u0634\u06cc\u062e"
+    ],
+    "name:aze_x_preferred":[
+        "Kafr \u0259l-\u015eeyx"
     ],
     "name:bul_x_preferred":[
         "\u041a\u0430\u0444\u044a\u0440 \u0435\u043b-\u0428\u0435\u0439\u0445"
     ],
     "name:cat_x_preferred":[
         "Kafr al-Sheikh"
+    ],
+    "name:ceb_x_preferred":[
+        "Kafr ash Shaykh"
     ],
     "name:ces_x_preferred":[
         "Kafr a\u0161-\u0160ajch"
@@ -56,8 +65,14 @@
     "name:fra_x_preferred":[
         "Kafr el-Cheik"
     ],
+    "name:gle_x_preferred":[
+        "Kafr el-Sheikh"
+    ],
     "name:heb_x_preferred":[
         "\u05db\u05e4\u05e8 \u05d0\u05dc\u05e9\u05d9\u05da"
+    ],
+    "name:heb_x_variant":[
+        "\u05db\u05e4\u05e8 \u05d0-\u05e9\u05d9\u05d7'"
     ],
     "name:ita_x_preferred":[
         "Kafr el-Sheikh"
@@ -79,6 +94,9 @@
     ],
     "name:nld_x_preferred":[
         "Kafr el Sheikh"
+    ],
+    "name:nob_x_preferred":[
+        "Kafr el-Sheikh"
     ],
     "name:pol_x_preferred":[
         "Kafr asz-Szajch"
@@ -104,6 +122,9 @@
     "name:swe_x_preferred":[
         "Kafr el-Sheikh"
     ],
+    "name:tgk_x_preferred":[
+        "\u041a\u0430\u0444\u0440-\u0430\u0448-\u0428\u0430\u0439\u0445"
+    ],
     "name:tha_x_preferred":[
         "\u0e01\u0e31\u0e1f\u0e23\u0e38\u0e0a\u0e0a\u0e31\u0e22\u0e04\u0e4c"
     ],
@@ -116,6 +137,9 @@
     "name:urd_x_preferred":[
         "\u06a9\u0641\u0631 \u0627\u0644\u0634\u06cc\u062e"
     ],
+    "name:vec_x_preferred":[
+        "Kafr el-Sheikh"
+    ],
     "name:vie_x_preferred":[
         "Kafr el-Sheikh"
     ],
@@ -124,6 +148,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8b1d\u8d6b\u6751"
+    ],
+    "name:zul_x_preferred":[
+        "Kafr El Sheikh"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Egypt",
@@ -263,7 +290,7 @@
         }
     ],
     "wof:id":421202571,
-    "wof:lastmodified":1566586559,
+    "wof:lastmodified":1690876052,
     "wof:name":"\u0643\u0641\u0631 \u0627\u0644\u0634\u064a\u062e",
     "wof:parent_id":1092021581,
     "wof:placetype":"locality",

--- a/data/421/204/231/421204231.geojson
+++ b/data/421/204/231/421204231.geojson
@@ -26,8 +26,14 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0627\u0642\u0635\u0631"
     ],
+    "name:ast_x_preferred":[
+        "Luxor"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0642\u0635\u0631"
+    ],
+    "name:aze_x_preferred":[
+        "\u0259l-\u00dcqs\u00fcr"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041b\u0443\u043a\u0441\u043e\u0440"
@@ -113,8 +119,14 @@
     "name:hye_x_preferred":[
         "\u053c\u0578\u0582\u0584\u057d\u0578\u0580"
     ],
+    "name:ibo_x_preferred":[
+        "Luxor"
+    ],
     "name:ind_x_preferred":[
         "Luxor"
+    ],
+    "name:isl_x_preferred":[
+        "L\u00faxor"
     ],
     "name:ita_x_preferred":[
         "Luxor"
@@ -158,8 +170,17 @@
     "name:mkd_x_preferred":[
         "\u041b\u0443\u043a\u0441\u043e\u0440"
     ],
+    "name:mlg_x_preferred":[
+        "Luxor"
+    ],
+    "name:mlt_x_preferred":[
+        "Luxor"
+    ],
     "name:msa_x_preferred":[
         "Luxor"
+    ],
+    "name:mya_x_preferred":[
+        "\u101c\u1030\u1037\u1000\u103a\u1006\u1031\u102c\u103a\u1019\u103c\u102d\u102f\u1037"
     ],
     "name:nep_x_preferred":[
         "\u0932\u0941\u0915\u094d\u0938\u0930"
@@ -178,6 +199,9 @@
     ],
     "name:oci_x_preferred":[
         "Lox\u00f2r"
+    ],
+    "name:oss_x_preferred":[
+        "\u041b\u0443\u043a\u0441\u043e\u0440"
     ],
     "name:pan_x_preferred":[
         "\u0a32\u0a15\u0a38\u0a30"
@@ -218,17 +242,29 @@
     "name:spa_x_preferred":[
         "L\u00faxor"
     ],
+    "name:spa_x_variant":[
+        "Luxor"
+    ],
     "name:srp_x_preferred":[
         "\u041b\u0443\u043a\u0441\u043e\u0440"
     ],
+    "name:swa_x_preferred":[
+        "Luxor"
+    ],
     "name:swe_x_preferred":[
         "Luxor"
+    ],
+    "name:szl_x_preferred":[
+        "Luksor"
     ],
     "name:tam_x_preferred":[
         "\u0b85\u0bb2\u0bcd-\u0b89\u0b95\u0bcd\u0b9a\u0bc1\u0bb0\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c32\u0c17\u0c4d\u0c38\u0c30\u0c4d"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0430\u043b-\u0423\u049b\u0441\u0443\u0440"
     ],
     "name:tgl_x_preferred":[
         "Luxor"
@@ -254,6 +290,12 @@
     "name:urd_x_variant":[
         "\u0627\u0644\u0627\u0642\u0635\u0631"
     ],
+    "name:uzb_x_preferred":[
+        "al-Uqsur"
+    ],
+    "name:vec_x_preferred":[
+        "Luxor"
+    ],
     "name:vie_x_preferred":[
         "Luxor"
     ],
@@ -274,6 +316,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6a02\u8700"
+    ],
+    "name:zul_x_preferred":[
+        "Luxor"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Egypt",
@@ -414,7 +459,7 @@
         }
     ],
     "wof:id":421204231,
-    "wof:lastmodified":1566586558,
+    "wof:lastmodified":1690876051,
     "wof:name":"\u0627\u0644\u0627\u0642\u0635\u0631",
     "wof:parent_id":1092018839,
     "wof:placetype":"locality",

--- a/data/421/204/393/421204393.geojson
+++ b/data/421/204/393/421204393.geojson
@@ -26,6 +26,9 @@
     "name:ara_x_variant":[
         "\u0645\u062f\u064a\u0646\u0629 \u0627\u0644\u062c\u064a\u0632\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u062c\u064a\u0632\u0629"
+    ],
     "name:ast_x_preferred":[
         "Guiza"
     ],
@@ -37,6 +40,9 @@
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0413\u0456\u0437\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u0413\u0456\u0437\u0430"
     ],
     "name:ben_x_preferred":[
         "\u0997\u09bf\u099c\u09be"
@@ -128,7 +134,16 @@
     "name:hye_x_preferred":[
         "\u0533\u056b\u0566\u0561"
     ],
+    "name:hyw_x_preferred":[
+        "\u053f\u056b\u0566\u0561"
+    ],
     "name:ido_x_preferred":[
+        "Giza"
+    ],
+    "name:ile_x_preferred":[
+        "Giza"
+    ],
+    "name:ina_x_preferred":[
         "Giza"
     ],
     "name:ind_x_preferred":[
@@ -173,6 +188,15 @@
     "name:mkd_x_preferred":[
         "\u0413\u0438\u0437\u0430"
     ],
+    "name:mlg_x_preferred":[
+        "Giza"
+    ],
+    "name:mlt_x_preferred":[
+        "Giza"
+    ],
+    "name:mni_x_preferred":[
+        "\uabd2\uabe4\uabd3\uabe5"
+    ],
     "name:mon_x_preferred":[
         "\u0413\u0438\u0437\u0430 \u0445\u043e\u0442"
     ],
@@ -202,6 +226,9 @@
     ],
     "name:oci_x_preferred":[
         "Gizeh"
+    ],
+    "name:oss_x_preferred":[
+        "\u042d\u043b\u044c-\u0413\u0438\u0437\u00e6"
     ],
     "name:pan_x_preferred":[
         "\u0a1c\u0a40\u0a1c\u0a3c\u0a3e"
@@ -251,6 +278,9 @@
     "name:swe_x_preferred":[
         "Giza"
     ],
+    "name:szl_x_preferred":[
+        "Giza"
+    ],
     "name:tam_x_preferred":[
         "\u0b95\u0bbf\u0b9a\u0bbe"
     ],
@@ -268,6 +298,9 @@
     ],
     "name:twi_x_preferred":[
         "Giza"
+    ],
+    "name:uig_x_preferred":[
+        "\u062c\u0649\u0632\u06d5"
     ],
     "name:ukr_x_preferred":[
         "\u0413\u0456\u0437\u0430"
@@ -304,6 +337,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5409\u8428"
+    ],
+    "name:zul_x_preferred":[
+        "Giza"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Egypt",
@@ -445,7 +481,7 @@
         }
     ],
     "wof:id":421204393,
-    "wof:lastmodified":1566586558,
+    "wof:lastmodified":1690876051,
     "wof:name":"\u0627\u0644\u062c\u064a\u0632\u0629",
     "wof:parent_id":1092021203,
     "wof:placetype":"locality",

--- a/data/856/325/81/85632581.geojson
+++ b/data/856/325/81/85632581.geojson
@@ -31,6 +31,9 @@
     "name:abk_x_preferred":[
         "\u041c\u044b\u0441\u0440\u044b"
     ],
+    "name:abk_x_variant":[
+        "\u041c\u0441\u044b\u0440"
+    ],
     "name:ace_x_preferred":[
         "Meus\u00e9"
     ],
@@ -56,8 +59,14 @@
     "name:amh_x_variant":[
         "\u130d\u1265\u133d"
     ],
+    "name:ami_x_preferred":[
+        "Egypt"
+    ],
     "name:ang_x_preferred":[
         "\u00c6gypt"
+    ],
+    "name:anp_x_preferred":[
+        "\u092e\u093f\u0938\u094d\u0930"
     ],
     "name:ara_x_preferred":[
         "\u0645\u0635\u0631"
@@ -75,6 +84,9 @@
     "name:arg_x_preferred":[
         "Echipto"
     ],
+    "name:arq_x_preferred":[
+        "\u0645\u0627\u0635\u0631"
+    ],
     "name:ary_x_preferred":[
         "\u0645\u0635\u0631"
     ],
@@ -89,6 +101,9 @@
     ],
     "name:ava_x_preferred":[
         "\u0415\u0433\u0438\u043f\u0435\u0442"
+    ],
+    "name:avk_x_preferred":[
+        "Misra"
     ],
     "name:aym_x_preferred":[
         "Iqiptu"
@@ -134,6 +149,9 @@
     ],
     "name:bho_x_preferred":[
         "\u092e\u093f\u0938\u094d\u0930"
+    ],
+    "name:bis_x_preferred":[
+        "Ijip"
     ],
     "name:bjn_x_preferred":[
         "Mesir"
@@ -206,6 +224,9 @@
     ],
     "name:cym_x_preferred":[
         "Yr Aifft"
+    ],
+    "name:dag_x_preferred":[
+        "Egypt"
     ],
     "name:dan_x_preferred":[
         "Egypten"
@@ -323,6 +344,9 @@
     "name:ful_x_preferred":[
         "Ejipt"
     ],
+    "name:ful_x_variant":[
+        "Misra"
+    ],
     "name:fur_x_preferred":[
         "Egjit"
     ],
@@ -353,8 +377,14 @@
     "name:gom_x_preferred":[
         "\u092e\u093f\u0938\u094d\u0930"
     ],
+    "name:gor_x_preferred":[
+        "Mesir"
+    ],
     "name:got_x_preferred":[
         "\ud800\udf30\ud800\udf39\ud800\udf32\ud800\udf45\ud800\udf40\ud800\udf44\ud800\udf30\ud800\udf3f"
+    ],
+    "name:gpe_x_preferred":[
+        "Egypt"
     ],
     "name:grn_x_preferred":[
         "Eh\u00edpto"
@@ -365,8 +395,14 @@
     "name:gsw_x_preferred":[
         "\u00c4gypte"
     ],
+    "name:gsw_x_variant":[
+        "\u00c4gypten"
+    ],
     "name:guj_x_preferred":[
         "\u0a87\u0a9c\u0abf\u0aaa\u0acd\u0aa4"
+    ],
+    "name:gur_x_preferred":[
+        "Egypt"
     ],
     "name:hak_x_preferred":[
         "\u00c2i-khi\u030dp"
@@ -485,11 +521,15 @@
     "name:kbp_x_preferred":[
         "Egipiti"
     ],
+    "name:kcg_x_preferred":[
+        "Ma\u0331sa\u0331r"
+    ],
     "name:khm_x_preferred":[
         "\u17a2\u17c1\u17a0\u17ca\u17d2\u179f\u17b8\u1794"
     ],
     "name:khm_x_variant":[
-        "\u17a2\u17c1\u17a0\u17d2\u179f\u17c9\u17b8\u1794"
+        "\u17a2\u17c1\u17a0\u17d2\u179f\u17c9\u17b8\u1794",
+        "\u17a2\u17c1\u17a0\u17d2\u179f\u17ca\u17b8\u1794"
     ],
     "name:kik_x_preferred":[
         "Egypt"
@@ -521,6 +561,9 @@
     "name:lao_x_preferred":[
         "\u0ead\u0eb5\u0ea2\u0eb4\u0e9a"
     ],
+    "name:lao_x_variant":[
+        "\u0e9b\u0eb0\u0ec0\u0e97\u0e94\u0ec0\u0ead\u0ea2\u0eb4\u0e9a"
+    ],
     "name:lat_x_preferred":[
         "Aegyptus"
     ],
@@ -551,6 +594,9 @@
     "name:lit_x_preferred":[
         "Egiptas"
     ],
+    "name:lld_x_preferred":[
+        "Egit"
+    ],
     "name:lmo_x_preferred":[
         "Egit"
     ],
@@ -569,6 +615,9 @@
     "name:lzh_x_preferred":[
         "\u57c3\u53ca"
     ],
+    "name:mad_x_preferred":[
+        "Mesir"
+    ],
     "name:mai_x_preferred":[
         "\u092e\u093f\u0938\u094d\u0930"
     ],
@@ -584,8 +633,17 @@
     "name:mdf_x_preferred":[
         "\u0415\u0433\u0438\u043f\u0435\u0442"
     ],
+    "name:mdf_x_variant":[
+        "\u042d\u0433\u0438\u043f\u0442"
+    ],
+    "name:mhr_x_preferred":[
+        "\u0415\u0433\u0438\u043f\u0435\u0442"
+    ],
     "name:min_x_preferred":[
         "Masia"
+    ],
+    "name:min_x_variant":[
+        "Mesir"
     ],
     "name:mkd_x_preferred":[
         "\u0415\u0433\u0438\u043f\u0435\u0442"
@@ -598,6 +656,9 @@
     ],
     "name:mlt_x_preferred":[
         "E\u0121ittu"
+    ],
+    "name:mni_x_preferred":[
+        "\uabcf\uabd6\uabe4\uabde"
     ],
     "name:mon_x_preferred":[
         "\u0415\u0433\u0438\u043f\u0435\u0442"
@@ -656,6 +717,9 @@
     "name:new_x_preferred":[
         "\u092e\u093f\u0938\u094d\u0930"
     ],
+    "name:nia_x_preferred":[
+        "Miserai"
+    ],
     "name:nld_x_preferred":[
         "Egypte (land)"
     ],
@@ -673,6 +737,9 @@
     ],
     "name:nov_x_preferred":[
         "Egiptia"
+    ],
+    "name:nqo_x_preferred":[
+        "\u07cc\u07d6\u07ed\u07cc\u07d4\u07d1\u07d5"
     ],
     "name:nrm_x_preferred":[
         "\u00cagypte"
@@ -737,6 +804,9 @@
     "name:pus_x_preferred":[
         "\u0645\u0635\u0631"
     ],
+    "name:pwn_x_preferred":[
+        "Idjiputu"
+    ],
     "name:que_x_preferred":[
         "Ihiptu"
     ],
@@ -785,8 +855,17 @@
     "name:sgs_x_preferred":[
         "Eg\u0117pts"
     ],
+    "name:shi_x_preferred":[
+        "Mi\u1e63ra"
+    ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u1022\u102e\u1038\u1075\u103b\u102d\u1015\u103a\u1088"
+    ],
     "name:sin_x_preferred":[
         "\u0d8a\u0da2\u0dd2\u0db4\u0dca\u0dad\u0dd4\u0dc0"
+    ],
+    "name:skr_x_preferred":[
+        "\u0645\u0635\u0631"
     ],
     "name:slk_x_preferred":[
         "Egypt"
@@ -797,8 +876,17 @@
     "name:sme_x_preferred":[
         "Egypta"
     ],
+    "name:smj_x_preferred":[
+        "Egippta"
+    ],
+    "name:smn_x_preferred":[
+        "Egypt"
+    ],
     "name:smo_x_preferred":[
         "Aikupito"
+    ],
+    "name:sms_x_preferred":[
+        "Egyptt"
     ],
     "name:sna_x_preferred":[
         "Egypt"
@@ -872,6 +960,9 @@
     "name:tat_x_preferred":[
         "\u041c\u0438\u0441\u044b\u0440"
     ],
+    "name:tay_x_preferred":[
+        "Egypt"
+    ],
     "name:tel_x_preferred":[
         "\u0c08\u0c1c\u0c3f\u0c2a\u0c4d\u0c1f\u0c41"
     ],
@@ -896,11 +987,20 @@
     "name:tir_x_preferred":[
         "\u130d\u1265\u133d"
     ],
+    "name:tir_x_variant":[
+        "\u130d\u1265\u133a"
+    ],
+    "name:tok_x_preferred":[
+        "ma Masu"
+    ],
     "name:ton_x_preferred":[
         "\u02bbIsipite"
     ],
     "name:tpi_x_preferred":[
         "Ijip"
+    ],
+    "name:trv_x_preferred":[
+        "Egypt"
     ],
     "name:tso_x_preferred":[
         "Egypt"
@@ -942,6 +1042,9 @@
     ],
     "name:vec_x_preferred":[
         "Egito"
+    ],
+    "name:vec_x_variant":[
+        "Ezito"
     ],
     "name:vep_x_preferred":[
         "Egipt"
@@ -1231,7 +1334,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1618362686,
+    "wof:lastmodified":1690876034,
     "wof:name":"Egypt",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/709/85/85670985.geojson
+++ b/data/856/709/85/85670985.geojson
@@ -54,6 +54,12 @@
     "name:azb_x_preferred":[
         "\u0628\u0627\u062a\u06cc \u0627\u0648\u0633\u062a\u0627\u0646"
     ],
+    "name:aze_x_preferred":[
+        "\u0259l-Q\u0259rbiyy\u0259 m\u00fchaf\u0259z\u0259si"
+    ],
+    "name:bel_x_preferred":[
+        "\u043c\u0443\u0445\u0430\u0444\u0430\u0437\u0430 \u0413\u0430\u0440\u0431\u0456\u044f"
+    ],
     "name:ben_x_preferred":[
         "\u0998\u09be\u09b0\u09ac\u09bf\u09af\u09bc\u09be \u0997\u09ad\u09b0\u09cd\u09a8\u09cb\u09b0\u09c7\u099f"
     ],
@@ -113,6 +119,9 @@
     "name:fra_x_variant":[
         "Gouvernorat de Gharbeya"
     ],
+    "name:gle_x_preferred":[
+        "Gobharn\u00f3ireacht Gharbia"
+    ],
     "name:guj_x_preferred":[
         "\u0a98\u0abe\u0ab0\u0aac\u0ac0\u0aaf\u0abe \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0aae\u0ac7\u0a82\u0a9f"
     ],
@@ -125,8 +134,14 @@
     "name:hun_x_preferred":[
         "El-Gharbia"
     ],
+    "name:hun_x_variant":[
+        "Gharbijja"
+    ],
     "name:hye_x_preferred":[
         "\u0542\u0561\u0580\u0562\u056b\u0561"
+    ],
+    "name:hyw_x_preferred":[
+        "\u0542\u0561\u0580\u057a\u056b\u0561"
     ],
     "name:ind_x_preferred":[
         "Kegubernuran Al Gharbiyah"
@@ -167,6 +182,9 @@
     "name:msa_x_preferred":[
         "Gharbia Governorate"
     ],
+    "name:nan_x_preferred":[
+        "Gharbia S\u00e9ng"
+    ],
     "name:nld_x_preferred":[
         "Al Gharbiyah"
     ],
@@ -206,11 +224,17 @@
     "name:swe_x_preferred":[
         "Guvernementet Al-Gharbiyya"
     ],
+    "name:swe_x_variant":[
+        "Al-Gharbiyya"
+    ],
     "name:tam_x_preferred":[
         "\u0b95\u0bbe\u0bb0\u0baa\u0bc0\u0b86 \u0b95\u0bcb\u0bb5\u0bc6\u0bb0\u0bcd\u0ba9\u0bcb\u0bb0\u0bc7"
     ],
     "name:tel_x_preferred":[
         "\u0c17\u0c3e\u0c30\u0c4d\u0c2c\u0c3f\u0c2f\u0c3e \u0c17\u0c35\u0c30\u0c4d\u0c28\u0c30\u0c47\u0c1f\u0c4d"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0412\u0438\u043b\u043e\u044f\u0442\u0438 \u0492\u0430\u0440\u0431\u0438\u044f"
     ],
     "name:tha_x_preferred":[
         "\u0e01\u0e32\u0e2e\u0e4c\u0e40\u0e1a\u0e35\u0e22 \u0e42\u0e01\u0e40\u0e27\u0e2d\u0e42\u0e19\u0e40\u0e23\u0e17"
@@ -236,8 +260,14 @@
     "name:war_x_preferred":[
         "Gharbia"
     ],
+    "name:wuu_x_preferred":[
+        "\u897f\u90e8\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u897f\u90e8\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Gharbia Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -361,7 +391,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636502260,
+    "wof:lastmodified":1690876033,
     "wof:name":"Al Gharbiyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/709/89/85670989.geojson
+++ b/data/856/709/89/85670989.geojson
@@ -55,6 +55,9 @@
     "name:azb_x_preferred":[
         "\u0627\u0633\u0645\u0627\u0639\u06cc\u0644\u06cc\u0647 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "\u018fl-\u0130smailiyy\u0259 m\u00fchaf\u0259z\u0259si"
+    ],
     "name:ben_x_preferred":[
         "\u0987\u09b8\u09cd\u09ae\u09be\u0987\u09b2\u09bf\u09af\u09bc\u09be \u0997\u09ad\u09b0\u09cd\u09a8\u09cb\u09b0\u09c7\u099f"
     ],
@@ -82,6 +85,9 @@
     "name:deu_x_preferred":[
         "al-Isma\u02bfiliyya"
     ],
+    "name:deu_x_variant":[
+        "Gouvernement Ismailia"
+    ],
     "name:ell_x_preferred":[
         "\u039a\u03c5\u03b2\u03b5\u03c1\u03bd\u03b5\u03af\u03bf \u0399\u03c3\u03bc\u03b1\u03b7\u03bb\u03af\u03b1\u03c2"
     ],
@@ -108,6 +114,9 @@
     ],
     "name:fra_x_variant":[
         "Gouvernorat d'Isma\u00eflia"
+    ],
+    "name:gle_x_preferred":[
+        "Gobharn\u00f3ireacht Ismailia"
     ],
     "name:guj_x_preferred":[
         "\u0a87\u0ab8\u0acd\u0aae\u0abe\u0a87\u0ab2\u0abf\u0aaf\u0abe \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
@@ -160,8 +169,14 @@
     "name:mar_x_preferred":[
         "\u0907\u0938\u094d\u092e\u093e\u0908\u0932\u093f\u092f\u093e \u0917\u0935\u094d\u0939\u0930\u094d\u0928\u094b\u0930\u0947\u091f"
     ],
+    "name:mkd_x_preferred":[
+        "\u0418\u0441\u043c\u0430\u0438\u043b\u0438\u0458\u0430"
+    ],
     "name:msa_x_preferred":[
         "Ismailia Governorate"
+    ],
+    "name:nan_x_preferred":[
+        "Ismailia S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Isma\u00eflia"
@@ -211,6 +226,9 @@
     "name:tel_x_preferred":[
         "\u0c07\u0c38\u0c4d\u0c2e\u0c3e\u0c2f\u0c3f\u0c32\u0c3f\u0c2f\u0c3e \u0c17\u0c35\u0c30\u0c4d\u0c28\u0c30\u0c47\u0c1f\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u0412\u0438\u043b\u043e\u044f\u0442\u0438 \u0418\u0441\u043c\u043e\u0438\u043b\u0438\u044f"
+    ],
     "name:tha_x_preferred":[
         "\u0e2d\u0e34\u0e2a\u0e21\u0e32\u0e40\u0e25\u0e35\u0e22 \u0e01\u0e2d\u0e1f\u0e40\u0e27\u0e2d\u0e42\u0e19\u0e40\u0e23\u0e17"
     ],
@@ -235,8 +253,14 @@
     "name:war_x_preferred":[
         "Ismailia"
     ],
+    "name:wuu_x_preferred":[
+        "\u4f0a\u65af\u6885\u5229\u4e9a\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u4f0a\u65af\u6885\u5229\u4e9a\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Ismailia Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -359,7 +383,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636502259,
+    "wof:lastmodified":1690876032,
     "wof:name":"Al Isma`iliyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/709/95/85670995.geojson
+++ b/data/856/709/95/85670995.geojson
@@ -54,6 +54,9 @@
     "name:azb_x_preferred":[
         "\u0645\u0646\u0648\u0641\u06cc\u0647 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "\u0259l-Minufiyy\u0259 m\u00fchaf\u0259z\u0259si"
+    ],
     "name:bel_x_preferred":[
         "\u041c\u0456\u043d\u0443\u0444\u0456\u044f"
     ],
@@ -108,6 +111,9 @@
     "name:fra_x_variant":[
         "Gouvernorat de Menufeya"
     ],
+    "name:gle_x_preferred":[
+        "Gobharn\u00f3ireacht Monufia"
+    ],
     "name:guj_x_preferred":[
         "\u0aae\u0acb\u0aa8\u0ac1\u0aab\u0abf\u0aaf\u0abe \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
     ],
@@ -159,6 +165,9 @@
     "name:msa_x_preferred":[
         "Monufia Governorate"
     ],
+    "name:nan_x_preferred":[
+        "Monufia S\u00e9ng"
+    ],
     "name:nld_x_preferred":[
         "Al Minufiyah"
     ],
@@ -204,6 +213,9 @@
     "name:tel_x_preferred":[
         "\u0c2e\u0c4b\u0c28\u0c42\u0c2b\u0c3f\u0c2f\u0c3e \u0c17\u0c35\u0c30\u0c4d\u0c28\u0c30\u0c47\u0c1f\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u0412\u0438\u043b\u043e\u044f\u0442\u0438 \u041c\u0438\u043d\u0443\u0444\u0438\u044f"
+    ],
     "name:tha_x_preferred":[
         "\u0e42\u0e21\u0e19\u0e39\u0e40\u0e1f\u0e35\u0e22 \u0e42\u0e01\u0e40\u0e27\u0e2d\u0e42\u0e19\u0e40\u0e23\u0e17"
     ],
@@ -229,8 +241,17 @@
     "name:war_x_preferred":[
         "Monufia"
     ],
+    "name:wuu_x_preferred":[
+        "\u7c73\u52aa\u592b\u7701"
+    ],
+    "name:yid_x_preferred":[
+        "\u05de\u05d0\u05e0\u05d5\u05e4\u05d9\u05e2 \u05d2\u05d5\u05d1\u05e2\u05e8\u05e0\u05d9\u05e2"
+    ],
     "name:zho_x_preferred":[
         "\u7c73\u52aa\u592b\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Monufia Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -352,7 +373,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636502259,
+    "wof:lastmodified":1690876032,
     "wof:name":"Al Minufiyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/709/99/85670999.geojson
+++ b/data/856/709/99/85670999.geojson
@@ -48,11 +48,17 @@
     "name:ara_x_variant":[
         "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0642\u0627\u0647\u0631\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0642\u0627\u0647\u0631\u0647"
+    ],
     "name:ast_x_preferred":[
         "El Cairu"
     ],
     "name:azb_x_preferred":[
         "\u0642\u0627\u0647\u0631\u0647 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
+    ],
+    "name:aze_x_preferred":[
+        "\u0259l-Qahir\u0259 m\u00fchaf\u0259z\u0259si"
     ],
     "name:bel_x_preferred":[
         "\u041c\u0443\u0445\u0430\u0444\u0430\u0437\u0430 \u041a\u0430\u0456\u0440"
@@ -78,6 +84,12 @@
     "name:ces_x_preferred":[
         "K\u00e1hira"
     ],
+    "name:ckb_x_preferred":[
+        "\u067e\u0627\u0631\u06ce\u0632\u06af\u0627\u06cc \u0642\u0627\u06be\u06cc\u0631\u06d5"
+    ],
+    "name:cym_x_preferred":[
+        "Llywodraethiaeth Cairo"
+    ],
     "name:dan_x_preferred":[
         "Al Qahirah"
     ],
@@ -85,7 +97,8 @@
         "Kairo"
     ],
     "name:deu_x_variant":[
-        "al-Qahira"
+        "al-Qahira",
+        "Gouvernement Kairo"
     ],
     "name:ell_x_preferred":[
         "\u039a\u03c5\u03b2\u03b5\u03c1\u03bd\u03b5\u03af\u03bf \u03c4\u03bf\u03c5 \u039a\u03b1\u0390\u03c1\u03bf\u03c5"
@@ -103,6 +116,9 @@
     "name:epo_x_preferred":[
         "Provinco Kairo"
     ],
+    "name:eus_x_preferred":[
+        "Kairoko gobernazioa"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0633\u062a\u0627\u0646 \u0642\u0627\u0647\u0631\u0647"
     ],
@@ -115,6 +131,9 @@
     "name:fra_x_variant":[
         "gouvernorat du Caire",
         "Gouvernorat du Caire"
+    ],
+    "name:gle_x_preferred":[
+        "Gobharn\u00f3ireacht Chaireo"
     ],
     "name:guj_x_preferred":[
         "\u0a95\u0ac8\u0ab0\u0acb \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
@@ -167,14 +186,23 @@
     "name:mar_x_preferred":[
         "\u0915\u0948\u0930\u094b \u0917\u0935\u094d\u0939\u0930\u094d\u0928\u094b\u0930\u0947\u091f"
     ],
+    "name:mlt_x_preferred":[
+        "Governorat tal-Kajr"
+    ],
     "name:msa_x_preferred":[
         "Cairo Governorate"
+    ],
+    "name:msa_x_variant":[
+        "Kegabenoran Kaherah"
     ],
     "name:nan_x_preferred":[
         "Cairo S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Ca\u00efro"
+    ],
+    "name:nld_x_variant":[
+        "Gouvernement Ca\u00efro"
     ],
     "name:nob_x_preferred":[
         "Guvernementet Al Qahirah"
@@ -251,11 +279,17 @@
     "name:war_x_preferred":[
         "Cairo"
     ],
+    "name:wuu_x_preferred":[
+        "\u5f00\u7f57\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u5f00\u7f57"
     ],
     "name:zho_x_variant":[
         "\u5f00\u7f57\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Cairo Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -381,7 +415,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636502260,
+    "wof:lastmodified":1690876033,
     "wof:name":"Al Qahirah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/03/85671003.geojson
+++ b/data/856/710/03/85671003.geojson
@@ -54,6 +54,9 @@
     "name:azb_x_preferred":[
         "\u0642\u0644\u06cc\u0648\u0628\u06cc\u0647 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "\u0259l-Q\u0259lyubiyy\u0259 m\u00fchaf\u0259z\u0259si"
+    ],
     "name:ben_x_preferred":[
         "\u0995\u09be\u09b2\u09c1\u09ac\u09bf\u09af\u09bc\u09be \u0997\u09ad\u09b0\u09cd\u09a8\u09cb\u09b0\u09c7\u099f"
     ],
@@ -109,6 +112,9 @@
     "name:fra_x_variant":[
         "Gouvernorat de Qalyubiya"
     ],
+    "name:gle_x_preferred":[
+        "Gobharn\u00f3ireacht Qalyubia"
+    ],
     "name:guj_x_preferred":[
         "\u0a95\u0acd\u0ab5\u0abe\u0ab2\u0abf\u0aac\u0abf\u0aaf\u0abe \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
     ],
@@ -120,6 +126,9 @@
     ],
     "name:hun_x_preferred":[
         "Al-Qalyubiyah"
+    ],
+    "name:hye_x_preferred":[
+        "\u0554\u0561\u056c\u0575\u0578\u0582\u0562\u056b\u0561"
     ],
     "name:ind_x_preferred":[
         "Kegubernuran Al Qalyubiyah"
@@ -156,6 +165,9 @@
     ],
     "name:msa_x_preferred":[
         "Qalyubia Governorate"
+    ],
+    "name:nan_x_preferred":[
+        "Qalyubiyya S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Al Qalyubiyah"
@@ -199,6 +211,9 @@
     "name:tel_x_preferred":[
         "\u0c16\u0c3e\u0c32\u0c4d\u0c2f\u0c41\u0c2c\u0c3f\u0c2f\u0c3e \u0c17\u0c35\u0c30\u0c4d\u0c28\u0c30\u0c47\u0c1f\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u0412\u0438\u043b\u043e\u044f\u0442\u0438 \u049a\u0430\u043b\u044e\u0431\u0438\u044f"
+    ],
     "name:tha_x_preferred":[
         "\u0e2d\u0e31\u0e25\u0e01\u0e2d\u0e25\u0e22\u0e38\u0e1a\u0e35\u0e22\u0e30\u0e2b\u0e4c"
     ],
@@ -224,8 +239,14 @@
     "name:war_x_preferred":[
         "Qalyubia"
     ],
+    "name:wuu_x_preferred":[
+        "\u76d6\u5362\u6bd4\u5c24\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u84cb\u76e7\u6bd4\u5c24\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Qalyubiyya Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -351,7 +372,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636502260,
+    "wof:lastmodified":1690876035,
     "wof:name":"Al Qalyubiyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/07/85671007.geojson
+++ b/data/856/710/07/85671007.geojson
@@ -51,6 +51,9 @@
     "name:arz_x_preferred":[
         "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u0634\u0631\u0642\u064a\u0647"
     ],
+    "name:aze_x_preferred":[
+        "\u0259\u015f-\u015e\u0259rqiyy\u0259 m\u00fchaf\u0259z\u0259si"
+    ],
     "name:ben_x_preferred":[
         "\u0986\u09b2 \u09b6\u09be\u09b0\u0995\u09bf\u09af\u09bc\u09be \u0997\u09ad\u09b0\u09cd\u09a8\u09cb\u09b0\u09c7\u099f"
     ],
@@ -102,6 +105,9 @@
     "name:fra_x_preferred":[
         "Ach-Charqiya"
     ],
+    "name:gle_x_preferred":[
+        "Gobharn\u00f3ireacht Al Sharqia"
+    ],
     "name:guj_x_preferred":[
         "\u0a85\u0ab2 \u0ab6\u0abe\u0ab0\u0a95\u0abf\u0aaf\u0abe \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
     ],
@@ -152,6 +158,9 @@
     ],
     "name:msa_x_preferred":[
         "Al Sharqia Governorate"
+    ],
+    "name:nan_x_preferred":[
+        "Sharqia S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Ash Sharqiyah"
@@ -207,6 +216,9 @@
     "name:tel_x_preferred":[
         "\u0c05\u0c32\u0c4d \u0c37\u0c30\u0c4d\u0c16\u0c3f\u0c2f\u0c3e \u0c17\u0c35\u0c30\u0c4d\u0c28\u0c30\u0c47\u0c1f\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u0412\u0438\u043b\u043e\u044f\u0442\u0438 \u0428\u0430\u0440\u049b\u0438\u044f"
+    ],
     "name:tha_x_preferred":[
         "\u0e40\u0e1a\u0e42\u0e23\u0e42\u0e27"
     ],
@@ -225,14 +237,23 @@
     "name:urd_x_preferred":[
         "\u0645\u062d\u0627\u0641\u0638\u06c1 \u0627\u0644\u0634\u0631\u0642\u06cc\u06c1"
     ],
+    "name:uzb_x_preferred":[
+        "Sharqiy viloyat"
+    ],
     "name:vie_x_preferred":[
         "T\u1ec9nh Al Sharqia"
     ],
     "name:war_x_preferred":[
         "Sharqia"
     ],
+    "name:wuu_x_preferred":[
+        "\u4e1c\u90e8\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u6771\u90e8\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Sharqia Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -358,7 +379,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636502262,
+    "wof:lastmodified":1690876038,
     "wof:name":"Ash Sharqiyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/13/85671013.geojson
+++ b/data/856/710/13/85671013.geojson
@@ -57,6 +57,9 @@
     "name:azb_x_preferred":[
         "\u0633\u0648\u0626\u0632 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "S\u00fcvey\u015f m\u00fchaf\u0259z\u0259si"
+    ],
     "name:bak_x_preferred":[
         "\u04d8\u0441-\u0421\u04af\u04d9\u0439\u0441"
     ],
@@ -77,6 +80,9 @@
     ],
     "name:ces_x_preferred":[
         "Suez"
+    ],
+    "name:cym_x_preferred":[
+        "Llywodraethiaeth Suez"
     ],
     "name:dan_x_preferred":[
         "Suez Governorate"
@@ -109,6 +115,9 @@
     ],
     "name:fra_x_variant":[
         "Gouvernorat de Suez"
+    ],
+    "name:gle_x_preferred":[
+        "Gobharn\u00f3ireacht Shuais"
     ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac1\u0a8f\u0a9d \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
@@ -158,8 +167,14 @@
     "name:mar_x_preferred":[
         "\u0938\u0941\u090f\u091d \u0917\u0935\u094d\u0939\u0930\u094d\u0928\u094b\u0930\u0947\u091f"
     ],
+    "name:mkd_x_preferred":[
+        "\u0421\u0443\u0435\u0446"
+    ],
     "name:msa_x_preferred":[
         "Pentadbiran Suez"
+    ],
+    "name:nan_x_preferred":[
+        "Suez S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Suez"
@@ -230,8 +245,14 @@
     "name:war_x_preferred":[
         "Suez"
     ],
+    "name:wuu_x_preferred":[
+        "\u82cf\u4f0a\u58eb\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u8607\u4f0a\u58eb\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Suez Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -357,7 +378,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636502263,
+    "wof:lastmodified":1690876041,
     "wof:name":"As Suways",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/17/85671017.geojson
+++ b/data/856/710/17/85671017.geojson
@@ -54,6 +54,9 @@
     "name:azb_x_preferred":[
         "\u062f\u0642\u0647\u0644\u06cc\u0647 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "\u0259d-D\u0259q\u0259hliyy\u0259 m\u00fchaf\u0259z\u0259si"
+    ],
     "name:bel_x_preferred":[
         "\u0414\u0430\u043a\u0430\u0445\u043b\u0456\u044f"
     ],
@@ -111,6 +114,12 @@
     "name:fra_x_variant":[
         "Gouvernorat de Dakahleya"
     ],
+    "name:frr_x_preferred":[
+        "Dakahlijja"
+    ],
+    "name:gle_x_preferred":[
+        "Gobharn\u00f3ireacht Dakahlia"
+    ],
     "name:guj_x_preferred":[
         "\u0aa1\u0abe\u0a95\u0abe\u0ab9\u0ab2\u0abf\u0a86 \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
     ],
@@ -165,11 +174,17 @@
     "name:msa_x_preferred":[
         "Dakahlia Governorate"
     ],
+    "name:nan_x_preferred":[
+        "Dakahlia S\u00e9ng"
+    ],
     "name:nld_x_preferred":[
         "Ad Daqahliyah"
     ],
     "name:nob_x_preferred":[
         "Ad Daqahliyah"
+    ],
+    "name:oss_x_preferred":[
+        "\u0414\u0430\u043a\u0430\u0445\u043b\u0438"
     ],
     "name:pnb_x_preferred":[
         "\u0635\u0648\u0628\u06c1 \u062f\u0627\u0642\u0627\u06c1\u0644\u06cc\u06c1"
@@ -210,6 +225,9 @@
     "name:tel_x_preferred":[
         "\u0c21\u0c3e\u0c15\u0c3e\u0c39\u0c3f\u0c32\u0c3e \u0c17\u0c35\u0c30\u0c4d\u0c28\u0c30\u0c47\u0c1f\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u0412\u0438\u043b\u043e\u044f\u0442\u0438 \u0414\u0430\u049b\u0430\u04b3\u043b\u0438\u044f"
+    ],
     "name:tha_x_preferred":[
         "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e19\u0e04\u0e23\u0e2a\u0e27\u0e23\u0e23\u0e04\u0e4c"
     ],
@@ -234,8 +252,14 @@
     "name:war_x_preferred":[
         "Dakahlia"
     ],
+    "name:wuu_x_preferred":[
+        "\u4ee3\u76d6\u8d6b\u5229\u8036\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u4ee3\u84cb\u8d6b\u5229\u8036\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Dakahlia Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -360,7 +384,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636502261,
+    "wof:lastmodified":1690876037,
     "wof:name":"Ad Daqahliyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/21/85671021.geojson
+++ b/data/856/710/21/85671021.geojson
@@ -56,6 +56,9 @@
     "name:azb_x_preferred":[
         "\u067e\u0648\u0631\u062a\u200c\u0633\u0639\u06cc\u062f \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "Port-S\u0259id m\u00fchaf\u0259z\u0259si"
+    ],
     "name:bel_x_preferred":[
         "\u041c\u0443\u0445\u0430\u0444\u0430\u0437\u0430 \u041f\u043e\u0440\u0442-\u0421\u0430\u0456\u0434"
     ],
@@ -109,6 +112,9 @@
     "name:fra_x_variant":[
         "Gouvernorat de Port-Sa\u00efd"
     ],
+    "name:gle_x_preferred":[
+        "Gobharn\u00f3ireacht Port Said"
+    ],
     "name:guj_x_preferred":[
         "\u0aaa\u0acb\u0ab0\u0acd\u0a9f \u0ab8\u0ac7\u0aa1 \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
     ],
@@ -120,6 +126,9 @@
     ],
     "name:hun_x_preferred":[
         "Port Sza\u00edd"
+    ],
+    "name:hye_x_preferred":[
+        "\u054a\u0578\u0580\u057f \u054d\u0561\u056b\u0564"
     ],
     "name:ind_x_preferred":[
         "Kegubernuran Bur Sa'id"
@@ -156,6 +165,9 @@
     ],
     "name:msa_x_preferred":[
         "Port Said Governorate"
+    ],
+    "name:nan_x_preferred":[
+        "Said K\u00e1ng S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Port Said"
@@ -202,6 +214,9 @@
     "name:tel_x_preferred":[
         "\u0c2a\u0c4b\u0c30\u0c4d\u0c1f\u0c4d \u0c38\u0c46\u0c2f\u0c3f\u0c26\u0c4d \u0c17\u0c35\u0c30\u0c4d\u0c28\u0c30\u0c47\u0c1f\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u0412\u0438\u043b\u043e\u044f\u0442\u0438 \u041f\u043e\u0440\u0442-\u0421\u0430\u0438\u0434"
+    ],
     "name:tha_x_preferred":[
         "\u0e40\u0e21\u0e37\u0e2d\u0e07\u0e1e\u0e2d\u0e23\u0e4c\u0e15\u0e0b\u0e32\u0e2d\u0e34\u0e14"
     ],
@@ -220,14 +235,23 @@
     "name:urd_x_preferred":[
         "\u0645\u062d\u0627\u0641\u0638\u06c1 \u067e\u0648\u0631\u0679 \u0633\u0639\u06cc\u062f"
     ],
+    "name:uzb_x_preferred":[
+        "Port Said Gubernatorligi"
+    ],
     "name:vie_x_preferred":[
         "T\u1ec9nh Port Said"
     ],
     "name:war_x_preferred":[
         "Port Said"
     ],
+    "name:wuu_x_preferred":[
+        "\u585e\u5f97\u6e2f\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u585e\u5f97\u6e2f\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Port Said Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -353,7 +377,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636502261,
+    "wof:lastmodified":1690876037,
     "wof:name":"Bur Sa`id",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/25/85671025.geojson
+++ b/data/856/710/25/85671025.geojson
@@ -52,6 +52,9 @@
     "name:azb_x_preferred":[
         "\u062f\u0645\u06cc\u0627\u0637 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "D\u00fcmyat m\u00fchaf\u0259z\u0259si"
+    ],
     "name:bel_x_preferred":[
         "\u0414\u0443\u043c'\u044f\u0442"
     ],
@@ -66,6 +69,9 @@
     ],
     "name:cat_x_preferred":[
         "Governaci\u00f3 de Damietta"
+    ],
+    "name:ceb_x_preferred":[
+        "Mu\u1e29\u0101faz\u0327at Dumy\u0101\u0163"
     ],
     "name:ces_x_preferred":[
         "Dimj\u00e1t"
@@ -103,8 +109,14 @@
     "name:fra_x_variant":[
         "Gouvernorat de Damiette"
     ],
+    "name:gle_x_preferred":[
+        "Gobharn\u00f3ireacht Damietta"
+    ],
     "name:guj_x_preferred":[
         "\u0aa1\u0ac7\u0aae\u0abf\u0a8f\u0a9f\u0abe \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d3\u05de\u05d9\u05d0\u05d8"
     ],
     "name:hin_x_preferred":[
         "\u0921\u0941\u092e\u094d\u092f\u093e\u0924"
@@ -157,6 +169,9 @@
     "name:msa_x_preferred":[
         "Damietta Governorate"
     ],
+    "name:nan_x_preferred":[
+        "Damietta S\u00e9ng"
+    ],
     "name:nld_x_preferred":[
         "Dumyat"
     ],
@@ -205,6 +220,9 @@
     "name:tel_x_preferred":[
         "\u0c21\u0c3e\u0c2e\u0c3f\u0c2f\u0c46\u0c1f\u0c4d\u0c1f\u0c3e \u0c17\u0c35\u0c30\u0c4d\u0c28\u0c30\u0c47\u0c1f\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u0412\u0438\u043b\u043e\u044f\u0442\u0438 \u0414\u0443\u043c\u0451\u0442"
+    ],
     "name:tha_x_preferred":[
         "\u0e14\u0e31\u0e21\u0e22\u0e31\u0e15"
     ],
@@ -230,8 +248,14 @@
     "name:war_x_preferred":[
         "Damietta"
     ],
+    "name:wuu_x_preferred":[
+        "\u675c\u59c6\u4e9a\u7279\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u675c\u59c6\u4e9e\u7279\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Damietta Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -357,7 +381,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636502264,
+    "wof:lastmodified":1690876042,
     "wof:name":"Dumyat",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/31/85671031.geojson
+++ b/data/856/710/31/85671031.geojson
@@ -54,6 +54,9 @@
     "name:azb_x_preferred":[
         "\u0645\u0637\u0631\u0648\u062d \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "M\u0259truh m\u00fchaf\u0259z\u0259si"
+    ],
     "name:ben_x_preferred":[
         "\u09ae\u09be\u09a4\u09cd\u09b0\u09c1\u09b9 \u0997\u09ad\u09b0\u09cd\u09a8\u09cb\u09b0\u09c7\u099f"
     ],
@@ -104,6 +107,9 @@
     ],
     "name:fra_x_variant":[
         "Gouvernorat de Marsa-Matruh"
+    ],
+    "name:gle_x_preferred":[
+        "Gobharn\u00f3ireacht Matrouh"
     ],
     "name:guj_x_preferred":[
         "\u0aae\u0a9f\u0acd\u0ab0\u0acb\u0ab9 \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
@@ -162,6 +168,12 @@
     "name:msa_x_preferred":[
         "Matrouh Governorate"
     ],
+    "name:msa_x_variant":[
+        "Kegabenoran Matrouh"
+    ],
+    "name:nan_x_preferred":[
+        "Matrouh S\u00e9ng"
+    ],
     "name:nld_x_preferred":[
         "Matruh"
     ],
@@ -207,6 +219,9 @@
     "name:tel_x_preferred":[
         "\u0c2e\u0c3e\u0c1f\u0c4d\u0c30\u0c4b \u0c17\u0c35\u0c30\u0c4d\u0c28\u0c30\u0c47\u0c1f\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u0412\u0438\u043b\u043e\u044f\u0442\u0438 \u041c\u0430\u0442\u0440\u0443\u04b3"
+    ],
     "name:tha_x_preferred":[
         "\u0e40\u0e02\u0e15\u0e21\u0e31\u0e0f\u0e23\u0e39\u0e2b\u0e4c"
     ],
@@ -239,6 +254,9 @@
     ],
     "name:zho_x_preferred":[
         "\u99ac\u7279\u9b6f\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Matrouh Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -363,7 +381,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636502262,
+    "wof:lastmodified":1690876038,
     "wof:name":"Matruh",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/35/85671035.geojson
+++ b/data/856/710/35/85671035.geojson
@@ -57,6 +57,9 @@
     "name:azb_x_preferred":[
         "\u0628\u062d\u06cc\u0631\u0647 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "\u018fl-B\u00fcheyr\u0259 m\u00fchaf\u0259z\u0259si"
+    ],
     "name:bel_x_preferred":[
         "\u041c\u0443\u0445\u0430\u0444\u0430\u0437\u0430 \u0411\u0443\u0445\u0435\u0439\u0440\u0430"
     ],
@@ -113,6 +116,12 @@
     "name:fra_x_variant":[
         "Gouvernorat de Beheira"
     ],
+    "name:frr_x_preferred":[
+        "Buhaira"
+    ],
+    "name:gle_x_preferred":[
+        "Gobharn\u00f3ireacht Beheira"
+    ],
     "name:guj_x_preferred":[
         "\u0aac\u0ac0\u0ab9\u0ac7\u0a87\u0ab0\u0abe \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
     ],
@@ -164,6 +173,9 @@
     "name:msa_x_preferred":[
         "Beheira Governorate"
     ],
+    "name:nan_x_preferred":[
+        "Beheira S\u00e9ng"
+    ],
     "name:nld_x_preferred":[
         "Al Buhayrah"
     ],
@@ -181,6 +193,9 @@
     ],
     "name:ron_x_preferred":[
         "Guvernoratul Beheira"
+    ],
+    "name:ron_x_variant":[
+        "guvernoratul Beheira"
     ],
     "name:rus_x_preferred":[
         "\u0411\u0443\u0445\u0435\u0439\u0440\u0430"
@@ -209,8 +224,14 @@
     "name:tam_x_preferred":[
         "\u0baa\u0bc6\u0bb9\u0bc6\u0baf\u0bbf\u0bb0\u0bbe  \u0b95\u0bcb\u0bb5\u0bc6\u0bb0\u0bcd\u0ba9\u0bcb\u0bb0\u0bc7"
     ],
+    "name:tam_x_variant":[
+        "\u0baa\u0bc6\u0bb9\u0bc6\u0baf\u0bbf\u0bb0\u0bbe \u0b95\u0bcb\u0bb5\u0bc6\u0bb0\u0bcd\u0ba9\u0bcb\u0bb0\u0bc7"
+    ],
     "name:tel_x_preferred":[
         "\u0c2c\u0c46\u0c39\u0c40\u0c30\u0c3e \u0c17\u0c35\u0c30\u0c4d\u0c28\u0c30\u0c47\u0c1f\u0c4d"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0412\u0438\u043b\u043e\u044f\u0442\u0438 \u0411\u0443\u04b3\u0430\u0439\u0440\u0430"
     ],
     "name:tha_x_preferred":[
         "\u0e40\u0e1a\u0e40\u0e2e\u0e22\u0e23\u0e32 \u0e42\u0e01\u0e40\u0e27\u0e2d\u0e42\u0e23\u0e40\u0e19\u0e17"
@@ -237,8 +258,14 @@
     "name:war_x_preferred":[
         "Beheira"
     ],
+    "name:wuu_x_preferred":[
+        "\u5e03\u6d77\u62c9\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u5e03\u6d77\u62c9\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Beheira Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -362,7 +389,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636502261,
+    "wof:lastmodified":1690876035,
     "wof:name":"Al Buhayrah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/37/85671037.geojson
+++ b/data/856/710/37/85671037.geojson
@@ -51,6 +51,9 @@
     "name:azb_x_preferred":[
         "\u0641\u06cc\u0648\u0645 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "\u0259l-F\u0259yyum m\u00fchaf\u0259z\u0259si"
+    ],
     "name:ben_x_preferred":[
         "\u0986\u09b2 \u09ab\u09be\u09df\u09c1\u09ae"
     ],
@@ -104,6 +107,9 @@
     "name:fra_x_variant":[
         "Gouvernorat du Fayoum"
     ],
+    "name:gle_x_preferred":[
+        "Gobharn\u00f3ireacht Faiyum"
+    ],
     "name:heb_x_preferred":[
         "\u05d0\u05dc-\u05e4\u05d9\u05d5\u05dd"
     ],
@@ -143,6 +149,9 @@
     "name:lit_x_preferred":[
         "Fajumo muchafaza"
     ],
+    "name:nan_x_preferred":[
+        "Faiyum S\u00e9ng"
+    ],
     "name:nld_x_preferred":[
         "Fajoem"
     ],
@@ -179,6 +188,12 @@
     "name:swe_x_preferred":[
         "Guvernementet Faijum"
     ],
+    "name:swe_x_variant":[
+        "Faijum"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0412\u0438\u043b\u043e\u044f\u0442\u0438 \u0424\u0430\u0439\u044e\u043c"
+    ],
     "name:tha_x_preferred":[
         "\u0e40\u0e02\u0e15\u0e1c\u0e39\u0e49\u0e27\u0e48\u0e32\u0e01\u0e32\u0e23\u0e2d\u0e31\u0e25\u0e1f\u0e31\u0e22\u0e22\u0e39\u0e21"
     ],
@@ -200,8 +215,14 @@
     "name:war_x_preferred":[
         "Faiyum"
     ],
+    "name:wuu_x_preferred":[
+        "\u6cd5\u5c24\u59c6\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u6cd5\u5c24\u59c6\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Faiyum Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -327,7 +348,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636502262,
+    "wof:lastmodified":1690876039,
     "wof:name":"Al Fayyum",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/41/85671041.geojson
+++ b/data/856/710/41/85671041.geojson
@@ -61,6 +61,9 @@
     "name:azb_x_preferred":[
         "\u0627\u0633\u06a9\u0646\u062f\u0631\u06cc\u0647 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "\u0259l-\u0130sk\u0259nd\u0259riyy\u0259 m\u00fchaf\u0259z\u0259si"
+    ],
     "name:bar_x_preferred":[
         "Alexandria"
     ],
@@ -88,11 +91,17 @@
     "name:ces_x_preferred":[
         "Alexandrie"
     ],
+    "name:ckb_x_preferred":[
+        "\u067e\u0627\u0631\u06ce\u0632\u06af\u0627\u06cc \u0626\u06d5\u0633\u06a9\u06d5\u0646\u062f\u06d5\u0631\u06cc\u06d5"
+    ],
     "name:dan_x_preferred":[
         "Alexandria"
     ],
     "name:deu_x_preferred":[
         "al-Iskandariyya"
+    ],
+    "name:deu_x_variant":[
+        "Gouvernement Alexandria"
     ],
     "name:ell_x_preferred":[
         "\u039a\u03c5\u03b2\u03b5\u03c1\u03bd\u03b5\u03af\u03bf \u0391\u03bb\u03b5\u03be\u03ac\u03bd\u03b4\u03c1\u03b5\u03b9\u03b1\u03c2"
@@ -122,6 +131,9 @@
     "name:fra_x_variant":[
         "gouvernorat d'Alexandrie"
     ],
+    "name:gle_x_preferred":[
+        "Gobharn\u00f3ireacht Chathair Alastair"
+    ],
     "name:guj_x_preferred":[
         "\u0a8f\u0ab2\u0ac7\u0a95\u0acd\u0a9d\u0abe\u0aa8\u0acd\u0aa1\u0acd\u0ab0\u0abf\u0aaf\u0abe \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
     ],
@@ -136,6 +148,9 @@
     ],
     "name:hye_x_preferred":[
         "\u0531\u056c\u0565\u0584\u057d\u0561\u0576\u0564\u0580\u056b\u0561"
+    ],
+    "name:hyw_x_preferred":[
+        "\u0531\u0572\u0565\u0584\u057d\u0561\u0576\u057f\u0580\u056b\u0578\u0575 \u0576\u0561\u0570\u0561\u0576\u0563"
     ],
     "name:ind_x_preferred":[
         "Kegubernuran Al Iskandariyah"
@@ -179,6 +194,12 @@
     "name:msa_x_preferred":[
         "Alexandria Governorate"
     ],
+    "name:msa_x_variant":[
+        "Kegabenoran Iskandariah"
+    ],
+    "name:nan_x_preferred":[
+        "Alexandria S\u00e9ng"
+    ],
     "name:nld_x_preferred":[
         "Alexandri\u00eb"
     ],
@@ -206,6 +227,9 @@
     "name:sin_x_preferred":[
         "\u0d87\u0dbd\u0dd9\u0d9a\u0dca\u0dc3\u0dd0\u0db1\u0dca\u0da9\u0dca\u200d\u0dbb\u0dd2\u0dba\u0dcf \u0db4\u0dc5\u0dcf\u0dad"
     ],
+    "name:som_x_preferred":[
+        "Alexandria Governorate"
+    ],
     "name:spa_x_preferred":[
         "Alejandr\u00eda"
     ],
@@ -218,11 +242,17 @@
     "name:swe_x_preferred":[
         "Guvernementet Alexandria"
     ],
+    "name:swe_x_variant":[
+        "Alexandria"
+    ],
     "name:tam_x_preferred":[
         "\u0b85\u0bb2\u0bc6\u0b95\u0bcd\u0b9a\u0bbe\u0ba3\u0bcd\u0b9f\u0bcd\u0bb0\u0bbf\u0baf\u0bbe \u0b95\u0bcb\u0bb5\u0bc6\u0bb0\u0bcd\u0ba9\u0bcb\u0bb0\u0bc7"
     ],
     "name:tel_x_preferred":[
         "\u0c06\u0c32\u0c46\u0c15\u0c4d\u0c38\u0c3e\u0c02\u0c21\u0c4d\u0c30\u0c3f\u0c2f\u0c3e \u0c17\u0c35\u0c30\u0c4d\u0c28\u0c30\u0c47\u0c1f\u0c4d"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0412\u0438\u043b\u043e\u044f\u0442\u0438 \u0418\u0441\u043a\u0430\u043d\u0434\u0430\u0440\u0438\u044f"
     ],
     "name:tha_x_preferred":[
         "\u0e2d\u0e31\u0e25\u0e2d\u0e34\u0e2a\u0e01\u0e31\u0e19\u0e14\u0e32\u0e23\u0e34\u0e22\u0e32\u0e2b\u0e4c"
@@ -248,8 +278,17 @@
     "name:war_x_preferred":[
         "Alexandria"
     ],
+    "name:wuu_x_preferred":[
+        "\u4e9a\u5386\u5c71\u5927\u7701"
+    ],
+    "name:yue_x_preferred":[
+        "\u4e9e\u6b77\u5c71\u5927\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u4e9e\u6b77\u5c71\u5927\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Alexandria Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -374,7 +413,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1614893766,
+    "wof:lastmodified":1690876039,
     "wof:name":"Al Iskandariyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/47/85671047.geojson
+++ b/data/856/710/47/85671047.geojson
@@ -48,11 +48,17 @@
     "name:ara_x_variant":[
         "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u062c\u064a\u0632\u0629"
     ],
+    "name:ary_x_preferred":[
+        "\u0644\u0645\u062d\u0627\u0641\u0638\u0629 \u062f \u0644\u06ad\u064a\u0632\u0629"
+    ],
     "name:arz_x_preferred":[
         "\u0627\u0644\u062c\u064a\u0632\u0647"
     ],
     "name:azb_x_preferred":[
         "\u062c\u06cc\u0632\u0647 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
+    ],
+    "name:aze_x_preferred":[
+        "\u0259l-Ciz\u0259 m\u00fchaf\u0259z\u0259si"
     ],
     "name:bel_x_preferred":[
         "\u042d\u043b\u044c-\u0413\u0456\u0437\u0430"
@@ -74,6 +80,9 @@
     ],
     "name:ces_x_preferred":[
         "G\u00edza"
+    ],
+    "name:crh_x_preferred":[
+        "Giza vil\u00e2yeti"
     ],
     "name:dan_x_preferred":[
         "Al Jizah"
@@ -115,6 +124,9 @@
     "name:fra_x_variant":[
         "Gouvernorat de Gizeh"
     ],
+    "name:gle_x_preferred":[
+        "Gobharn\u00f3ireacht Giza"
+    ],
     "name:guj_x_preferred":[
         "\u0a97\u0abf\u0a9d\u0abe \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
     ],
@@ -129,6 +141,9 @@
     ],
     "name:hye_x_preferred":[
         "\u0531\u056c-\u0533\u056b\u0566\u0561"
+    ],
+    "name:hyw_x_preferred":[
+        "\u053f\u056b\u0566\u0561"
     ],
     "name:ind_x_preferred":[
         "Kegubernuran Al Jizah"
@@ -166,11 +181,20 @@
     "name:msa_x_preferred":[
         "Giza Governorate"
     ],
+    "name:msa_x_variant":[
+        "Kegabenoran Giza"
+    ],
+    "name:nan_x_preferred":[
+        "Giza S\u00e9ng"
+    ],
     "name:nld_x_preferred":[
         "Gizeh"
     ],
     "name:nob_x_preferred":[
         "Guvernementet Al Jizah"
+    ],
+    "name:oss_x_preferred":[
+        "\u042d\u043b\u044c-\u0413\u0438\u0437\u00e6"
     ],
     "name:pnb_x_preferred":[
         "\u0635\u0648\u0628\u06c1 \u063a\u0632\u0627"
@@ -205,6 +229,9 @@
     "name:swe_x_preferred":[
         "Guvernementet Giza"
     ],
+    "name:swe_x_variant":[
+        "Giza"
+    ],
     "name:tam_x_preferred":[
         "\u0b95\u0bbf\u0b9a\u0bbe \u0b95\u0bcb\u0bb5\u0bc6\u0bb0\u0bcd\u0ba9\u0bcb\u0bb0\u0bc7"
     ],
@@ -238,8 +265,14 @@
     "name:war_x_preferred":[
         "Giza"
     ],
+    "name:wuu_x_preferred":[
+        "\u5409\u8428\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u5409\u85a9\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Giza Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -365,7 +398,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636502263,
+    "wof:lastmodified":1690876041,
     "wof:name":"Al Jizah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/49/85671049.geojson
+++ b/data/856/710/49/85671049.geojson
@@ -55,6 +55,9 @@
     "name:azb_x_preferred":[
         "\u0645\u0646\u06cc\u0627 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "\u0259l-Minya m\u00fchaf\u0259z\u0259si"
+    ],
     "name:bel_x_preferred":[
         "\u042d\u043b\u044c-\u041c\u0456\u043d\u044c\u044f"
     ],
@@ -115,11 +118,17 @@
     "name:fra_x_variant":[
         "Gouvernorat de Minya"
     ],
+    "name:gle_x_preferred":[
+        "Gobharn\u00f3ireacht Minya"
+    ],
     "name:guj_x_preferred":[
         "\u0aae\u0abf\u0aa8\u0acd\u0aaf\u0abe \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
     ],
     "name:heb_x_preferred":[
         "\u05de\u05d9\u05e0\u05d9\u05d4"
+    ],
+    "name:heb_x_variant":[
+        "\u05de\u05d7\u05d5\u05d6 \u05d0\u05dc-\u05de\u05d9\u05e0\u05d9\u05d0"
     ],
     "name:hin_x_preferred":[
         "\u092e\u093f\u0928\u094d\u092f\u093e \u092e\u0941\u0939\u093e\u092b\u093c\u091c\u093c\u093e\u0939"
@@ -175,6 +184,9 @@
     "name:msa_x_preferred":[
         "Al Minya"
     ],
+    "name:nan_x_preferred":[
+        "Minya S\u00e9ng"
+    ],
     "name:nld_x_preferred":[
         "Minya"
     ],
@@ -226,6 +238,9 @@
     "name:tel_x_preferred":[
         "\u0c2e\u0c3f\u0c28\u0c4d\u0c2f\u0c3e \u0c17\u0c35\u0c30\u0c4d\u0c28\u0c30\u0c47\u0c1f\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u0412\u0438\u043b\u043e\u044f\u0442\u0438 \u041c\u0438\u043d\u0451"
+    ],
     "name:tha_x_preferred":[
         "\u0e2d\u0e31\u0e25\u0e21\u0e34\u0e40\u0e19\u0e35\u0e22"
     ],
@@ -255,6 +270,9 @@
     ],
     "name:zho_x_preferred":[
         "\u660e\u4e9e\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Minya Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -378,7 +396,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636502263,
+    "wof:lastmodified":1690876041,
     "wof:name":"Al Minya",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/53/85671053.geojson
+++ b/data/856/710/53/85671053.geojson
@@ -54,6 +54,9 @@
     "name:azb_x_preferred":[
         "\u0628\u0646\u06cc\u200c\u0633\u0648\u06cc\u0641 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "B\u0259ni S\u00fcveyf m\u00fchaf\u0259z\u0259si"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0411\u0435\u043d\u0456-\u0421\u0443\u044d\u0439\u0444"
     ],
@@ -129,6 +132,9 @@
     "name:gle_x_preferred":[
         "Beni Suef"
     ],
+    "name:gle_x_variant":[
+        "Gobharn\u00f3ireacht Beni Suef"
+    ],
     "name:guj_x_preferred":[
         "\u0aac\u0ac7\u0aa8\u0ac0 \u0ab8\u0ac1\u0a8f\u0aab \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
     ],
@@ -192,11 +198,17 @@
     "name:mar_x_preferred":[
         "\u092c\u0947\u0928\u0940 \u0938\u0941\u090f\u092b \u0917\u0935\u094d\u0939\u0930\u0928\u0947\u091f\u0947\u091f"
     ],
+    "name:mkd_x_preferred":[
+        "\u0411\u0435\u043d\u0438 \u0421\u0443\u0435\u0458\u0444"
+    ],
     "name:msa_x_preferred":[
         "Beni Suef"
     ],
     "name:msa_x_variant":[
         "Beni Suef Governorate"
+    ],
+    "name:nan_x_preferred":[
+        "Beni Suef S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Beni Suef"
@@ -252,6 +264,9 @@
     "name:tel_x_preferred":[
         "\u0c2c\u0c47\u0c28\u0c3f \u0c38\u0c41\u0c2f\u0c46\u0c2b\u0c4d \u0c17\u0c35\u0c30\u0c4d\u0c28\u0c30\u0c47\u0c1f\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u0412\u0438\u043b\u043e\u044f\u0442\u0438 \u0411\u0430\u043d\u04e3-\u0421\u0443\u0432\u0430\u0439\u0444"
+    ],
     "name:tha_x_preferred":[
         "\u0e40\u0e1a\u0e19\u0e35 \u0e40\u0e0b\u0e34\u0e1f \u0e01\u0e2d\u0e1f\u0e40\u0e27\u0e2d\u0e42\u0e19\u0e40\u0e25\u0e17"
     ],
@@ -282,11 +297,17 @@
     "name:war_x_preferred":[
         "Beni Suef"
     ],
+    "name:wuu_x_preferred":[
+        "\u8d1d\u5c3c\u82cf\u97e6\u592b\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u8c9d\u5c3c\u8607\u97cb\u592b"
     ],
     "name:zho_x_variant":[
         "\u8d1d\u5c3c\u82cf\u97e6\u592b\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Beni Suef Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -415,7 +436,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1582352364,
+    "wof:lastmodified":1690876038,
     "wof:name":"Bani Suwayf",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/57/85671057.geojson
+++ b/data/856/710/57/85671057.geojson
@@ -54,6 +54,9 @@
     "name:azb_x_preferred":[
         "\u06a9\u0641\u0631\u0627\u0644\u0634\u06cc\u062e \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "K\u0259fr \u0259\u015f-\u015eeyx m\u00fchaf\u0259z\u0259si"
+    ],
     "name:ben_x_preferred":[
         "\u0995\u09be\u09ab\u09cd\u09b0 \u098f\u09b2-\u09b6\u09c7\u0987\u0996 \u0997\u09ad\u09b0\u09cd\u09a8\u09cb\u09b0\u09c7\u099f"
     ],
@@ -105,6 +108,9 @@
     "name:fra_x_variant":[
         "Gouvernorat de Kafr el-Cheik"
     ],
+    "name:gle_x_preferred":[
+        "Gobharn\u00f3ireacht Kafr el-Sheikh"
+    ],
     "name:guj_x_preferred":[
         "\u0a95\u0abe\u0aab\u0ab0 \u0a85\u0ab2-\u0ab6\u0ac7\u0a96 \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
     ],
@@ -116,6 +122,9 @@
     ],
     "name:hun_x_preferred":[
         "Kafr El Sheikh"
+    ],
+    "name:hye_x_preferred":[
+        "\u053f\u0561\u0586\u0580 \u0561\u0577-\u0547\u0565\u0575\u056d"
     ],
     "name:ind_x_preferred":[
         "Kegubernuran Kafr asy Syaykh"
@@ -152,6 +161,9 @@
     ],
     "name:msa_x_preferred":[
         "Kafr el-Sheikh Governorate"
+    ],
+    "name:nan_x_preferred":[
+        "Kafr El Sheikh S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Kafr el Sheikh"
@@ -223,8 +235,14 @@
     "name:war_x_preferred":[
         "Kafr el-Sheikh"
     ],
+    "name:wuu_x_preferred":[
+        "\u8c22\u8d6b\u6751\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u8b1d\u8d6b\u6751\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Kafr El Sheikh Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -349,7 +367,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636502260,
+    "wof:lastmodified":1690876035,
     "wof:name":"Kafr ash Shaykh",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/61/85671061.geojson
+++ b/data/856/710/61/85671061.geojson
@@ -56,13 +56,17 @@
         "\u0623\u0633\u0648\u0627\u0646"
     ],
     "name:arz_x_variant":[
-        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0623\u0633\u0648\u0627\u0646"
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0623\u0633\u0648\u0627\u0646",
+        "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0633\u0648\u0627\u0646"
     ],
     "name:ast_x_preferred":[
         "gobernaci\u00f3n d'Aswan"
     ],
     "name:azb_x_preferred":[
         "\u0627\u0633\u0648\u0627\u0646 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
+    ],
+    "name:aze_x_preferred":[
+        "\u018fsvan m\u00fchaf\u0259z\u0259si"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0410\u0441\u0443\u0430\u043d"
@@ -149,6 +153,9 @@
     "name:gle_x_preferred":[
         "Aswan"
     ],
+    "name:gle_x_variant":[
+        "Gobharn\u00f3ireacht Aswan"
+    ],
     "name:glg_x_preferred":[
         "Asu\u00e1n"
     ],
@@ -233,8 +240,14 @@
     "name:mar_x_preferred":[
         "\u0906\u0938\u094d\u0935\u093e\u0928"
     ],
+    "name:mkd_x_preferred":[
+        "\u0410\u0441\u0443\u0430\u043d"
+    ],
     "name:msa_x_preferred":[
         "Aswan"
+    ],
+    "name:nan_x_preferred":[
+        "Aswan S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Aswan"
@@ -287,6 +300,9 @@
     "name:slv_x_preferred":[
         "Asuan"
     ],
+    "name:som_x_preferred":[
+        "Aswan Governorate"
+    ],
     "name:spa_x_preferred":[
         "Asu\u00e1n"
     ],
@@ -301,6 +317,9 @@
     ],
     "name:swe_x_variant":[
         "Guvernementet Assuan"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0412\u0438\u043b\u043e\u044f\u0442\u0438 \u0410\u0441\u0432\u043e\u043d"
     ],
     "name:tha_x_preferred":[
         "\u0e40\u0e02\u0e15\u0e1c\u0e39\u0e49\u0e27\u0e48\u0e32\u0e01\u0e32\u0e23\u0e2d\u0e31\u0e2a\u0e27\u0e32\u0e19"
@@ -329,6 +348,12 @@
     "name:war_x_preferred":[
         "Aswan"
     ],
+    "name:wuu_x_preferred":[
+        "\u963f\u65af\u65fa\u7701"
+    ],
+    "name:yue_x_preferred":[
+        "\u963f\u65af\u65fa\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u963f\u65af\u65fa"
     ],
@@ -338,6 +363,9 @@
     ],
     "name:zho_yue_x_preferred":[
         "\u963f\u65af\u65fa"
+    ],
+    "name:zul_x_preferred":[
+        "Aswan Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -469,7 +497,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636502260,
+    "wof:lastmodified":1690876034,
     "wof:name":"Aswan",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/69/85671069.geojson
+++ b/data/856/710/69/85671069.geojson
@@ -62,6 +62,9 @@
     "name:azb_x_preferred":[
         "\u0627\u0633\u06cc\u0648\u0637 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "\u018fsyut m\u00fchaf\u0259z\u0259si"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0410\u0441\u044c\u044e\u0442"
     ],
@@ -144,6 +147,9 @@
     "name:gle_x_preferred":[
         "Asyut"
     ],
+    "name:gle_x_variant":[
+        "Gobharn\u00f3ireacht Asyut"
+    ],
     "name:guj_x_preferred":[
         "\u0a85\u0ab8\u0acd\u0aaf\u0ac1\u0aa4 \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
     ],
@@ -223,7 +229,11 @@
         "Asyut"
     ],
     "name:msa_x_variant":[
-        "Asyut Governorate"
+        "Asyut Governorate",
+        "Kegabenoran Asyut"
+    ],
+    "name:nan_x_preferred":[
+        "Asyut S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Assioet"
@@ -236,6 +246,9 @@
     ],
     "name:nob_x_preferred":[
         "Guvernementet Asyut"
+    ],
+    "name:nob_x_variant":[
+        "Asyut"
     ],
     "name:nor_x_preferred":[
         "Asyut"
@@ -294,6 +307,9 @@
     "name:tel_x_preferred":[
         "\u0c05\u0c38\u0c4d\u0c2f\u0c41\u0c24\u0c4d \u0c17\u0c35\u0c30\u0c4d\u0c28\u0c30\u0c47\u0c1f\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u0412\u0438\u043b\u043e\u044f\u0442\u0438 \u0410\u0441\u044e\u0442"
+    ],
     "name:tha_x_preferred":[
         "\u0e2d\u0e31\u0e2a\u0e22\u0e39\u0e15"
     ],
@@ -302,6 +318,9 @@
     ],
     "name:tur_x_preferred":[
         "Asyut"
+    ],
+    "name:uig_x_preferred":[
+        "\u0626\u06d5\u0633\u064a\u06c7\u062a"
     ],
     "name:ukr_x_preferred":[
         "\u0410\u0441\u044c\u044e\u0442"
@@ -321,11 +340,20 @@
     "name:war_x_preferred":[
         "Asyut"
     ],
+    "name:wuu_x_preferred":[
+        "\u827e\u65af\u5c24\u7279\u7701"
+    ],
+    "name:yue_x_preferred":[
+        "\u827e\u65af\u5c24\u7279\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u827e\u65af\u5c24\u7279"
     ],
     "name:zho_x_variant":[
         "\u827e\u65af\u5c24\u7279\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Asyut Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -455,7 +483,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1614893765,
+    "wof:lastmodified":1690876036,
     "wof:name":"Asyut",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/71/85671071.geojson
+++ b/data/856/710/71/85671071.geojson
@@ -54,6 +54,9 @@
     "name:azb_x_preferred":[
         "\u0648\u0627\u062f\u06cc\u200c\u0627\u0644\u062c\u062f\u06cc\u062f \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "Yeni Vadi m\u00fchaf\u0259z\u0259si"
+    ],
     "name:ben_x_preferred":[
         "\u09a8\u09bf\u0989 \u09ad\u09cd\u09af\u09be\u09b2\u09bf \u0997\u09ad\u09b0\u09cd\u09a8\u09cb\u09b0\u09c7\u099f"
     ],
@@ -110,6 +113,9 @@
     "name:fra_x_variant":[
         "Gouvernorat de la Nouvelle-Vall\u00e9e"
     ],
+    "name:gle_x_preferred":[
+        "Gobharn\u00f3ireacht an Ghleanna Nua"
+    ],
     "name:guj_x_preferred":[
         "\u0aa8\u0acd\u0aaf\u0ac2 \u0ab5\u0ac7\u0ab2\u0ac0 \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
     ],
@@ -158,6 +164,12 @@
     "name:msa_x_preferred":[
         "New Valley Governorate"
     ],
+    "name:msa_x_variant":[
+        "Kegabenoran Lembah Baru"
+    ],
+    "name:nan_x_preferred":[
+        "Sin H\u00f4-kok S\u00e9ng"
+    ],
     "name:nld_x_preferred":[
         "Nieuwe Vallei"
     ],
@@ -200,6 +212,9 @@
     "name:swe_x_preferred":[
         "Guvernementet Al-Wadi al-Jadid"
     ],
+    "name:swe_x_variant":[
+        "Al-Wadi al-Jadid"
+    ],
     "name:tam_x_preferred":[
         "\u0ba8\u0bbf\u0baf\u0bc2 \u0bb5\u0bbe\u0bb2\u0bc7 \u0b95\u0bcb\u0bb5\u0bc6\u0bb0\u0bcd\u0ba9\u0bcb\u0bb0\u0bc7\u0b9f\u0bcd"
     ],
@@ -232,6 +247,9 @@
     ],
     "name:zho_x_preferred":[
         "\u65b0\u6cb3\u8c37\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "New Valley Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -353,7 +371,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636502263,
+    "wof:lastmodified":1690876040,
     "wof:name":"Al Wadi at Jadid",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/75/85671075.geojson
+++ b/data/856/710/75/85671075.geojson
@@ -55,6 +55,9 @@
     "name:azb_x_preferred":[
         "\u0642\u0646\u0627 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "Qina m\u00fchaf\u0259z\u0259si"
+    ],
     "name:bel_x_preferred":[
         "\u041a\u0435\u043d\u0430"
     ],
@@ -110,6 +113,9 @@
     "name:fra_x_variant":[
         "gouvernorat de Qena"
     ],
+    "name:gle_x_preferred":[
+        "Gobharn\u00f3ireacht Qena"
+    ],
     "name:guj_x_preferred":[
         "\u0a95\u0acd\u0ab5\u0ac7\u0aa8\u0abe \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
     ],
@@ -158,6 +164,12 @@
     "name:msa_x_preferred":[
         "Qena Governorate"
     ],
+    "name:msa_x_variant":[
+        "Kegabenoran Qena"
+    ],
+    "name:nan_x_preferred":[
+        "Qena S\u00e9ng"
+    ],
     "name:nld_x_preferred":[
         "Qina"
     ],
@@ -197,11 +209,17 @@
     "name:swe_x_preferred":[
         "Guvernementet Qena"
     ],
+    "name:swe_x_variant":[
+        "Qena"
+    ],
     "name:tam_x_preferred":[
         "\u0b95\u0bbf\u0baf\u0bc7\u0ba9\u0bbe \u0b95\u0bcb\u0bb5\u0bc6\u0bb0\u0bcd\u0ba9\u0bcb\u0bb0\u0bc7"
     ],
     "name:tel_x_preferred":[
         "\u0c16\u0c47\u0c28\u0c3e \u0c17\u0c35\u0c30\u0c4d\u0c28\u0c30\u0c47\u0c1f\u0c4d"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0412\u0438\u043b\u043e\u044f\u0442\u0438 \u049a\u0438\u043d\u043e"
     ],
     "name:tha_x_preferred":[
         "\u0e01\u0e34\u0e19\u0e30"
@@ -227,8 +245,14 @@
     "name:war_x_preferred":[
         "Qena"
     ],
+    "name:wuu_x_preferred":[
+        "\u57fa\u7eb3\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u57fa\u7d0d\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Qena Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -355,7 +379,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636502261,
+    "wof:lastmodified":1690876037,
     "wof:name":"Qina",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/79/85671079.geojson
+++ b/data/856/710/79/85671079.geojson
@@ -56,6 +56,9 @@
     "name:azb_x_preferred":[
         "\u0633\u0648\u0647\u0627\u062c \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "S\u00f6vhac m\u00fchaf\u0259z\u0259si"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09cb\u09b9\u09be\u0997 \u0997\u09ad\u09b0\u09cd\u09a8\u09cb\u09b0\u09c7\u099f"
     ],
@@ -105,6 +108,9 @@
     "name:fra_x_variant":[
         "Gouvernorat de Sohag"
     ],
+    "name:gle_x_preferred":[
+        "Gobharn\u00f3ireacht Sohag"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0acb\u0ab9\u0a97 \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
     ],
@@ -153,6 +159,12 @@
     "name:msa_x_preferred":[
         "Sohag Governorate"
     ],
+    "name:msa_x_variant":[
+        "Kegabenoran Sohag"
+    ],
+    "name:nan_x_preferred":[
+        "Sohag S\u00e9ng"
+    ],
     "name:nld_x_preferred":[
         "Suhaj"
     ],
@@ -195,6 +207,9 @@
     "name:swe_x_preferred":[
         "Guvernementet Sohag"
     ],
+    "name:swe_x_variant":[
+        "Sohag"
+    ],
     "name:tam_x_preferred":[
         "\u0b9a\u0bcb\u0b95\u0b95\u0bcd \u0b95\u0bcb\u0bb5\u0bc6\u0bb0\u0bcd\u0ba9\u0bcb\u0bb0\u0bc7\u0b9f\u0bcd"
     ],
@@ -228,8 +243,14 @@
     "name:war_x_preferred":[
         "Sohag"
     ],
+    "name:wuu_x_preferred":[
+        "\u7d22\u54c8\u6770\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u7d22\u54c8\u5091\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Sohag Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -354,7 +375,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1614893766,
+    "wof:lastmodified":1690876039,
     "wof:name":"Suhaj",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/85/85671085.geojson
+++ b/data/856/710/85/85671085.geojson
@@ -55,6 +55,9 @@
     "name:azb_x_preferred":[
         "\u0628\u062d\u0631\u0627\u0644\u0627\u062d\u0645\u0631 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "Q\u0131rm\u0131z\u0131 d\u0259niz m\u00fchaf\u0259z\u0259si"
+    ],
     "name:ben_x_preferred":[
         "\u09b2\u09cb\u09b9\u09bf\u09a4 \u09b8\u09be\u0997\u09b0 \u0997\u09ad\u09b0\u09cd\u09a8\u09cb\u09b0\u09c7\u099f"
     ],
@@ -80,7 +83,8 @@
         "Rotes Meer"
     ],
     "name:deu_x_variant":[
-        "al-Bahr al-ahmar"
+        "al-Bahr al-ahmar",
+        "Gouvernement Rotes Meer"
     ],
     "name:ell_x_preferred":[
         "\u039a\u03c5\u03b2\u03b5\u03c1\u03bd\u03b5\u03af\u03bf \u0395\u03c1\u03c5\u03b8\u03c1\u03ac\u03c2 \u0398\u03ac\u03bb\u03b1\u03c3\u03c3\u03b1\u03c2"
@@ -111,6 +115,9 @@
     "name:fra_x_variant":[
         "Gouvernorat de la Mer-Rouge",
         "Mer Rouge"
+    ],
+    "name:gle_x_preferred":[
+        "Gobharn\u00f3ireacht na Mara Rua"
     ],
     "name:guj_x_preferred":[
         "\u0ab0\u0ac7\u0aa1 \u0ab8\u0ac0 \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
@@ -160,8 +167,17 @@
     "name:mar_x_preferred":[
         "\u0930\u0947\u0921 \u0938\u0940 \u0917\u0935\u094d\u0939\u0930\u094d\u0928\u094b\u0930\u0947\u091f"
     ],
+    "name:mkd_x_preferred":[
+        "\u0426\u0440\u0432\u0435\u043d\u043e \u041c\u043e\u0440\u0435"
+    ],
     "name:msa_x_preferred":[
         "Pentadbiran Red Sea"
+    ],
+    "name:msa_x_variant":[
+        "Kegabenoran Laut Merah"
+    ],
+    "name:nan_x_preferred":[
+        "\u00c2ng H\u00e1i S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Rode Zee"
@@ -237,6 +253,9 @@
     ],
     "name:zho_x_preferred":[
         "\u7ea2\u6d77\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Red Sea Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -358,7 +377,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636502263,
+    "wof:lastmodified":1690876040,
     "wof:name":"Al Bahr al Ahmar",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/89/85671089.geojson
+++ b/data/856/710/89/85671089.geojson
@@ -57,6 +57,9 @@
     "name:azb_x_preferred":[
         "\u062c\u0646\u0648\u0628\u06cc \u0633\u06cc\u0646\u0627 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "C\u0259nubi Sina m\u00fchaf\u0259z\u0259si"
+    ],
     "name:ben_x_preferred":[
         "\u09a6\u0995\u09cd\u09b7\u09bf\u09a8 \u09b8\u09bf\u09a8\u09be\u0987 \u0997\u09ad\u09b0\u09cd\u09a8\u09cb\u09b0\u09c7\u099f"
     ],
@@ -109,6 +112,9 @@
     "name:fra_x_variant":[
         "Gouvernorat du Sina\u00ef Sud"
     ],
+    "name:gle_x_preferred":[
+        "Gobharn\u00f3ireacht Sh\u00edon\u00e1\u00ed Theas"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0abe\u0a89\u0aa5 \u0ab8\u0abf\u0aa8\u0abe\u0a87 \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
     ],
@@ -123,6 +129,9 @@
     ],
     "name:hun_x_preferred":[
         "Jan\u016bb S\u012bn\u0101\u02be"
+    ],
+    "name:hun_x_variant":[
+        "D\u00e9l-S\u00ednai korm\u00e1nyz\u00f3s\u00e1g"
     ],
     "name:hye_x_preferred":[
         "\u0540\u0561\u0580\u0561\u057e\u0561\u0575\u056b\u0576 \u054d\u056b\u0576\u0561\u0575"
@@ -169,11 +178,17 @@
     "name:msa_x_preferred":[
         "Sinai Selatan"
     ],
+    "name:nan_x_preferred":[
+        "L\u00e2m Sinai S\u00e9ng"
+    ],
     "name:nld_x_preferred":[
         "Zuid-Sina\u00ef"
     ],
     "name:nob_x_preferred":[
         "Guvernementet Janub Sina'"
+    ],
+    "name:pnb_x_preferred":[
+        "\u0645\u062d\u0627\u0641\u0638\u06c1 \u062c\u0646\u0648\u0628\u06cc \u0633\u06cc\u0646\u0627"
     ],
     "name:pol_x_preferred":[
         "Synaj Po\u0142udniowy"
@@ -205,6 +220,9 @@
     "name:swe_x_preferred":[
         "Guvernementet Sina al-Janubiyya"
     ],
+    "name:swe_x_variant":[
+        "Sina al-Janubiyya"
+    ],
     "name:tam_x_preferred":[
         "\u0ba4\u0bc6\u0bb1\u0bcd\u0b95\u0bc1 \u0b9a\u0bbf\u0ba9\u0bbe\u0baf\u0bcd \u0b95\u0bcb\u0bb5\u0bc6\u0bb0\u0bcd\u0ba9\u0bcb\u0bb0\u0bc7"
     ],
@@ -235,8 +253,14 @@
     "name:war_x_preferred":[
         "Salatan nga Sinai"
     ],
+    "name:wuu_x_preferred":[
+        "\u5357\u897f\u5948\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u5357\u897f\u5948\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "South Sinai Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -361,7 +385,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636502261,
+    "wof:lastmodified":1690876036,
     "wof:name":"Janub Sina'",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/93/85671093.geojson
+++ b/data/856/710/93/85671093.geojson
@@ -57,6 +57,9 @@
     "name:azb_x_preferred":[
         "\u0642\u0648\u0632\u0626\u06cc \u0633\u06cc\u0646\u0627 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "\u015eimali Sina m\u00fchaf\u0259z\u0259si"
+    ],
     "name:ben_x_preferred":[
         "\u09a8\u09b0\u09cd\u09a5 \u09b8\u09bf\u09a8\u09be\u0987 \u0997\u09ad\u09b0\u09cd\u09a8\u09cb\u09b0\u09c7\u099f"
     ],
@@ -108,6 +111,9 @@
     ],
     "name:fra_x_variant":[
         "Gouvernorat du Sina\u00ef Nord"
+    ],
+    "name:gle_x_preferred":[
+        "Gobharn\u00f3ireacht Sh\u00edon\u00e1\u00ed Thuaidh"
     ],
     "name:guj_x_preferred":[
         "\u0aa8\u0acb\u0ab0\u0acd\u0aa5 \u0ab8\u0abf\u0aa8\u0abe\u0a87 \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
@@ -163,6 +169,9 @@
     "name:msa_x_preferred":[
         "North Sinai Governorate"
     ],
+    "name:nan_x_preferred":[
+        "Pak Sinai S\u00e9ng"
+    ],
     "name:nld_x_preferred":[
         "Noord-Sina\u00ef"
     ],
@@ -202,8 +211,14 @@
     "name:swe_x_preferred":[
         "Guvernementet Sina ash-Shamaliyya"
     ],
+    "name:swe_x_variant":[
+        "Sina ash-Shamaliyya"
+    ],
     "name:tam_x_preferred":[
         "\u0bb5\u0b9f\u0b95\u0bcd\u0b95\u0bc1  \u0b9a\u0bbf\u0ba9\u0bbe\u0baf\u0bcd \u0b95\u0bcb\u0bb5\u0bc6\u0bb0\u0bcd\u0ba9\u0bcb\u0bb0\u0bc7"
+    ],
+    "name:tam_x_variant":[
+        "\u0bb5\u0b9f\u0b95\u0bcd\u0b95\u0bc1 \u0b9a\u0bbf\u0ba9\u0bbe\u0baf\u0bcd \u0b95\u0bcb\u0bb5\u0bc6\u0bb0\u0bcd\u0ba9\u0bcb\u0bb0\u0bc7"
     ],
     "name:tel_x_preferred":[
         "\u0c28\u0c3e\u0c30\u0c4d\u0c24\u0c4d \u0c38\u0c3f\u0c28\u0c3e\u0c2f\u0c3f \u0c17\u0c35\u0c30\u0c4d\u0c28\u0c30\u0c47\u0c1f\u0c4d"
@@ -229,8 +244,14 @@
     "name:war_x_preferred":[
         "Amihanan nga Sinai"
     ],
+    "name:wuu_x_preferred":[
+        "\u5317\u897f\u5948\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u5317\u897f\u5948\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "North Sinai Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -354,7 +375,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636502261,
+    "wof:lastmodified":1690876036,
     "wof:name":"Shamal Sina'",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/97/85671097.geojson
+++ b/data/856/710/97/85671097.geojson
@@ -56,6 +56,9 @@
     "name:azb_x_preferred":[
         "\u0627\u0642\u0635\u0631 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "\u0259l-\u00dcqs\u00fcr m\u00fchaf\u0259z\u0259si"
+    ],
     "name:bel_x_preferred":[
         "\u041b\u0443\u043a\u0441\u043e\u0440"
     ],
@@ -108,6 +111,9 @@
     "name:fra_x_variant":[
         "Gouvernorat de Louxor"
     ],
+    "name:gle_x_preferred":[
+        "Gobharn\u00f3ireacht Lucsar"
+    ],
     "name:heb_x_preferred":[
         "\u05de\u05d7\u05d5\u05d6 \u05dc\u05d5\u05e7\u05e1\u05d5\u05e8"
     ],
@@ -122,6 +128,9 @@
     ],
     "name:ind_x_preferred":[
         "Luxor"
+    ],
+    "name:ind_x_variant":[
+        "Kegubernuran Luxor"
     ],
     "name:ita_x_preferred":[
         "Governatorato di Luxor"
@@ -143,6 +152,12 @@
     ],
     "name:lit_x_preferred":[
         "Luksoro muchafaza"
+    ],
+    "name:mkd_x_preferred":[
+        "\u041b\u0443\u043a\u0441\u043e\u0440"
+    ],
+    "name:nan_x_preferred":[
+        "Luxor S\u00e9ng"
     ],
     "name:nld_x_preferred":[
         "Luxor"
@@ -180,6 +195,9 @@
     "name:swe_x_preferred":[
         "Guvernementet Luxor"
     ],
+    "name:swe_x_variant":[
+        "Luxor"
+    ],
     "name:tgk_x_preferred":[
         "\u0410\u049b\u0441\u0430\u0440"
     ],
@@ -204,8 +222,14 @@
     "name:war_x_preferred":[
         "Luxor"
     ],
+    "name:wuu_x_preferred":[
+        "\u5362\u514b\u7d22\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u76e7\u514b\u7d22\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Luxor Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"EGY",
@@ -330,7 +354,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636502262,
+    "wof:lastmodified":1690876039,
     "wof:name":"Luxor",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/859/029/37/85902937.geojson
+++ b/data/859/029/37/85902937.geojson
@@ -58,6 +58,9 @@
     "name:gle_x_preferred":[
         "Bab al-Louq"
     ],
+    "name:nld_x_preferred":[
+        "Bab al-Louq"
+    ],
     "qs:gn_adm0_cc":"EG",
     "qs:gn_id":0,
     "qs:gn_local":360630,
@@ -119,7 +122,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1582352360,
+    "wof:lastmodified":1690876031,
     "wof:name":"\u0628\u0627\u0628 \u0627\u0644\u0644\u0648\u0642",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/47/85902947.geojson
+++ b/data/859/029/47/85902947.geojson
@@ -41,6 +41,9 @@
     "name:arz_x_preferred":[
         "\u0628\u0648\u0631 \u0633\u0639\u064a\u062f"
     ],
+    "name:ast_x_preferred":[
+        "Port Said"
+    ],
     "name:azb_x_preferred":[
         "\u067e\u0648\u0631\u062a\u200c\u0633\u0639\u06cc\u062f"
     ],
@@ -53,8 +56,14 @@
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041f\u043e\u0440\u0442-\u0421\u0430\u0456\u0434"
     ],
+    "name:bel_x_variant":[
+        "\u041f\u043e\u0440\u0442-\u0421\u0430\u0456\u0434"
+    ],
     "name:ben_x_preferred":[
         "\u09aa\u09cb\u09b0\u09cd\u099f \u09b8\u0988\u09a6"
+    ],
+    "name:ben_x_variant":[
+        "\u09b8\u09be\u0987\u09a6 \u09ac\u09a8\u09cd\u09a6\u09b0"
     ],
     "name:bul_x_preferred":[
         "\u041f\u043e\u0440\u0442 \u0421\u0430\u0438\u0434"
@@ -70,6 +79,9 @@
     ],
     "name:che_x_preferred":[
         "\u0411\u0443\u0440-\u0421\u0430\u04c0\u0438\u0439\u0434"
+    ],
+    "name:cos_x_preferred":[
+        "Portu Said"
     ],
     "name:cym_x_preferred":[
         "Port Said"
@@ -189,6 +201,9 @@
     "name:mar_x_preferred":[
         "\u092c\u0941\u0930 \u0938\u0948\u0926"
     ],
+    "name:mlg_x_preferred":[
+        "Port Said"
+    ],
     "name:msa_x_preferred":[
         "Port Said"
     ],
@@ -209,6 +224,9 @@
     ],
     "name:nor_x_preferred":[
         "Port Said"
+    ],
+    "name:oss_x_preferred":[
+        "\u041f\u043e\u0440\u0442-\u0421\u0430\u0438\u0434"
     ],
     "name:pan_x_preferred":[
         "\u0a2c\u0a4b\u0a30 \u0a38\u0a08\u0a26"
@@ -255,6 +273,9 @@
     "name:tel_x_preferred":[
         "\u0c2a\u0c4b\u0c30\u0c4d\u0c1f\u0c4d \u0c38\u0c46\u0c21\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u041f\u043e\u0440\u0442-\u0421\u0430\u0438\u0434"
+    ],
     "name:tha_x_preferred":[
         "\u0e1e\u0e2d\u0e23\u0e4c\u0e15\u0e0b\u0e32\u0e2d\u0e34\u0e14"
     ],
@@ -273,11 +294,20 @@
     "name:uzb_x_preferred":[
         "Port-said"
     ],
+    "name:uzb_x_variant":[
+        "Port-Said"
+    ],
+    "name:vec_x_preferred":[
+        "Porto Said"
+    ],
     "name:vie_x_preferred":[
         "Port Said"
     ],
     "name:war_x_preferred":[
         "Port Said"
+    ],
+    "name:wuu_x_preferred":[
+        "\u585e\u5f97\u6e2f"
     ],
     "name:xmf_x_preferred":[
         "\u10de\u10dd\u10e0\u10e2-\u10e1\u10d0\u10d8\u10d3\u10d8"
@@ -287,6 +317,9 @@
     ],
     "name:zho_x_preferred":[
         "\u585e\u5fb7\u6e2f"
+    ],
+    "name:zul_x_preferred":[
+        "Port Said"
     ],
     "qs:gn_adm0_cc":"EG",
     "qs:gn_fcode":"PPLA",
@@ -353,7 +386,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1582352361,
+    "wof:lastmodified":1690876031,
     "wof:name":"B\u016br Sa\u2019\u012bd",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/51/85902951.geojson
+++ b/data/859/029/51/85902951.geojson
@@ -32,6 +32,9 @@
     "name:arz_x_preferred":[
         "\u0643\u0631\u0645\u0648\u0632"
     ],
+    "name:azb_x_preferred":[
+        "\u06a9\u0631\u0645\u0648\u0632"
+    ],
     "name:eng_x_colloquial":[
         "Karmoes",
         "Karmos",
@@ -50,6 +53,9 @@
     ],
     "name:fas_x_preferred":[
         "\u06a9\u0631\u0645\u0648\u0632"
+    ],
+    "name:nld_x_preferred":[
+        "Karmoz"
     ],
     "qs:gn_id":0,
     "qs:gn_local":0,
@@ -109,7 +115,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1582352360,
+    "wof:lastmodified":1690876031,
     "wof:name":"\u0643\u0631\u0645\u0648\u0632",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/59/85902959.geojson
+++ b/data/859/029/59/85902959.geojson
@@ -36,6 +36,9 @@
     "name:arz_x_preferred":[
         "\u0645\u062f\u064a\u0646\u0629 \u0646\u0635\u0631"
     ],
+    "name:dan_x_preferred":[
+        "Nasr City"
+    ],
     "name:deu_x_preferred":[
         "Nasr City"
     ],
@@ -49,7 +52,8 @@
         "Nasr City",
         "Nasser City",
         "Madinet Nasr",
-        "El Nasr City"
+        "El Nasr City",
+        "nasr city"
     ],
     "name:fas_x_preferred":[
         "\u0634\u0647\u0631\u06a9 \u0646\u0635\u0631"
@@ -63,17 +67,29 @@
     "name:heb_x_preferred":[
         "\u05e0\u05d0\u05e1\u05e8 \u05e1\u05d9\u05d8\u05d9"
     ],
+    "name:ita_x_preferred":[
+        "Nasr"
+    ],
     "name:jpn_x_preferred":[
         "\u30ca\u30b9\u30eb\u30fb\u30b7\u30c6\u30a3"
     ],
     "name:nld_x_preferred":[
         "Nasr City"
     ],
+    "name:rus_x_preferred":[
+        "\u041c\u0430\u0434\u0438\u043d\u0430\u0442-\u041d\u0430\u0441\u0440"
+    ],
+    "name:spa_x_preferred":[
+        "Mad\u012bnat an-Na\u1e63r"
+    ],
     "name:swe_x_preferred":[
         "Nasser City"
     ],
     "name:ukr_x_preferred":[
         "\u041d\u0430\u0441\u0435\u0440-\u0421\u0456\u0442\u0456"
+    ],
+    "name:urd_x_preferred":[
+        "\u0646\u0635\u0631 \u0634\u06c1\u0631"
     ],
     "name:zho_x_preferred":[
         "\u7d0d\u65af\u723e\u5e02"
@@ -159,7 +175,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1582352360,
+    "wof:lastmodified":1690876030,
     "wof:name":"Mad\u012bnat an Na\u015fr",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/67/85902967.geojson
+++ b/data/859/029/67/85902967.geojson
@@ -59,6 +59,9 @@
     "name:fas_x_preferred":[
         "\u0633\u06cc\u062f\u06cc \u062c\u0627\u0628\u0631"
     ],
+    "name:nld_x_preferred":[
+        "Sidi Gaber"
+    ],
     "qs:gn_adm0_cc":"EG",
     "qs:gn_fcode":"PPLX",
     "qs:gn_local":0,
@@ -139,7 +142,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1582352360,
+    "wof:lastmodified":1690876031,
     "wof:name":"\u0633\u064a\u062f\u0649 \u062c\u0627\u0628\u0631",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/063/63/85906363.geojson
+++ b/data/859/063/63/85906363.geojson
@@ -36,6 +36,9 @@
     "name:arz_x_preferred":[
         "\u0633\u064a\u062f\u0649 \u0628\u0634\u0631"
     ],
+    "name:azb_x_preferred":[
+        "\u0633\u06cc\u062f\u06cc \u0628\u0634\u0631"
+    ],
     "name:eng_x_preferred":[
         "Sidi Bishr"
     ],
@@ -124,7 +127,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1582352360,
+    "wof:lastmodified":1690876030,
     "wof:name":"Sidi Bishr",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/067/71/85906771.geojson
+++ b/data/859/067/71/85906771.geojson
@@ -44,6 +44,9 @@
     "name:fas_x_preferred":[
         "\u0633\u06cc\u062f\u06cc \u062c\u0627\u0628\u0631"
     ],
+    "name:nld_x_preferred":[
+        "Sidi Gaber"
+    ],
     "qs:gn_id":0,
     "qs:gn_local":0,
     "qs:local_max":1580,
@@ -104,7 +107,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1582352361,
+    "wof:lastmodified":1690876032,
     "wof:name":"Sidi Gaber District",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/067/75/85906775.geojson
+++ b/data/859/067/75/85906775.geojson
@@ -32,6 +32,9 @@
     "name:arz_x_preferred":[
         "\u0645\u062d\u0637\u0629 \u0627\u0644\u0631\u0645\u0644"
     ],
+    "name:azb_x_preferred":[
+        "\u0645\u062d\u0637\u0647 \u0627\u0644\u0631\u0645\u0644"
+    ],
     "name:deu_x_preferred":[
         "Mahattat ar-Raml"
     ],
@@ -43,6 +46,9 @@
     ],
     "name:fas_x_preferred":[
         "\u0645\u062d\u0637\u0647 \u0627\u0644\u0631\u0645\u0644"
+    ],
+    "name:nld_x_preferred":[
+        "Mahatet El Raml"
     ],
     "qs:gn_id":0,
     "qs:gn_local":0,
@@ -104,7 +110,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1582352361,
+    "wof:lastmodified":1690876032,
     "wof:name":"El Raml District",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/23/85907023.geojson
+++ b/data/859/070/23/85907023.geojson
@@ -53,8 +53,14 @@
     "name:nld_x_preferred":[
         "Azbakeya"
     ],
+    "name:spa_x_preferred":[
+        "Al-Azbakiyah"
+    ],
     "name:swe_x_preferred":[
         "Azbakeya"
+    ],
+    "name:urd_x_preferred":[
+        "\u0627\u0632\u0628\u06a9\u06cc\u06c1"
     ],
     "qs:gn_adm0_cc":"EG",
     "qs:gn_id":0,
@@ -117,7 +123,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1582352360,
+    "wof:lastmodified":1690876030,
     "wof:name":"Al-azbakiya",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/414/445/890414445.geojson
+++ b/data/890/414/445/890414445.geojson
@@ -22,6 +22,15 @@
     "name:ara_x_preferred":[
         "\u0641\u0627\u0631\u0633\u0643\u0648\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0641\u0627\u0631\u0633\u0643\u0648\u0631"
+    ],
+    "name:ast_x_preferred":[
+        "Faraskur"
+    ],
+    "name:azb_x_preferred":[
+        "\u0641\u0627\u0631\u0633\u06a9\u0648\u0631"
+    ],
     "name:cat_x_preferred":[
         "Faraskur"
     ],
@@ -46,6 +55,12 @@
     "name:heb_x_preferred":[
         "\u05e4\u05e8\u05e1\u05e7\u05d5\u05e8"
     ],
+    "name:heb_x_variant":[
+        "\u05e4\u05d0\u05e8\u05e1\u05db\u05d5\u05e8"
+    ],
+    "name:mlg_x_preferred":[
+        "F\u0101rask\u016br"
+    ],
     "name:nld_x_preferred":[
         "Faraskur"
     ],
@@ -60,6 +75,9 @@
     ],
     "name:und_x_variant":[
         "F\u00e2risk\u00fbr"
+    ],
+    "name:zul_x_preferred":[
+        "Faraskur"
     ],
     "qs:name":"F\u0101rask\u016br",
     "qs:photos_9r":0,
@@ -92,7 +110,7 @@
         }
     ],
     "wof:id":890414445,
-    "wof:lastmodified":1566586574,
+    "wof:lastmodified":1690876061,
     "wof:name":"F\u0101rask\u016br",
     "wof:parent_id":1092020865,
     "wof:placetype":"locality",

--- a/data/890/418/011/890418011.geojson
+++ b/data/890/418/011/890418011.geojson
@@ -28,14 +28,26 @@
     "name:arz_x_preferred":[
         "\u062d\u0627\u0645\u0648\u0644"
     ],
+    "name:ast_x_preferred":[
+        "Al Hamool"
+    ],
     "name:ceb_x_preferred":[
         "Markaz al \u1e28\u0101m\u016bl"
+    ],
+    "name:ceb_x_variant":[
+        "Al \u1e28\u0101m\u016bl"
     ],
     "name:eng_x_preferred":[
         "Al Hamool"
     ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u062d\u0627\u0645\u0648\u0644"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d0\u05dc-\u05d7\u05de\u05d5\u05dc"
+    ],
+    "name:mlg_x_preferred":[
+        "Al \u1e28\u0101m\u016bl"
     ],
     "name:nld_x_preferred":[
         "Al Hamool"
@@ -52,8 +64,14 @@
     "name:swe_x_preferred":[
         "Markaz al \u1e28\u0101m\u016bl"
     ],
+    "name:swe_x_variant":[
+        "Al \u1e28\u0101m\u016bl"
+    ],
     "name:und_x_variant":[
         "El-\u1e24\u00e2m\u00fbl"
+    ],
+    "name:zul_x_preferred":[
+        "El Hamool"
     ],
     "qs:name":"Al \u1e28\u0101m\u016bl",
     "qs:photos_9r":0,
@@ -86,7 +104,7 @@
         }
     ],
     "wof:id":890418011,
-    "wof:lastmodified":1566586577,
+    "wof:lastmodified":1690876065,
     "wof:name":"Al \u1e28\u0101m\u016bl",
     "wof:parent_id":1092017993,
     "wof:placetype":"locality",

--- a/data/890/418/013/890418013.geojson
+++ b/data/890/418/013/890418013.geojson
@@ -28,6 +28,9 @@
     "name:arz_x_preferred":[
         "\u0628\u0627\u0648\u064a\u0637"
     ],
+    "name:ast_x_preferred":[
+        "Bawiti"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u0628\u0627\u0648\u06cc\u0637\u06cc"
     ],
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":890418013,
-    "wof:lastmodified":1566586577,
+    "wof:lastmodified":1690876065,
     "wof:name":"Al Baw\u012b\u0163\u012b",
     "wof:parent_id":1092022885,
     "wof:placetype":"locality",

--- a/data/890/418/075/890418075.geojson
+++ b/data/890/418/075/890418075.geojson
@@ -22,11 +22,17 @@
     "name:ara_x_preferred":[
         "\u0645\u062f\u064a\u0646\u0629 \u0627\u0644\u0641\u0631\u0627\u0641\u0631\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0641\u0631\u0627\u0641\u0631\u0629"
+    ],
     "name:deu_x_preferred":[
         "al-Farafra"
     ],
     "name:eng_x_preferred":[
         "Farafra town"
+    ],
+    "name:eng_x_variant":[
+        "Farafra Town"
     ],
     "name:fra_x_preferred":[
         "Farafra town"
@@ -163,7 +169,7 @@
         }
     ],
     "wof:id":890418075,
-    "wof:lastmodified":1566586578,
+    "wof:lastmodified":1690876066,
     "wof:name":"Qa\u015fr al Far\u0101firah",
     "wof:parent_id":1092017585,
     "wof:placetype":"locality",

--- a/data/890/418/081/890418081.geojson
+++ b/data/890/418/081/890418081.geojson
@@ -25,8 +25,14 @@
     "name:arz_x_preferred":[
         "\u0642\u0648\u0635"
     ],
+    "name:ast_x_preferred":[
+        "Qus"
+    ],
     "name:azb_x_preferred":[
         "\u0634\u0647\u0631\u0633\u062a\u0627\u0646 \u0642\u0648\u0635"
+    ],
+    "name:aze_x_preferred":[
+        "Kus"
     ],
     "name:cat_x_preferred":[
         "Kus"
@@ -79,8 +85,14 @@
     "name:und_x_variant":[
         "Apollinopolis Parva"
     ],
+    "name:vie_x_preferred":[
+        "Qus"
+    ],
     "name:zho_x_preferred":[
         "\u53e4\u65af"
+    ],
+    "name:zul_x_preferred":[
+        "Qus"
     ],
     "qs:name":"Kousa",
     "qs:photos_9r":0,
@@ -115,7 +127,7 @@
         }
     ],
     "wof:id":890418081,
-    "wof:lastmodified":1566586578,
+    "wof:lastmodified":1690876065,
     "wof:name":"Kousa",
     "wof:parent_id":1092023581,
     "wof:placetype":"locality",

--- a/data/890/418/083/890418083.geojson
+++ b/data/890/418/083/890418083.geojson
@@ -31,6 +31,9 @@
     "name:fas_x_preferred":[
         "\u0645\u0646\u06cc\u0647 \u0627\u0644\u0646\u0635\u0631"
     ],
+    "name:mlg_x_preferred":[
+        "Minyat an Na\u015fr"
+    ],
     "name:nld_x_preferred":[
         "Minyat an Na\u015fr"
     ],
@@ -74,7 +77,7 @@
         }
     ],
     "wof:id":890418083,
-    "wof:lastmodified":1566586577,
+    "wof:lastmodified":1690876064,
     "wof:name":"Minyat an Na\u015fr",
     "wof:parent_id":1092022451,
     "wof:placetype":"locality",

--- a/data/890/418/085/890418085.geojson
+++ b/data/890/418/085/890418085.geojson
@@ -22,11 +22,20 @@
     "name:ara_x_preferred":[
         "\u0645\u0646\u0648\u0641"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0646\u0648\u0641"
+    ],
+    "name:ast_x_preferred":[
+        "Menouf"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0646\u0648\u0641"
     ],
     "name:ceb_x_preferred":[
         "Min\u016bf"
+    ],
+    "name:deu_x_preferred":[
+        "Minuf"
     ],
     "name:ell_x_preferred":[
         "\u039c\u03b5\u03bd\u03bf\u03cd\u03c6"
@@ -37,7 +46,16 @@
     "name:fas_x_preferred":[
         "\u0645\u0646\u0648\u0641"
     ],
+    "name:fin_x_preferred":[
+        "Minuf"
+    ],
+    "name:fra_x_preferred":[
+        "M\u00e9nouf"
+    ],
     "name:nld_x_preferred":[
+        "Menouf"
+    ],
+    "name:nob_x_preferred":[
         "Menouf"
     ],
     "name:pol_x_preferred":[
@@ -55,8 +73,14 @@
     "name:swe_x_preferred":[
         "Minuf"
     ],
+    "name:ukr_x_preferred":[
+        "\u041c\u0456\u043d\u0443\u0444"
+    ],
     "name:und_x_variant":[
         "Menuf"
+    ],
+    "name:zul_x_preferred":[
+        "Menouf"
     ],
     "qs:name":"Min\u016bf",
     "qs:photos_9r":0,
@@ -89,7 +113,7 @@
         }
     ],
     "wof:id":890418085,
-    "wof:lastmodified":1566586577,
+    "wof:lastmodified":1690876065,
     "wof:name":"Min\u016bf",
     "wof:parent_id":1092022369,
     "wof:placetype":"locality",

--- a/data/890/418/089/890418089.geojson
+++ b/data/890/418/089/890418089.geojson
@@ -22,11 +22,20 @@
     "name:ara_x_preferred":[
         "\u0645\u0637\u0627\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0637\u0627\u064a"
+    ],
+    "name:ast_x_preferred":[
+        "Matai"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0637\u0627\u06cc"
     ],
     "name:ceb_x_preferred":[
         "Markaz Ma\u0163\u0101y"
+    ],
+    "name:ceb_x_variant":[
+        "Ma\u0163\u0101y"
     ],
     "name:deu_x_preferred":[
         "Ma\u1e6d\u0101i"
@@ -43,6 +52,9 @@
     "name:kat_x_preferred":[
         "\u10db\u10d0\u10d7\u10d0\u10d8"
     ],
+    "name:mlg_x_preferred":[
+        "Ma\u0163\u0101y"
+    ],
     "name:nld_x_preferred":[
         "Matai"
     ],
@@ -55,8 +67,14 @@
     "name:swe_x_preferred":[
         "Markaz Ma\u0163\u0101y"
     ],
+    "name:swe_x_variant":[
+        "Ma\u0163\u0101y"
+    ],
     "name:und_x_variant":[
         "Muttay"
+    ],
+    "name:zul_x_preferred":[
+        "Matai"
     ],
     "qs:name":"Ma\u0163\u0101y",
     "qs:photos_9r":0,
@@ -88,7 +106,7 @@
         }
     ],
     "wof:id":890418089,
-    "wof:lastmodified":1566586577,
+    "wof:lastmodified":1690876065,
     "wof:name":"Ma\u0163\u0101y",
     "wof:parent_id":1092022239,
     "wof:placetype":"locality",

--- a/data/890/418/093/890418093.geojson
+++ b/data/890/418/093/890418093.geojson
@@ -25,6 +25,12 @@
     "name:arz_x_preferred":[
         "\u0645\u0631\u0643\u0632 \u0645\u0646\u0641\u0644\u0648\u0637"
     ],
+    "name:arz_x_variant":[
+        "\u0645\u0646\u0641\u0644\u0648\u0637"
+    ],
+    "name:ast_x_preferred":[
+        "Manfalut"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0646\u0641\u0644\u0648\u0637"
     ],
@@ -46,6 +52,9 @@
     "name:fra_x_preferred":[
         "Manfalut"
     ],
+    "name:gle_x_preferred":[
+        "Manfalut"
+    ],
     "name:heb_x_preferred":[
         "\u05de\u05e0\u05e4\u05dc\u05d5\u05d8"
     ],
@@ -64,7 +73,13 @@
     "name:kor_x_preferred":[
         "\ub9cc\ud314\ub8e8\ud2b8"
     ],
+    "name:mlg_x_preferred":[
+        "Manfal\u016b\u0163"
+    ],
     "name:nld_x_preferred":[
+        "Manfalut"
+    ],
+    "name:nob_x_preferred":[
         "Manfalut"
     ],
     "name:pol_x_preferred":[
@@ -84,6 +99,9 @@
     ],
     "name:zho_x_preferred":[
         "\u66fc\u8cbb\u76e7\u7279"
+    ],
+    "name:zul_x_preferred":[
+        "Manfalut"
     ],
     "qs:name":"Manfal\u016b\u0163",
     "qs:photos_9r":0,
@@ -116,7 +134,7 @@
         }
     ],
     "wof:id":890418093,
-    "wof:lastmodified":1566586578,
+    "wof:lastmodified":1690876066,
     "wof:name":"Manfal\u016b\u0163",
     "wof:parent_id":1092022045,
     "wof:placetype":"locality",

--- a/data/890/422/277/890422277.geojson
+++ b/data/890/422/277/890422277.geojson
@@ -22,11 +22,17 @@
     "name:ara_x_preferred":[
         "\u0625\u062f\u0643\u0648"
     ],
+    "name:ast_x_preferred":[
+        "Idku"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u062f\u06a9\u0648"
     ],
     "name:ceb_x_preferred":[
         "Idk\u016b"
+    ],
+    "name:deu_x_preferred":[
+        "Idku"
     ],
     "name:eng_x_preferred":[
         "Idku"
@@ -40,8 +46,14 @@
     "name:kaz_x_preferred":[
         "\u0418\u0434\u043a\u0443"
     ],
+    "name:mlg_x_preferred":[
+        "Idk\u016b"
+    ],
     "name:nld_x_preferred":[
         "Idku"
+    ],
+    "name:nob_x_preferred":[
+        "Edku"
     ],
     "name:pol_x_preferred":[
         "Idku"
@@ -60,6 +72,9 @@
     ],
     "name:zho_x_preferred":[
         "\u4f0a\u5fb7\u5eab"
+    ],
+    "name:zul_x_preferred":[
+        "Edku"
     ],
     "qs:name":"Idk\u016b",
     "qs:photos_9r":0,
@@ -96,7 +111,7 @@
         }
     ],
     "wof:id":890422277,
-    "wof:lastmodified":1566586574,
+    "wof:lastmodified":1690876061,
     "wof:name":"Idk\u016b",
     "wof:parent_id":1092016481,
     "wof:placetype":"locality",

--- a/data/890/422/279/890422279.geojson
+++ b/data/890/422/279/890422279.geojson
@@ -25,6 +25,12 @@
     "name:ara_x_variant":[
         "\u0647\u0647\u064a\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0647\u0647\u064a\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Hihya"
+    ],
     "name:azb_x_preferred":[
         "\u0647\u0647\u06cc\u0627"
     ],
@@ -39,6 +45,9 @@
     ],
     "name:fas_x_preferred":[
         "\u0647\u0647\u06cc\u0627"
+    ],
+    "name:mlg_x_preferred":[
+        "Hihy\u0101"
     ],
     "name:nld_x_preferred":[
         "Hihya"
@@ -57,6 +66,9 @@
     ],
     "name:und_x_variant":[
         "Rehia"
+    ],
+    "name:zul_x_preferred":[
+        "Hihya"
     ],
     "qs:name":"Hihy\u0101",
     "qs:photos_9r":0,
@@ -91,7 +103,7 @@
         }
     ],
     "wof:id":890422279,
-    "wof:lastmodified":1566586574,
+    "wof:lastmodified":1690876061,
     "wof:name":"Hihy\u0101",
     "wof:parent_id":1092021319,
     "wof:placetype":"locality",

--- a/data/890/422/283/890422283.geojson
+++ b/data/890/422/283/890422283.geojson
@@ -22,11 +22,20 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0634\u0647\u062f\u0627\u0621"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0634\u0647\u062f\u0627\u0621"
+    ],
+    "name:ast_x_preferred":[
+        "Shuhada"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u0634\u0647\u062f\u0627\u0621"
     ],
     "name:ceb_x_preferred":[
         "Ash Shuhad\u0101'"
+    ],
+    "name:deu_x_preferred":[
+        "asch-Schuhada"
     ],
     "name:eng_x_preferred":[
         "Shuhada"
@@ -80,7 +89,7 @@
         }
     ],
     "wof:id":890422283,
-    "wof:lastmodified":1566586574,
+    "wof:lastmodified":1690876060,
     "wof:name":"Ash Shuhad\u0101\u2019",
     "wof:parent_id":1092019949,
     "wof:placetype":"locality",

--- a/data/890/422/285/890422285.geojson
+++ b/data/890/422/285/890422285.geojson
@@ -22,11 +22,17 @@
     "name:ara_x_preferred":[
         "\u0623\u0634\u0645\u0648\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0634\u0645\u0648\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0634\u0645\u0648\u0646"
     ],
     "name:ceb_x_preferred":[
         "Ashm\u016bn"
+    ],
+    "name:deu_x_preferred":[
+        "Aschmun"
     ],
     "name:eng_x_preferred":[
         "Ashmoun"
@@ -34,7 +40,16 @@
     "name:fas_x_preferred":[
         "\u0627\u0634\u0645\u0648\u0646"
     ],
+    "name:heb_x_preferred":[
+        "\u05d0\u05e9\u05de\u05d5\u05df"
+    ],
+    "name:mlg_x_preferred":[
+        "Ashm\u016bn"
+    ],
     "name:nld_x_preferred":[
+        "Ashmoun"
+    ],
+    "name:nob_x_preferred":[
         "Ashmoun"
     ],
     "name:pol_x_preferred":[
@@ -51,6 +66,9 @@
     ],
     "name:und_x_variant":[
         "ASHM\u016aN"
+    ],
+    "name:zul_x_preferred":[
+        "Ashmoun"
     ],
     "qs:name":"Ashm\u016bn",
     "qs:photos_9r":0,
@@ -83,7 +101,7 @@
         }
     ],
     "wof:id":890422285,
-    "wof:lastmodified":1566586574,
+    "wof:lastmodified":1690876061,
     "wof:name":"Ashm\u016bn",
     "wof:parent_id":1092014621,
     "wof:placetype":"locality",

--- a/data/890/422/287/890422287.geojson
+++ b/data/890/422/287/890422287.geojson
@@ -22,8 +22,14 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0642\u0631\u064a\u0646"
     ],
+    "name:ast_x_preferred":[
+        "Al Qurayn"
+    ],
     "name:azb_x_preferred":[
         "\u0642\u0631\u06cc\u0646"
+    ],
+    "name:ceb_x_preferred":[
+        "Al Qurayn"
     ],
     "name:eng_x_preferred":[
         "Al Qurayn"
@@ -45,6 +51,9 @@
     ],
     "name:rus_x_variant":[
         "\u042d\u043b\u044c-\u041a\u0443\u0440\u0435\u0439\u043d"
+    ],
+    "name:swe_x_preferred":[
+        "Al Qurayn"
     ],
     "name:und_x_variant":[
         "El-Qurein"
@@ -80,7 +89,7 @@
         }
     ],
     "wof:id":890422287,
-    "wof:lastmodified":1566586573,
+    "wof:lastmodified":1690876060,
     "wof:name":"Al Qurayn",
     "wof:parent_id":1092019105,
     "wof:placetype":"locality",

--- a/data/890/428/837/890428837.geojson
+++ b/data/890/428/837/890428837.geojson
@@ -28,6 +28,9 @@
     "name:arz_x_preferred":[
         "\u0631\u0634\u064a\u062f"
     ],
+    "name:ast_x_preferred":[
+        "Rosetta"
+    ],
     "name:bul_x_preferred":[
         "\u0420\u043e\u0437\u0435\u0442\u0430"
     ],
@@ -58,11 +61,17 @@
     "name:fas_x_preferred":[
         "\u0631\u0634\u06cc\u062f"
     ],
+    "name:fin_x_preferred":[
+        "Rosetta"
+    ],
     "name:fra_x_preferred":[
         "Rachid"
     ],
     "name:fra_x_variant":[
         "Rosette"
+    ],
+    "name:gle_x_preferred":[
+        "Rosetta"
     ],
     "name:hbs_x_preferred":[
         "Ra\u0161id"
@@ -78,6 +87,9 @@
     ],
     "name:ind_x_preferred":[
         "Rashid"
+    ],
+    "name:ind_x_variant":[
+        "Rasyid"
     ],
     "name:isl_x_preferred":[
         "Rosetta"
@@ -99,6 +111,12 @@
     ],
     "name:lat_x_preferred":[
         "Rosetta"
+    ],
+    "name:mlg_x_preferred":[
+        "Rosetta"
+    ],
+    "name:msa_x_preferred":[
+        "Rasyid"
     ],
     "name:nld_x_preferred":[
         "Rosetta"
@@ -136,8 +154,20 @@
     "name:ukr_x_preferred":[
         "\u0420\u0430\u0448\u0438\u0434"
     ],
+    "name:urd_x_preferred":[
+        "\u0631\u0634\u064a\u062f"
+    ],
+    "name:war_x_preferred":[
+        "Rosetta"
+    ],
+    "name:wuu_x_preferred":[
+        "\u7f57\u585e\u5854"
+    ],
     "name:zho_x_preferred":[
         "\u7f85\u585e\u5854"
+    ],
+    "name:zul_x_preferred":[
+        "Rosetta"
     ],
     "qs:name":"Rosetta",
     "qs:photos_9r":0,
@@ -176,7 +206,7 @@
         }
     ],
     "wof:id":890428837,
-    "wof:lastmodified":1566586576,
+    "wof:lastmodified":1690876063,
     "wof:name":"Rosetta",
     "wof:parent_id":1092023921,
     "wof:placetype":"locality",

--- a/data/890/429/453/890429453.geojson
+++ b/data/890/429/453/890429453.geojson
@@ -37,6 +37,9 @@
     "name:arg_x_preferred":[
         "Aleixandr\u00eda"
     ],
+    "name:ary_x_preferred":[
+        "\u0644\u0625\u0633\u0643\u0646\u062f\u0631\u064a\u0629"
+    ],
     "name:arz_x_preferred":[
         "\u0627\u0633\u0643\u0646\u062f\u0631\u064a\u0647"
     ],
@@ -106,6 +109,9 @@
     "name:ckb_x_variant":[
         "\u0626\u06d5\u0633\u06a9\u06d5\u0646\u062f\u06d5\u0631\u06cc\u06cc\u06d5"
     ],
+    "name:cos_x_preferred":[
+        "Alessandria"
+    ],
     "name:cym_x_preferred":[
         "Alecsandria"
     ],
@@ -117,6 +123,9 @@
     ],
     "name:deu_x_preferred":[
         "Alexandria"
+    ],
+    "name:diq_x_preferred":[
+        "\u0130skenderiya"
     ],
     "name:ell_x_preferred":[
         "\u0391\u03bb\u03b5\u03be\u03ac\u03bd\u03b4\u03c1\u03b5\u03b9\u03b1"
@@ -160,6 +169,12 @@
     "name:fry_x_preferred":[
         "Aleksandrje"
     ],
+    "name:ful_x_preferred":[
+        "Alexandria"
+    ],
+    "name:gla_x_preferred":[
+        "Alecsandria"
+    ],
     "name:gle_x_preferred":[
         "Cathair Alastair"
     ],
@@ -198,6 +213,12 @@
     ],
     "name:hyw_x_preferred":[
         "\u0531\u0572\u0565\u0584\u057d\u0561\u0576\u057f\u0580\u056b\u0561"
+    ],
+    "name:hyw_x_variant":[
+        "\u0531\u0572\u0565\u0584\u057d\u0561\u0576\u0564\u0580\u056b\u0561"
+    ],
+    "name:ido_x_preferred":[
+        "Alexandria"
     ],
     "name:ile_x_preferred":[
         "Alexandria"
@@ -262,8 +283,14 @@
     "name:lav_x_preferred":[
         "Aleksandrija"
     ],
+    "name:lfn_x_preferred":[
+        "Iskandariya"
+    ],
     "name:lij_x_preferred":[
         "Lusciandria d'Egitto"
+    ],
+    "name:lim_x_preferred":[
+        "Alexandri\u00eb"
     ],
     "name:lit_x_preferred":[
         "Aleksandrija"
@@ -289,6 +316,9 @@
     "name:mlg_x_preferred":[
         "Alexandria"
     ],
+    "name:mlt_x_preferred":[
+        "Lixandra"
+    ],
     "name:mon_x_preferred":[
         "\u0410\u043b\u0435\u043a\u0441\u0430\u043d\u0434\u0440\u0438\u044f"
     ],
@@ -300,6 +330,9 @@
     ],
     "name:mya_x_preferred":[
         "\u1021\u101c\u1000\u103a\u1007\u1014\u1039\u1012\u101b\u102e\u1038\u101a\u102c\u1038\u1019\u103c\u102d\u102f\u1037"
+    ],
+    "name:mzn_x_preferred":[
+        "\u0627\u0633\u06a9\u0646\u062f\u0631\u06cc\u0647"
     ],
     "name:nah_x_preferred":[
         "Alexandria"
@@ -364,6 +397,9 @@
     "name:ron_x_preferred":[
         "Alexandria"
     ],
+    "name:rue_x_preferred":[
+        "\u0410\u043b\u0435\u043a\u0441\u0430\u043d\u0434\u0440\u0438\u044f"
+    ],
     "name:rus_x_preferred":[
         "\u0410\u043b\u0435\u043a\u0441\u0430\u043d\u0434\u0440\u0438\u044f"
     ],
@@ -385,11 +421,20 @@
     "name:slv_x_preferred":[
         "Aleksandrija"
     ],
+    "name:smn_x_preferred":[
+        "Aleksandria"
+    ],
     "name:sna_x_preferred":[
         "Alexandria"
     ],
     "name:snd_x_preferred":[
         "\u0627\u0633\u06aa\u0646\u062f\u0631\u064a\u06c1"
+    ],
+    "name:snd_x_variant":[
+        "\u0627\u0644\u064a\u06af\u0632\u064a\u0646\u068a\u0631\u064a\u0627"
+    ],
+    "name:som_x_preferred":[
+        "Askandariya"
     ],
     "name:spa_x_preferred":[
         "Alejandr\u00eda"
@@ -444,6 +489,9 @@
     ],
     "name:twi_x_variant":[
         "Alexandria"
+    ],
+    "name:uig_x_preferred":[
+        "\u0626\u0649\u0633\u0643\u06d5\u0646\u062f\u06d5\u0631\u0649\u064a\u06d5"
     ],
     "name:ukr_x_preferred":[
         "\u0410\u043b\u0435\u043a\u0441\u0430\u043d\u0434\u0440\u0456\u044f"
@@ -511,6 +559,9 @@
     "name:zho_x_variant":[
         "\u4e9a\u5386\u5c71\u5927\u6e2f",
         "\u4e9e\u6b77\u5c71\u5927\u6e2f"
+    ],
+    "name:zul_x_preferred":[
+        "Alexandria"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Egypt",
@@ -622,8 +673,8 @@
     "wof:belongsto":[
         102191573,
         85632581,
-        1092024943,
-        85671041
+        85671041,
+        1092024943
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -649,7 +700,7 @@
         }
     ],
     "wof:id":890429453,
-    "wof:lastmodified":1610154837,
+    "wof:lastmodified":1690876064,
     "wof:megacity":1,
     "wof:name":"Alexandria",
     "wof:parent_id":1092024943,

--- a/data/890/430/393/890430393.geojson
+++ b/data/890/430/393/890430393.geojson
@@ -25,8 +25,20 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0632\u0631\u0642\u0627"
     ],
+    "name:ast_x_preferred":[
+        "El Zarqa"
+    ],
+    "name:azb_x_preferred":[
+        "\u0632\u0631\u0642\u0627"
+    ],
+    "name:cat_x_preferred":[
+        "Al-Zarqa"
+    ],
     "name:ceb_x_preferred":[
         "Az Zarq\u0101"
+    ],
+    "name:deu_x_preferred":[
+        "al-Zarqa"
     ],
     "name:eng_x_preferred":[
         "El Zarqa"
@@ -40,6 +52,9 @@
     "name:ita_x_preferred":[
         "Al Zarqa"
     ],
+    "name:mlg_x_preferred":[
+        "Az Zarq\u0101"
+    ],
     "name:nld_x_preferred":[
         "Az Zarqa"
     ],
@@ -49,8 +64,14 @@
     "name:swe_x_preferred":[
         "Az Zarq\u0101"
     ],
+    "name:tha_x_preferred":[
+        "\u0e2d\u0e31\u0e0b\u0e0b\u0e31\u0e23\u0e01\u0e2d"
+    ],
     "name:und_x_variant":[
         "Az-Zarq\u0101"
+    ],
+    "name:zul_x_preferred":[
+        "El Zarqa"
     ],
     "qs:name":"Az Zarq\u0101",
     "qs:photos_9r":0,
@@ -83,7 +104,7 @@
         }
     ],
     "wof:id":890430393,
-    "wof:lastmodified":1566586575,
+    "wof:lastmodified":1690876062,
     "wof:name":"Az Zarq\u0101",
     "wof:parent_id":1092020509,
     "wof:placetype":"locality",

--- a/data/890/431/221/890431221.geojson
+++ b/data/890/431/221/890431221.geojson
@@ -28,14 +28,23 @@
     "name:arz_x_preferred":[
         "\u062f\u0633\u0648\u0642"
     ],
+    "name:ast_x_preferred":[
+        "Desouk"
+    ],
     "name:azb_x_preferred":[
         "\u062f\u0633\u0648\u0642"
     ],
     "name:aze_x_preferred":[
         "D\u0259suk"
     ],
+    "name:aze_x_variant":[
+        "D\u0259suq"
+    ],
     "name:ben_x_preferred":[
         "\u09a6\u09c7\u09b8\u09cb\u0989\u0995"
+    ],
+    "name:ben_x_variant":[
+        "\u09a6\u09c7\u09b8\u09c1\u0995"
     ],
     "name:bjn_x_preferred":[
         "Dosouk"
@@ -49,6 +58,9 @@
     "name:ceb_x_preferred":[
         "Markaz Dis\u016bq"
     ],
+    "name:ceb_x_variant":[
+        "Dis\u016bq"
+    ],
     "name:ces_x_preferred":[
         "Desouk"
     ],
@@ -57,6 +69,9 @@
     ],
     "name:deu_x_preferred":[
         "Disuk"
+    ],
+    "name:deu_x_variant":[
+        "Disuq"
     ],
     "name:ell_x_preferred":[
         "\u039d\u03c4\u03b5\u03c3\u03bf\u03cd\u03ba"
@@ -76,6 +91,9 @@
     "name:fra_x_preferred":[
         "Dessouk"
     ],
+    "name:gle_x_preferred":[
+        "Desouk"
+    ],
     "name:guj_x_preferred":[
         "\u0aa6\u0ac7\u0ab8\u0acc\u0a95"
     ],
@@ -84,6 +102,9 @@
     ],
     "name:hrv_x_preferred":[
         "Disuk"
+    ],
+    "name:hye_x_preferred":[
+        "\u0534\u056b\u057d\u0578\u0582\u0584"
     ],
     "name:ind_x_preferred":[
         "Dosouk"
@@ -123,6 +144,9 @@
     ],
     "name:mar_x_preferred":[
         "\u0921\u0947\u0938\u094b\u090a\u0915"
+    ],
+    "name:mlg_x_preferred":[
+        "Dis\u016bq"
     ],
     "name:msa_x_preferred":[
         "Desouk"
@@ -184,6 +208,9 @@
     "name:urd_x_preferred":[
         "\u062f\u0633\u0648\u0642"
     ],
+    "name:vec_x_preferred":[
+        "Disuq"
+    ],
     "name:vie_x_preferred":[
         "Desouk"
     ],
@@ -192,6 +219,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8fea\u65af\u6c83\u514b"
+    ],
+    "name:zul_x_preferred":[
+        "Desouk"
     ],
     "qs:name":"Dis\u016bq",
     "qs:photos_9r":0,
@@ -224,7 +254,7 @@
         }
     ],
     "wof:id":890431221,
-    "wof:lastmodified":1566586576,
+    "wof:lastmodified":1690876063,
     "wof:name":"Dis\u016bq",
     "wof:parent_id":1092016203,
     "wof:placetype":"locality",

--- a/data/890/431/233/890431233.geojson
+++ b/data/890/431/233/890431233.geojson
@@ -31,6 +31,9 @@
     "name:ceb_x_preferred":[
         "Dayr\u016b\u0163"
     ],
+    "name:deu_x_preferred":[
+        "Dairut"
+    ],
     "name:eng_x_preferred":[
         "Dairut"
     ],
@@ -48,6 +51,9 @@
     ],
     "name:kat_x_preferred":[
         "\u10d3\u10d0\u10d8\u10e0\u10e3\u10e2\u10d8"
+    ],
+    "name:mlg_x_preferred":[
+        "Dayr\u016b\u0163"
     ],
     "name:nld_x_preferred":[
         "Dairut"
@@ -69,6 +75,9 @@
     ],
     "name:zho_x_preferred":[
         "\u4ee3\u9b6f\u7279"
+    ],
+    "name:zul_x_preferred":[
+        "Dairut"
     ],
     "qs:name":"Dayr\u016b\u0163",
     "qs:photos_9r":0,
@@ -101,7 +110,7 @@
         }
     ],
     "wof:id":890431233,
-    "wof:lastmodified":1566586576,
+    "wof:lastmodified":1690876063,
     "wof:name":"Dayr\u016b\u0163",
     "wof:parent_id":1092015987,
     "wof:placetype":"locality",

--- a/data/890/432/009/890432009.geojson
+++ b/data/890/432/009/890432009.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0641\u0634\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0641\u0634\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u0641\u0634\u0646"
     ],
@@ -40,7 +43,13 @@
     "name:fas_x_preferred":[
         "\u0627\u0644\u0641\u0634\u0646"
     ],
+    "name:mlg_x_preferred":[
+        "Al Fashn"
+    ],
     "name:nld_x_preferred":[
+        "Al Fashn"
+    ],
+    "name:nob_x_preferred":[
         "Al Fashn"
     ],
     "name:pol_x_preferred":[
@@ -53,6 +62,9 @@
         "Al Fashn"
     ],
     "name:und_x_variant":[
+        "El Fashn"
+    ],
+    "name:zul_x_preferred":[
         "El Fashn"
     ],
     "qs:name":"Al Fashn",
@@ -88,7 +100,7 @@
         }
     ],
     "wof:id":890432009,
-    "wof:lastmodified":1566586582,
+    "wof:lastmodified":1690876071,
     "wof:name":"Al Fashn",
     "wof:parent_id":1092017627,
     "wof:placetype":"locality",

--- a/data/890/433/319/890433319.geojson
+++ b/data/890/433/319/890433319.geojson
@@ -25,11 +25,17 @@
     "name:arz_x_preferred":[
         "\u0627\u0628\u0648 \u0642\u0631\u0642\u0627\u0635"
     ],
+    "name:ast_x_preferred":[
+        "Abu Qirqas"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0628\u0648 \u0642\u0631\u0642\u0627\u0635"
     ],
     "name:ceb_x_preferred":[
         "Markaz Ab\u016b Qurq\u0101\u015f"
+    ],
+    "name:ceb_x_variant":[
+        "Ab\u016b Qurq\u0101\u015f"
     ],
     "name:deu_x_preferred":[
         "Ab\u016b Qurq\u0101\u1e63"
@@ -49,6 +55,9 @@
     "name:kat_x_preferred":[
         "\u10d0\u10d1\u10e3-\u10e5\u10d8\u10e0\u10e5\u10d0\u10e1\u10d8"
     ],
+    "name:mlg_x_preferred":[
+        "Ab\u016b Qurq\u0101\u015f"
+    ],
     "name:nld_x_preferred":[
         "Abu Qirqas"
     ],
@@ -63,6 +72,9 @@
     ],
     "name:swe_x_preferred":[
         "Markaz Ab\u016b Qurq\u0101\u015f"
+    ],
+    "name:swe_x_variant":[
+        "Ab\u016b Qurq\u0101\u015f"
     ],
     "name:und_x_variant":[
         "Abu Kerkae"
@@ -97,7 +109,7 @@
         }
     ],
     "wof:id":890433319,
-    "wof:lastmodified":1566586581,
+    "wof:lastmodified":1690876069,
     "wof:name":"Ab\u016b Qurq\u0101\u015f",
     "wof:parent_id":1092014221,
     "wof:placetype":"locality",

--- a/data/890/433/321/890433321.geojson
+++ b/data/890/433/321/890433321.geojson
@@ -34,11 +34,20 @@
     "name:heb_x_preferred":[
         "\u05d0\u05d1\u05d5 \u05db\u05d1\u05d9\u05e8"
     ],
+    "name:ind_x_preferred":[
+        "Abu Kabir"
+    ],
     "name:nld_x_preferred":[
+        "Abu Kabir"
+    ],
+    "name:spa_x_preferred":[
         "Abu Kabir"
     ],
     "name:und_x_variant":[
         "Abu Keb\u00eer"
+    ],
+    "name:urd_x_preferred":[
+        "\u0627\u0628\u0648 \u06a9\u0628\u06cc\u0631"
     ],
     "qs:name":"Ab\u016b Kab\u012br",
     "qs:photos_9r":0,
@@ -73,7 +82,7 @@
         }
     ],
     "wof:id":890433321,
-    "wof:lastmodified":1566586581,
+    "wof:lastmodified":1690876069,
     "wof:name":"Ab\u016b Kab\u012br",
     "wof:parent_id":1092014175,
     "wof:placetype":"locality",

--- a/data/890/433/335/890433335.geojson
+++ b/data/890/433/335/890433335.geojson
@@ -28,11 +28,17 @@
     "name:arz_x_preferred":[
         "\u0627\u062f\u0641\u0648"
     ],
+    "name:ast_x_preferred":[
+        "Edfu"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u062f\u0641\u0648"
     ],
     "name:aze_x_preferred":[
         "Edfu"
+    ],
+    "name:aze_x_variant":[
+        "\u0130dfu"
     ],
     "name:bul_x_preferred":[
         "\u0415\u0434\u0444\u0443"
@@ -43,6 +49,12 @@
     "name:ceb_x_preferred":[
         "Markaz Idf\u016b"
     ],
+    "name:ceb_x_variant":[
+        "Idf\u016b"
+    ],
+    "name:ces_x_preferred":[
+        "Edfu"
+    ],
     "name:deu_x_preferred":[
         "Edfu"
     ],
@@ -50,6 +62,9 @@
         "\u0395\u03bd\u03c4\u03c6\u03bf\u03cd"
     ],
     "name:eng_x_preferred":[
+        "Edfu"
+    ],
+    "name:epo_x_preferred":[
         "Edfu"
     ],
     "name:eus_x_preferred":[
@@ -79,6 +94,12 @@
     "name:hun_x_preferred":[
         "Edfu"
     ],
+    "name:hye_x_preferred":[
+        "\u053b\u0564\u0586\u0578\u0582"
+    ],
+    "name:ind_x_preferred":[
+        "Edfu"
+    ],
     "name:ita_x_preferred":[
         "Edfu"
     ],
@@ -99,6 +120,9 @@
     ],
     "name:ltz_x_preferred":[
         "Edfu"
+    ],
+    "name:mlg_x_preferred":[
+        "Idf\u016b"
     ],
     "name:nld_x_preferred":[
         "Edfu"
@@ -121,6 +145,9 @@
     "name:sco_x_preferred":[
         "Edfu"
     ],
+    "name:slk_x_preferred":[
+        "Edfu"
+    ],
     "name:slv_x_preferred":[
         "Edfu"
     ],
@@ -130,8 +157,14 @@
     "name:srp_x_preferred":[
         "\u0415\u0434\u0444\u0443"
     ],
+    "name:swa_x_preferred":[
+        "Edfu"
+    ],
     "name:swe_x_preferred":[
         "Idfu"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0418\u0434\u0444\u0443"
     ],
     "name:tur_x_preferred":[
         "Edfu"
@@ -142,8 +175,17 @@
     "name:urd_x_preferred":[
         "\u0627\u062f\u0641\u0648"
     ],
+    "name:vec_x_preferred":[
+        "Edfu"
+    ],
+    "name:war_x_preferred":[
+        "Edfu"
+    ],
     "name:zho_x_preferred":[
         "\u57c3\u5fb7\u5bcc"
+    ],
+    "name:zul_x_preferred":[
+        "Edfu"
     ],
     "qs:name":"Idfu",
     "qs:photos_9r":0,
@@ -182,7 +224,7 @@
         }
     ],
     "wof:id":890433335,
-    "wof:lastmodified":1566586580,
+    "wof:lastmodified":1690876069,
     "wof:name":"Idfu",
     "wof:parent_id":1092016437,
     "wof:placetype":"locality",

--- a/data/890/434/695/890434695.geojson
+++ b/data/890/434/695/890434695.geojson
@@ -37,8 +37,14 @@
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0425\u0443\u0440\u0433\u0430\u0434\u0430"
     ],
+    "name:bel_x_variant":[
+        "\u0425\u0443\u0440\u0433\u0430\u0434\u0430"
+    ],
     "name:ben_x_preferred":[
         "\u09b9\u09be\u09b0\u0998\u09be\u09a6\u09be"
+    ],
+    "name:ben_x_variant":[
+        "\u09b9\u09be\u09b0\u0997\u09be\u09a6\u09be"
     ],
     "name:bul_x_preferred":[
         "\u0425\u0443\u0440\u0433\u0430\u0434\u0430"
@@ -145,6 +151,9 @@
     "name:mkd_x_preferred":[
         "\u0425\u0443\u0440\u0433\u0430\u0434\u0430"
     ],
+    "name:mlg_x_preferred":[
+        "Hurghada"
+    ],
     "name:msa_x_preferred":[
         "Hurghada"
     ],
@@ -179,6 +188,9 @@
         "\u0dc4\u0dbb\u0dca\u0d9c\u0dcf\u0da9\u0dcf"
     ],
     "name:slk_x_preferred":[
+        "Hurgada"
+    ],
+    "name:slv_x_preferred":[
         "Hurgada"
     ],
     "name:spa_x_preferred":[
@@ -220,11 +232,17 @@
     "name:urd_x_preferred":[
         "\u063a\u0631\u062f\u0642\u06c1"
     ],
+    "name:vec_x_preferred":[
+        "Hurghada"
+    ],
     "name:vie_x_preferred":[
         "Hurghada"
     ],
     "name:war_x_preferred":[
         "Hurghada"
+    ],
+    "name:wuu_x_preferred":[
+        "\u53e4\u5c14\u4ee3\u76d6"
     ],
     "name:xmf_x_preferred":[
         "\u10f0\u10e3\u10e0\u10d2\u10d0\u10d3\u10d0"
@@ -234,6 +252,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6d2a\u52a0\u9054"
+    ],
+    "name:zul_x_preferred":[
+        "Hurghada"
     ],
     "qs:name":"Al Ghardaqah",
     "qs:photos_9r":0,
@@ -266,7 +287,7 @@
         }
     ],
     "wof:id":890434695,
-    "wof:lastmodified":1566586580,
+    "wof:lastmodified":1690876068,
     "wof:name":"Al Ghardaqah",
     "wof:parent_id":1092021497,
     "wof:placetype":"locality",

--- a/data/890/434/721/890434721.geojson
+++ b/data/890/434/721/890434721.geojson
@@ -28,8 +28,14 @@
     "name:azb_x_preferred":[
         "\u0645\u062d\u0644\u0647 \u0627\u0644\u06a9\u0628\u0631\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "\u018fl-M\u0259h\u0259ll\u0259 \u0259l-K\u00fcbra"
+    ],
     "name:bel_x_preferred":[
         "\u042d\u043b\u044c-\u041c\u0430\u0445\u0430\u043b\u0430-\u044d\u043b\u044c-\u041a\u0443\u0431\u0440\u0430"
+    ],
+    "name:ben_x_preferred":[
+        "\u098f\u09b2 \u09ae\u09be\u09b9\u09be\u09b2\u09cd\u09b2\u09be \u098f\u09b2 \u0995\u09c1\u09ac\u09b0\u09be"
     ],
     "name:bul_x_preferred":[
         "\u0415\u043b-\u041c\u0430\u0445\u0430\u043b\u0430 \u0415\u043b-\u041a\u0443\u0431\u0440\u0430"
@@ -51,6 +57,9 @@
     ],
     "name:eng_x_preferred":[
         "El-Mahalla El-Kubra"
+    ],
+    "name:eng_x_variant":[
+        "El Mahalla El Kubra"
     ],
     "name:est_x_preferred":[
         "Al-Ma\u1e29allah al-Kubr\u00e1"
@@ -76,6 +85,9 @@
     "name:hye_x_preferred":[
         "\u0561\u056c-\u0544\u0561\u0570\u0561\u056c\u056c\u0561 \u0561\u056c-\u0554\u0578\u0582\u0562\u0580\u0561"
     ],
+    "name:hyw_x_preferred":[
+        "\u0531\u056c \u0544\u0561\u0570\u0561\u056c\u056c\u0561 \u0531\u056c \u0554\u0578\u0582\u057a\u0580\u0561"
+    ],
     "name:ita_x_preferred":[
         "El-Mahalla El-Kubra"
     ],
@@ -91,8 +103,14 @@
     "name:lit_x_preferred":[
         "Mahala el Kubra"
     ],
+    "name:mlg_x_preferred":[
+        "Al Ma\u1e29allah al Kubr\u00e1"
+    ],
     "name:nld_x_preferred":[
         "El-Mahalla El-Kubra"
+    ],
+    "name:nob_x_preferred":[
+        "El Mahalla El Kubra"
     ],
     "name:pol_x_preferred":[
         "Al-Mahalla al-Kubra"
@@ -133,11 +151,20 @@
     "name:urd_x_preferred":[
         "\u0627\u0644\u0645\u062d\u0644\u06c1 \u0627\u0644\u06a9\u0628\u0631\u06cc"
     ],
+    "name:uzb_x_preferred":[
+        "Mahallat ul-kubro"
+    ],
+    "name:vec_x_preferred":[
+        "El-Mahalla El-Kubra"
+    ],
     "name:war_x_preferred":[
         "El-Mahalla El-Kubra"
     ],
     "name:zho_x_preferred":[
         "\u5927\u9081\u54c8\u840a"
+    ],
+    "name:zul_x_preferred":[
+        "El Mahalla El Kubra"
     ],
     "qs:name":"Al Ma\u1e29allah al Kubr\u00e1",
     "qs:photos_9r":0,
@@ -170,7 +197,7 @@
         }
     ],
     "wof:id":890434721,
-    "wof:lastmodified":1566586580,
+    "wof:lastmodified":1690876069,
     "wof:name":"Al Ma\u1e29allah al Kubr\u00e1",
     "wof:parent_id":1092025637,
     "wof:placetype":"locality",

--- a/data/890/441/647/890441647.geojson
+++ b/data/890/441/647/890441647.geojson
@@ -22,8 +22,17 @@
     "name:ara_x_preferred":[
         "\u0637\u0627\u0645\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0637\u0627\u0645\u064a\u0647"
+    ],
+    "name:azb_x_preferred":[
+        "\u0637\u0627\u0645\u06cc\u0647"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0422\u0430\u043c\u0456\u044f"
+    ],
+    "name:bel_x_variant":[
+        "\u0422\u0430\u043c\u0456\u044f"
     ],
     "name:eng_x_preferred":[
         "Tamiya"
@@ -48,6 +57,9 @@
     ],
     "name:und_x_variant":[
         "T\u0101m\u012bya"
+    ],
+    "name:zul_x_preferred":[
+        "Tamiya"
     ],
     "qs:name":"\u0162\u0101miyah",
     "qs:photos_9r":0,
@@ -80,7 +92,7 @@
         }
     ],
     "wof:id":890441647,
-    "wof:lastmodified":1566586575,
+    "wof:lastmodified":1690876062,
     "wof:name":"\u0162\u0101miyah",
     "wof:parent_id":1092025417,
     "wof:placetype":"locality",

--- a/data/890/441/653/890441653.geojson
+++ b/data/890/441/653/890441653.geojson
@@ -22,6 +22,12 @@
     "name:ara_x_preferred":[
         "\u062f\u064a\u0631 \u0645\u0648\u0627\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u064a\u0631 \u0645\u0648\u0627\u0633"
+    ],
+    "name:ast_x_preferred":[
+        "Deir Mawas"
+    ],
     "name:azb_x_preferred":[
         "\u062f\u06cc\u0631 \u0645\u0648\u0627\u0633"
     ],
@@ -43,6 +49,9 @@
     "name:kat_x_preferred":[
         "\u10d3\u10d4\u10d8\u10e0-\u10db\u10d0\u10d5\u10d0\u10e1\u10d8"
     ],
+    "name:mlg_x_preferred":[
+        "Dayr Maw\u0101s"
+    ],
     "name:nld_x_preferred":[
         "Deir Mawas"
     ],
@@ -54,6 +63,9 @@
     ],
     "name:swe_x_preferred":[
         "Dayr Maw\u0101s"
+    ],
+    "name:zul_x_preferred":[
+        "Dir Mawas"
     ],
     "qs:name":"Dayr Maw\u0101s",
     "qs:photos_9r":0,
@@ -86,7 +98,7 @@
         }
     ],
     "wof:id":890441653,
-    "wof:lastmodified":1566586575,
+    "wof:lastmodified":1690876062,
     "wof:name":"Dayr Maw\u0101s",
     "wof:parent_id":1092016033,
     "wof:placetype":"locality",

--- a/data/890/441/655/890441655.geojson
+++ b/data/890/441/655/890441655.geojson
@@ -22,6 +22,12 @@
     "name:ara_x_preferred":[
         "\u0646\u0627\u0635\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0646\u0627\u0635\u0631"
+    ],
+    "name:ast_x_preferred":[
+        "Nasser"
+    ],
     "name:azb_x_preferred":[
         "\u0646\u0627\u0635\u0631"
     ],
@@ -43,6 +49,9 @@
     "name:nld_x_preferred":[
         "Nasser"
     ],
+    "name:nob_x_preferred":[
+        "Nasser"
+    ],
     "name:pol_x_preferred":[
         "Nasir"
     ],
@@ -54,6 +63,9 @@
     ],
     "name:swe_x_preferred":[
         "B\u016bsh"
+    ],
+    "name:zul_x_preferred":[
+        "Nasser"
     ],
     "qs:name":"B\u016bsh",
     "qs:photos_9r":0,
@@ -86,7 +98,7 @@
         }
     ],
     "wof:id":890441655,
-    "wof:lastmodified":1566586575,
+    "wof:lastmodified":1690876062,
     "wof:name":"B\u016bsh",
     "wof:parent_id":1092022779,
     "wof:placetype":"locality",

--- a/data/890/441/657/890441657.geojson
+++ b/data/890/441/657/890441657.geojson
@@ -37,6 +37,9 @@
     "name:eng_x_preferred":[
         "El-bagour"
     ],
+    "name:eng_x_variant":[
+        "El Bagour"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0628\u0627\u062c\u0648\u0631"
     ],
@@ -57,6 +60,9 @@
     ],
     "name:und_x_variant":[
         "El-B\u00e2g\u00fbr"
+    ],
+    "name:zul_x_preferred":[
+        "El Bagour"
     ],
     "qs:name":"Al B\u0101j\u016br",
     "qs:photos_9r":0,
@@ -89,7 +95,7 @@
         }
     ],
     "wof:id":890441657,
-    "wof:lastmodified":1566586575,
+    "wof:lastmodified":1690876061,
     "wof:name":"Al B\u0101j\u016br",
     "wof:parent_id":1092017065,
     "wof:placetype":"locality",

--- a/data/890/442/877/890442877.geojson
+++ b/data/890/442/877/890442877.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"32.3552505,29.58333,32.3552505,29.58333",
+    "geom:bbox":"32.35525,29.58333,32.35525,29.58333",
     "geom:latitude":29.58333,
     "geom:longitude":32.35525,
     "gn:country":"EG",
@@ -42,11 +42,23 @@
     "name:eng_x_preferred":[
         "Ain Sukhna"
     ],
+    "name:eng_x_variant":[
+        "Ain Sokhna"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0639\u06cc\u0646 \u0627\u0644\u0633\u062e\u0646\u0629"
     ],
     "name:fra_x_preferred":[
         "Ain Sukhna"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e2\u05d9\u05df \u05e1\u05d5\u05d7\u05e0\u05d4"
+    ],
+    "name:ibo_x_preferred":[
+        "Ain Sokhna"
+    ],
+    "name:ita_x_preferred":[
+        "Ain Sokhna"
     ],
     "name:jpn_x_preferred":[
         "\u30a2\u30a4\u30f3\u30fb\u30b9\u30af\u30ca"
@@ -60,11 +72,20 @@
     "name:kor_x_preferred":[
         "\uc544\uc778 \uc218\ud06c\ub098"
     ],
+    "name:mlg_x_preferred":[
+        "Ain Sukhna"
+    ],
     "name:nld_x_preferred":[
         "Ain Sukhna"
     ],
     "name:pol_x_preferred":[
         "Ajn Suchna"
+    ],
+    "name:ron_x_preferred":[
+        "Ain Sokhna"
+    ],
+    "name:rus_x_preferred":[
+        "\u0410\u0439\u043d-\u0421\u043e\u0445\u043d\u0430"
     ],
     "name:slv_x_preferred":[
         "Ain Suhna"
@@ -72,8 +93,23 @@
     "name:spa_x_preferred":[
         "Ain Sujna"
     ],
+    "name:swa_x_preferred":[
+        "Ain Sokhna"
+    ],
     "name:swe_x_preferred":[
         "Ain Sokhna"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0410\u0457\u043d \u0421\u043e\u0445\u043d\u0430"
+    ],
+    "name:urd_x_preferred":[
+        "\u0639\u06cc\u0646 \u0627\u0644\u0633\u062e\u0646\u06c1"
+    ],
+    "name:vie_x_preferred":[
+        "Ain Sokhna"
+    ],
+    "name:zho_x_preferred":[
+        "\u827e\u56e0\u00b7\u8607\u514b\u7d0d"
     ],
     "qs:name":"Ein El Sokhna",
     "qs:name_adm0":"\u0645\u0635\u0631",
@@ -99,7 +135,7 @@
     },
     "wof:country":"EG",
     "wof:created":1469052385,
-    "wof:geomhash":"ff48402c52ffc2023aa433263032a941",
+    "wof:geomhash":"20303bd3972f89728eb19bbc4a4d3517",
     "wof:hierarchy":[
         {
             "country_id":85632581,
@@ -107,7 +143,7 @@
         }
     ],
     "wof:id":890442877,
-    "wof:lastmodified":1566586578,
+    "wof:lastmodified":1690876066,
     "wof:name":"Ein El Sokhna",
     "wof:parent_id":-1,
     "wof:placetype":"locality",
@@ -117,10 +153,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    32.3552505,
+    32.35525,
     29.58333,
-    32.3552505,
+    32.35525,
     29.58333
 ],
-  "geometry": {"coordinates":[32.3552505,29.58333],"type":"Point"}
+  "geometry": {"coordinates":[32.35525,29.58333],"type":"Point"}
 }

--- a/data/890/443/435/890443435.geojson
+++ b/data/890/443/435/890443435.geojson
@@ -25,6 +25,9 @@
     "name:arz_x_preferred":[
         "\u062a\u0627\u0631\u064a\u062e \u0627\u0644\u0642\u0646\u0627\u0637\u0631 \u0627\u0644\u062e\u064a\u0631\u064a\u0629"
     ],
+    "name:ast_x_preferred":[
+        "Qanatir el Qahiriya"
+    ],
     "name:azb_x_preferred":[
         "\u0642\u0646\u0627\u0637\u0631 \u062e\u06cc\u0631\u06cc\u0647"
     ],
@@ -51,6 +54,9 @@
     ],
     "name:und_x_variant":[
         "El-Qan\u00e2\u1e6dir el-Khair\u00eeya"
+    ],
+    "name:zul_x_preferred":[
+        "El Qanater El Khayreya"
     ],
     "qs:name":"Al Qan\u0101\u0163ir al Khayr\u012byah",
     "qs:photos_9r":0,
@@ -83,7 +89,7 @@
         }
     ],
     "wof:id":890443435,
-    "wof:lastmodified":1566586576,
+    "wof:lastmodified":1690876064,
     "wof:name":"Al Qan\u0101\u0163ir al Khayr\u012byah",
     "wof:parent_id":1092018935,
     "wof:placetype":"locality",

--- a/data/890/445/293/890445293.geojson
+++ b/data/890/445/293/890445293.geojson
@@ -22,11 +22,20 @@
     "name:ara_x_preferred":[
         "\u0643\u0641\u0631 \u0627\u0644\u062f\u0648\u0627\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0641\u0631 \u0627\u0644\u062f\u0648\u0627\u0631"
+    ],
+    "name:ast_x_preferred":[
+        "Kafr el-Dawwar"
+    ],
     "name:azb_x_preferred":[
         "\u06a9\u0641\u0631 \u0627\u0644\u062f\u0648\u0627\u0631"
     ],
     "name:ceb_x_preferred":[
         "Markaz Kafr ad Daww\u0101r"
+    ],
+    "name:ceb_x_variant":[
+        "Kafr ad Daww\u0101r"
     ],
     "name:deu_x_preferred":[
         "Kafr ad-Dawwar"
@@ -46,11 +55,17 @@
     "name:fra_x_preferred":[
         "Kafr el-Dawwar"
     ],
+    "name:gle_x_preferred":[
+        "Kafr el-Dawwar"
+    ],
     "name:heb_x_preferred":[
         "\u05db\u05e4\u05e8 \u05d0-\u05d3\u05d5\u05d5\u05d0\u05e8"
     ],
     "name:ita_x_preferred":[
         "Kafr el-Dawar"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30ab\u30d5\u30eb\u30fb\u30a8\u30eb\u30fb\u30c0\u30ef\u30fc\u30eb"
     ],
     "name:kat_x_preferred":[
         "\u10e5\u10d0\u10e4\u10e0-\u10d4\u10da-\u10d3\u10d0\u10d5\u10d0\u10e0\u10d8"
@@ -64,8 +79,14 @@
     "name:lit_x_preferred":[
         "Kafr ed Davaras"
     ],
+    "name:mlg_x_preferred":[
+        "Kafr ad Daww\u0101r"
+    ],
     "name:nld_x_preferred":[
         "Kafr el-Dawwar"
+    ],
+    "name:nob_x_preferred":[
+        "Kafr ad-Dawwar"
     ],
     "name:pan_x_preferred":[
         "\u0a15\u0a2b\u0a3c\u0a30 \u0a05\u0a32-\u0a26\u0a41\u0a06\u0a30"
@@ -100,6 +121,9 @@
     "name:zho_x_preferred":[
         "\u9053\u74e6\u723e"
     ],
+    "name:zul_x_preferred":[
+        "Kafr El Dawwar"
+    ],
     "qs:name":"Kafr ad Daww\u0101r",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -131,7 +155,7 @@
         }
     ],
     "wof:id":890445293,
-    "wof:lastmodified":1566586578,
+    "wof:lastmodified":1690876066,
     "wof:name":"Kafr ad Daww\u0101r",
     "wof:parent_id":1092021541,
     "wof:placetype":"locality",

--- a/data/890/450/043/890450043.geojson
+++ b/data/890/450/043/890450043.geojson
@@ -22,6 +22,12 @@
     "name:ara_x_preferred":[
         "\u0634\u0628\u064a\u0646 \u0627\u0644\u0642\u0646\u0627\u0637\u0631"
     ],
+    "name:ast_x_preferred":[
+        "Shibin el-Qanater"
+    ],
+    "name:ceb_x_preferred":[
+        "Shib\u012bn al Qan\u0101\u0163ir"
+    ],
     "name:ell_x_preferred":[
         "\u03a3\u03b9\u03bc\u03c0\u03af\u03bd \u03b5\u03bb \u039a\u03b1\u03bd\u03b1\u03c4\u03af\u03c1"
     ],
@@ -56,8 +62,14 @@
     "name:rus_x_preferred":[
         "\u0428\u0438\u0431\u0438\u043d-\u044d\u043b\u044c-\u041a\u0430\u043d\u0430\u0442\u0438\u0440"
     ],
+    "name:swe_x_preferred":[
+        "Shib\u012bn al Qan\u0101\u0163ir"
+    ],
     "name:und_x_variant":[
         "Shab\u012bn al Qan\u0101tir"
+    ],
+    "name:zul_x_preferred":[
+        "Shibin El Qanater"
     ],
     "qs:name":"Shib\u012bn al Qan\u0101\u0163ir",
     "qs:photos_9r":0,
@@ -90,7 +102,7 @@
         }
     ],
     "wof:id":890450043,
-    "wof:lastmodified":1566586581,
+    "wof:lastmodified":1690876070,
     "wof:name":"Shib\u012bn al Qan\u0101\u0163ir",
     "wof:parent_id":1092024593,
     "wof:placetype":"locality",

--- a/data/890/450/045/890450045.geojson
+++ b/data/890/450/045/890450045.geojson
@@ -43,11 +43,20 @@
     "name:fas_x_preferred":[
         "\u06a9\u0641\u0631 \u0627\u0644\u0632\u06cc\u0627\u062a"
     ],
+    "name:heb_x_preferred":[
+        "\u05db\u05e4\u05e8 \u05d0\u05dc \u05d6\u05d9\u05d0\u05ea"
+    ],
+    "name:ita_x_preferred":[
+        "Kafr El-Zayat"
+    ],
     "name:kaz_x_preferred":[
         "\u041a\u0430\u0444\u0440-\u0430\u0437-\u0417\u0438\u044f\u0442 \u049b\u0430\u043b\u0430\u0441\u044b"
     ],
     "name:lit_x_preferred":[
         "Kafr ez Zejatas"
+    ],
+    "name:mlg_x_preferred":[
+        "Kafr az Zayy\u0101t"
     ],
     "name:nld_x_preferred":[
         "Kafr az-Zayyat"
@@ -95,7 +104,7 @@
         }
     ],
     "wof:id":890450045,
-    "wof:lastmodified":1566586581,
+    "wof:lastmodified":1690876070,
     "wof:name":"Kafr az Zayy\u0101t",
     "wof:parent_id":1092021623,
     "wof:placetype":"locality",

--- a/data/890/450/047/890450047.geojson
+++ b/data/890/450/047/890450047.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0633\u064a\u0648\u0646"
     ],
+    "name:ast_x_preferred":[
+        "Basyoun"
+    ],
     "name:ceb_x_preferred":[
         "Basy\u016bn"
     ],
@@ -43,6 +46,9 @@
     "name:kaz_x_preferred":[
         "\u0411\u0430\u0441\u044c\u044e\u043d \u049b\u0430\u043b\u0430\u0441\u044b"
     ],
+    "name:mlg_x_preferred":[
+        "Basy\u016bn"
+    ],
     "name:nld_x_preferred":[
         "Basyoun"
     ],
@@ -52,11 +58,26 @@
     "name:rus_x_preferred":[
         "\u0411\u0430\u0441\u044c\u044e\u043d"
     ],
+    "name:srp_x_preferred":[
+        "\u0411\u0430\u0441\u0458\u0443\u043d"
+    ],
     "name:swe_x_preferred":[
         "Basy\u016bn"
     ],
+    "name:tha_x_preferred":[
+        "\u0e1a\u0e31\u0e2a\u0e22\u0e39\u0e19"
+    ],
+    "name:tur_x_preferred":[
+        "Basyun"
+    ],
     "name:und_x_variant":[
         "Basy\u00fbn"
+    ],
+    "name:zho_x_preferred":[
+        "\u5df4\u65af\u5c24\u6069"
+    ],
+    "name:zul_x_preferred":[
+        "Basyoun"
     ],
     "qs:name":"Basy\u016bn",
     "qs:photos_9r":0,
@@ -89,7 +110,7 @@
         }
     ],
     "wof:id":890450047,
-    "wof:lastmodified":1566586581,
+    "wof:lastmodified":1690876070,
     "wof:name":"Basy\u016bn",
     "wof:parent_id":1092015375,
     "wof:placetype":"locality",

--- a/data/890/450/049/890450049.geojson
+++ b/data/890/450/049/890450049.geojson
@@ -25,6 +25,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u062a\u0644 \u0627\u0644\u0643\u0628\u064a\u0631"
     ],
+    "name:ast_x_preferred":[
+        "Tall al Kabir"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u0644 \u0627\u0644\u06a9\u0628\u06cc\u0631"
     ],
@@ -34,8 +37,17 @@
     "name:eng_x_preferred":[
         "Tall al Kabir"
     ],
+    "name:epo_x_preferred":[
+        "Tel el-Kebir"
+    ],
     "name:fas_x_preferred":[
         "\u062a\u0644 \u0627\u0644\u06a9\u0628\u06cc\u0631"
+    ],
+    "name:fin_x_preferred":[
+        "Tall al-Kabir"
+    ],
+    "name:fra_x_preferred":[
+        "Tall al Kabir"
     ],
     "name:ita_x_preferred":[
         "Tell al-Kebir"
@@ -45,6 +57,9 @@
     ],
     "name:und_x_variant":[
         "Tell el- Keb\u00eer"
+    ],
+    "name:zul_x_preferred":[
+        "Tell El Kebir"
     ],
     "qs:name":"At Tall al Kab\u012br",
     "qs:photos_9r":0,
@@ -79,7 +94,7 @@
         }
     ],
     "wof:id":890450049,
-    "wof:lastmodified":1566586581,
+    "wof:lastmodified":1690876070,
     "wof:name":"At Tall al Kab\u012br",
     "wof:parent_id":1092020039,
     "wof:placetype":"locality",

--- a/data/890/450/053/890450053.geojson
+++ b/data/890/450/053/890450053.geojson
@@ -22,8 +22,20 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0645\u0637\u0631\u064a\u0629"
     ],
+    "name:ara_x_variant":[
+        "\u0627\u0644\u0645\u0637\u0631\u064a\u0629 Mataria"
+    ],
+    "name:ast_x_preferred":[
+        "Matarieh"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u0645\u0637\u0631\u06cc\u0647"
+    ],
+    "name:ceb_x_preferred":[
+        "Al Ma\u0163ar\u012byah"
+    ],
+    "name:deu_x_preferred":[
+        "Matariyya"
     ],
     "name:ell_x_preferred":[
         "\u039c\u03b1\u03c4\u03b1\u03c1\u03af\u03b3\u03b9\u03b1"
@@ -31,11 +43,20 @@
     "name:eng_x_preferred":[
         "El Matareya"
     ],
+    "name:eng_x_variant":[
+        "Matarieh"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0645\u0637\u0631\u06cc\u0647"
     ],
     "name:fra_x_preferred":[
         "El Matareya"
+    ],
+    "name:fra_x_variant":[
+        "Matar\u00e9e"
+    ],
+    "name:mlg_x_preferred":[
+        "Al Ma\u0163ar\u012byah"
     ],
     "name:nld_x_preferred":[
         "El Matareya"
@@ -63,6 +84,9 @@
     ],
     "name:urd_x_variant":[
         "\u0645\u0637\u0631\u06cc\u06c1"
+    ],
+    "name:zul_x_preferred":[
+        "El Matareya"
     ],
     "qs:name":"Al Ma\u0163ar\u012byah",
     "qs:photos_9r":0,
@@ -95,7 +119,7 @@
         }
     ],
     "wof:id":890450053,
-    "wof:lastmodified":1566586581,
+    "wof:lastmodified":1690876070,
     "wof:name":"Al Ma\u0163ar\u012byah",
     "wof:parent_id":1092018479,
     "wof:placetype":"locality",

--- a/data/890/450/057/890450057.geojson
+++ b/data/890/450/057/890450057.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u062f\u0644\u0646\u062c\u0627\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u062f\u0644\u0646\u062c\u0627\u062a"
+    ],
     "name:eng_x_preferred":[
         "Ad Dilinjat"
     ],
@@ -33,6 +36,9 @@
     ],
     "name:und_x_variant":[
         "El-Diling\u00e2t"
+    ],
+    "name:zul_x_preferred":[
+        "El Delengat"
     ],
     "qs:name":"Ad Dilinj\u0101t",
     "qs:photos_9r":0,
@@ -65,7 +71,7 @@
         }
     ],
     "wof:id":890450057,
-    "wof:lastmodified":1566586582,
+    "wof:lastmodified":1690876071,
     "wof:name":"Ad Dilinj\u0101t",
     "wof:parent_id":1092017317,
     "wof:placetype":"locality",

--- a/data/890/451/953/890451953.geojson
+++ b/data/890/451/953/890451953.geojson
@@ -25,11 +25,20 @@
     "name:arz_x_preferred":[
         "\u0637\u0646\u0637\u0627"
     ],
+    "name:ast_x_preferred":[
+        "Tanta"
+    ],
     "name:azb_x_preferred":[
         "\u0637\u0646\u0637\u0627"
     ],
+    "name:aze_x_preferred":[
+        "T\u0259nta"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0422\u0430\u043d\u0442\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u0422\u0430\u043d\u0442\u0430"
     ],
     "name:ben_x_preferred":[
         "\u099f\u09be\u09a8\u09cd\u099f\u09be"
@@ -58,6 +67,9 @@
     "name:eng_x_preferred":[
         "Tanta"
     ],
+    "name:epo_x_preferred":[
+        "Tanta"
+    ],
     "name:est_x_preferred":[
         "\u0162an\u0163\u0101"
     ],
@@ -78,6 +90,9 @@
     ],
     "name:guj_x_preferred":[
         "\u0aa4\u0a82\u0aa4\u0abe"
+    ],
+    "name:hau_x_preferred":[
+        "Tanta"
     ],
     "name:heb_x_preferred":[
         "\u05d8\u05e0\u05d8\u05d4"
@@ -127,6 +142,9 @@
     "name:mar_x_preferred":[
         "\u0924\u0902\u0924\u093e"
     ],
+    "name:mlg_x_preferred":[
+        "Tanda"
+    ],
     "name:msa_x_preferred":[
         "Tanta"
     ],
@@ -169,6 +187,9 @@
     "name:tel_x_preferred":[
         "\u0c24\u0c02\u0c24\u0c3e"
     ],
+    "name:tgk_x_preferred":[
+        "\u0422\u0430\u043d\u0442\u043e"
+    ],
     "name:tha_x_preferred":[
         "\u0e0f\u0e47\u0e2d\u0e19\u0e0f\u0e2d"
     ],
@@ -184,6 +205,12 @@
     "name:uzb_x_preferred":[
         "Tanta"
     ],
+    "name:uzb_x_variant":[
+        "Tanto"
+    ],
+    "name:vec_x_preferred":[
+        "Tanta"
+    ],
     "name:vie_x_preferred":[
         "Tanta"
     ],
@@ -195,6 +222,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5766\u5854"
+    ],
+    "name:zul_x_preferred":[
+        "Tanta"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Egypt",
@@ -321,7 +351,7 @@
         }
     ],
     "wof:id":890451953,
-    "wof:lastmodified":1566586579,
+    "wof:lastmodified":1690876067,
     "wof:name":"Tanda",
     "wof:parent_id":1092025893,
     "wof:placetype":"locality",

--- a/data/890/451/955/890451955.geojson
+++ b/data/890/451/955/890451955.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0637\u0647\u0637\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0637\u0647\u0637\u0627"
+    ],
     "name:azb_x_preferred":[
         "\u0637\u0647\u0637\u0627"
     ],
@@ -46,6 +49,12 @@
     "name:fra_x_preferred":[
         "Tahta"
     ],
+    "name:heb_x_preferred":[
+        "\u05d8\u05d4\u05d8\u05d0"
+    ],
+    "name:ind_x_preferred":[
+        "Tahta"
+    ],
     "name:jpn_x_preferred":[
         "\u30bf\u30cf\u30bf"
     ],
@@ -55,7 +64,13 @@
     "name:kaz_x_preferred":[
         "\u0422\u0430\u0445\u0442\u0430 \u049b\u0430\u043b\u0430\u0441\u044b"
     ],
+    "name:mlg_x_preferred":[
+        "\u0162ah\u0163\u0101"
+    ],
     "name:nld_x_preferred":[
+        "Tahta"
+    ],
+    "name:nob_x_preferred":[
         "Tahta"
     ],
     "name:pol_x_preferred":[
@@ -67,7 +82,16 @@
     "name:sco_x_preferred":[
         "Tahta"
     ],
+    "name:spa_x_preferred":[
+        "\u1e6cah\u1e6d\u0101"
+    ],
     "name:swe_x_preferred":[
+        "Tahta"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0422\u0430\u04b3\u0442\u043e"
+    ],
+    "name:tur_x_preferred":[
         "Tahta"
     ],
     "name:ukr_x_preferred":[
@@ -75,6 +99,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6cf0\u8d6b\u5854"
+    ],
+    "name:zul_x_preferred":[
+        "Tahta"
     ],
     "qs:name":"\u0162ah\u0163\u0101",
     "qs:photos_9r":0,
@@ -107,7 +134,7 @@
         }
     ],
     "wof:id":890451955,
-    "wof:lastmodified":1566586579,
+    "wof:lastmodified":1690876067,
     "wof:name":"\u0162ah\u0163\u0101",
     "wof:parent_id":1092025101,
     "wof:placetype":"locality",

--- a/data/890/451/957/890451957.geojson
+++ b/data/890/451/957/890451957.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_variant":[
         "\u0634\u0631\u0628\u064a\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0634\u0631\u0628\u064a\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u0634\u0631\u0628\u06cc\u0646"
     ],
@@ -40,6 +43,9 @@
     "name:fas_x_preferred":[
         "\u0634\u0631\u0628\u06cc\u0646"
     ],
+    "name:mlg_x_preferred":[
+        "Shirb\u012bn"
+    ],
     "name:nld_x_preferred":[
         "Sherbin"
     ],
@@ -52,6 +58,9 @@
     "name:swe_x_preferred":[
         "Shirb\u012bn"
     ],
+    "name:tha_x_preferred":[
+        "\u0e0a\u0e31\u0e23\u0e1a\u0e35\u0e19"
+    ],
     "name:ukr_x_preferred":[
         "\u0428\u0438\u0440\u0431\u0456\u043d"
     ],
@@ -60,6 +69,9 @@
     ],
     "name:urd_x_preferred":[
         "\u0634\u0631\u0628\u06cc\u0646"
+    ],
+    "name:zul_x_preferred":[
+        "Sherbin"
     ],
     "qs:name":"Shirb\u00een",
     "qs:photos_9r":0,
@@ -91,7 +103,7 @@
         }
     ],
     "wof:id":890451957,
-    "wof:lastmodified":1566586579,
+    "wof:lastmodified":1690876067,
     "wof:name":"Shirb\u00een",
     "wof:parent_id":1092024759,
     "wof:placetype":"locality",

--- a/data/890/451/959/890451959.geojson
+++ b/data/890/451/959/890451959.geojson
@@ -25,6 +25,9 @@
     "name:arz_x_preferred":[
         "\u0634\u0628\u064a\u0646 \u0627\u0644\u0643\u0648\u0645"
     ],
+    "name:ast_x_preferred":[
+        "Shibin Al Kawm"
+    ],
     "name:azb_x_preferred":[
         "\u0634\u0628\u06cc\u0646 \u0627\u0644\u06a9\u0648\u0645"
     ],
@@ -52,11 +55,23 @@
     "name:fra_x_preferred":[
         "Shibin El Kom"
     ],
+    "name:gle_x_preferred":[
+        "Shibin Al Kawm"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e9\u05d9\u05d1\u05d9\u05df \u05d0\u05dc-\u05db\u05d5\u05dd"
+    ],
+    "name:hun_x_preferred":[
+        "Sib\u00edn-el-K\u00f3m"
+    ],
     "name:ita_x_preferred":[
         "Shibin El Kom"
     ],
     "name:jpn_x_preferred":[
         "\u30b7\u30d3\u30fc\u30f3\u30fb\u30a8\u30eb\uff1d\u30b3\u30fc\u30e0"
+    ],
+    "name:jpn_x_variant":[
+        "\u30b7\u30d3\u30fc\u30f3\u30fb\u30b3\u30fc\u30e0"
     ],
     "name:kat_x_preferred":[
         "\u10e8\u10d8\u10d1\u10d8\u10dc-\u10d4\u10da-\u10e5\u10e3\u10db\u10d8"
@@ -64,8 +79,17 @@
     "name:kor_x_preferred":[
         "\uc2dc\ube48\uc5d8\ucf64"
     ],
+    "name:lit_x_preferred":[
+        "\u0160ibin al Komas"
+    ],
+    "name:mlg_x_preferred":[
+        "Shib\u012bn al Kawm"
+    ],
     "name:nld_x_preferred":[
         "Shibin al Kawm"
+    ],
+    "name:nob_x_preferred":[
+        "Shibin Al Kawm"
     ],
     "name:pol_x_preferred":[
         "Szibin al-Kaum"
@@ -103,11 +127,17 @@
     "name:urd_x_preferred":[
         "\u0634\u0628\u06cc\u0646 \u0627\u0644\u06a9\u0648\u0645"
     ],
+    "name:vec_x_preferred":[
+        "Shibin El Kom"
+    ],
     "name:war_x_preferred":[
         "Shibin el-Kom"
     ],
     "name:zho_x_preferred":[
         "\u5e0c\u8cd3\u5eab\u59c6"
+    ],
+    "name:zul_x_preferred":[
+        "Shibin El Kom"
     ],
     "qs:name":"Shib\u012bn al Kawm",
     "qs:photos_9r":0,
@@ -140,7 +170,7 @@
         }
     ],
     "wof:id":890451959,
-    "wof:lastmodified":1566586579,
+    "wof:lastmodified":1690876068,
     "wof:name":"Shib\u012bn al Kawm",
     "wof:parent_id":1092024543,
     "wof:placetype":"locality",

--- a/data/890/451/961/890451961.geojson
+++ b/data/890/451/961/890451961.geojson
@@ -25,6 +25,9 @@
     "name:arz_x_preferred":[
         "\u0633\u0645\u0646\u0648\u062f"
     ],
+    "name:ast_x_preferred":[
+        "Samannud"
+    ],
     "name:cat_x_preferred":[
         "Sebenitos"
     ],
@@ -40,14 +43,23 @@
     "name:eng_x_preferred":[
         "Sebennytos"
     ],
+    "name:eng_x_variant":[
+        "Samannud"
+    ],
     "name:eus_x_preferred":[
         "Sebennitos"
     ],
     "name:fas_x_preferred":[
         "\u0633\u0645\u0646\u0648\u062f"
     ],
+    "name:fin_x_preferred":[
+        "Samannud"
+    ],
     "name:fra_x_preferred":[
         "Sebennytos"
+    ],
+    "name:grc_x_preferred":[
+        "\u03a3\u03b5\u03b2\u03ad\u03bd\u03bd\u03c5\u03c4\u03bf\u03c2"
     ],
     "name:ind_x_preferred":[
         "Sebennytos"
@@ -88,6 +100,9 @@
     "name:swe_x_preferred":[
         "Samann\u016bd"
     ],
+    "name:tha_x_preferred":[
+        "\u0e0b\u0e30\u0e21\u0e31\u0e19\u0e19\u0e39\u0e14"
+    ],
     "name:ukr_x_preferred":[
         "\u0421\u0435\u0431\u0435\u043d\u043d\u0456\u0442"
     ],
@@ -96,6 +111,9 @@
     ],
     "name:zho_x_preferred":[
         "\u585e\u672c\u5c3c\u6258\u65af"
+    ],
+    "name:zul_x_preferred":[
+        "Samannud"
     ],
     "qs:name":"Samann\u016bd",
     "qs:photos_9r":0,
@@ -128,7 +146,7 @@
         }
     ],
     "wof:id":890451961,
-    "wof:lastmodified":1566586579,
+    "wof:lastmodified":1690876068,
     "wof:name":"Samann\u016bd",
     "wof:parent_id":1092024253,
     "wof:placetype":"locality",

--- a/data/890/451/965/890451965.geojson
+++ b/data/890/451/965/890451965.geojson
@@ -25,6 +25,9 @@
     "name:arz_x_preferred":[
         "\u0642\u0644\u064a\u0648\u0628"
     ],
+    "name:ast_x_preferred":[
+        "Qalyub"
+    ],
     "name:azb_x_preferred":[
         "\u0642\u0644\u06cc\u0648\u0628"
     ],
@@ -33,6 +36,9 @@
     ],
     "name:ceb_x_preferred":[
         "Qaly\u016bb"
+    ],
+    "name:deu_x_preferred":[
+        "Qalyub"
     ],
     "name:ell_x_preferred":[
         "\u039a\u03b1\u03bb\u03b3\u03b9\u03bf\u03cd\u03bc\u03c0"
@@ -43,8 +49,14 @@
     "name:fas_x_preferred":[
         "\u0642\u0644\u06cc\u0648\u0628"
     ],
+    "name:fin_x_preferred":[
+        "Qalyub"
+    ],
     "name:fra_x_preferred":[
         "Kalyoub"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e7\u05dc\u05d9\u05d5\u05d1"
     ],
     "name:jpn_x_preferred":[
         "\u30ab\u30ea\u30e5\u30fc\u30d6"
@@ -55,7 +67,13 @@
     "name:lit_x_preferred":[
         "Kaljubas"
     ],
+    "name:mlg_x_preferred":[
+        "Qaly\u016bb"
+    ],
     "name:nld_x_preferred":[
+        "Qalyub"
+    ],
+    "name:nob_x_preferred":[
         "Qalyub"
     ],
     "name:pol_x_preferred":[
@@ -91,6 +109,9 @@
     "name:zho_x_preferred":[
         "\u84cb\u52d2\u5c24\u535c"
     ],
+    "name:zul_x_preferred":[
+        "Qalyub"
+    ],
     "qs:name":"Qaly\u016bb",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -122,7 +143,7 @@
         }
     ],
     "wof:id":890451965,
-    "wof:lastmodified":1566586579,
+    "wof:lastmodified":1690876067,
     "wof:name":"Qaly\u016bb",
     "wof:parent_id":1092023447,
     "wof:placetype":"locality",

--- a/data/890/451/967/890451967.geojson
+++ b/data/890/451/967/890451967.geojson
@@ -25,6 +25,9 @@
     "name:arz_x_preferred":[
         "\u0646\u0648\u064a\u0628\u0639"
     ],
+    "name:ast_x_preferred":[
+        "Nuweiba"
+    ],
     "name:azb_x_preferred":[
         "\u0646\u0648\u06cc\u0628\u0639"
     ],
@@ -70,11 +73,17 @@
     "name:guj_x_preferred":[
         "\u0aa8\u0ac1\u0ab5\u0ac7\u0a87\u0aac\u0abe"
     ],
+    "name:hau_x_preferred":[
+        "Nuweiba"
+    ],
     "name:heb_x_preferred":[
         "\u05e0\u05d5\u05d0\u05d9\u05d1\u05d4"
     ],
     "name:hin_x_preferred":[
         "\u0928\u0941\u0935\u0947\u0907\u092c\u093e"
+    ],
+    "name:ibo_x_preferred":[
+        "Nuweiba"
     ],
     "name:ind_x_preferred":[
         "Nuweiba"
@@ -123,6 +132,9 @@
     ],
     "name:sin_x_preferred":[
         "\u0db1\u0dd4\u0dc0\u0dd9\u0dba\u0dd2\u0db6\u0dcf"
+    ],
+    "name:spa_x_preferred":[
+        "Nuweiba"
     ],
     "name:swe_x_preferred":[
         "Nuweiba"
@@ -183,7 +195,7 @@
         }
     ],
     "wof:id":890451967,
-    "wof:lastmodified":1566586580,
+    "wof:lastmodified":1690876068,
     "wof:name":"Nuwaybi\u2018a",
     "wof:parent_id":85671089,
     "wof:placetype":"locality",

--- a/data/890/452/817/890452817.geojson
+++ b/data/890/452/817/890452817.geojson
@@ -22,11 +22,17 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0645\u0646\u0632\u0644\u0629"
     ],
+    "name:ast_x_preferred":[
+        "Manzala"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0646\u0632\u0644\u0647"
     ],
     "name:ceb_x_preferred":[
         "Al Manzilah"
+    ],
+    "name:deu_x_preferred":[
+        "El Manzala"
     ],
     "name:eng_x_preferred":[
         "Manzala"
@@ -51,6 +57,9 @@
     ],
     "name:und_x_variant":[
         "El-Manzala"
+    ],
+    "name:zul_x_preferred":[
+        "El Manzala"
     ],
     "qs:name":"Al Manzilah",
     "qs:photos_9r":0,
@@ -83,7 +92,7 @@
         }
     ],
     "wof:id":890452817,
-    "wof:lastmodified":1566586575,
+    "wof:lastmodified":1690876062,
     "wof:name":"Al Manzilah",
     "wof:parent_id":1092018397,
     "wof:placetype":"locality",

--- a/data/890/453/477/890453477.geojson
+++ b/data/890/453/477/890453477.geojson
@@ -28,11 +28,17 @@
     "name:arz_x_preferred":[
         "\u0627\u0628\u0646\u0648\u0628"
     ],
+    "name:ast_x_preferred":[
+        "Abnub"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0628\u200c\u0646\u0627\u0628"
     ],
     "name:ceb_x_preferred":[
         "Abn\u016bb"
+    ],
+    "name:deu_x_preferred":[
+        "Abnub"
     ],
     "name:eng_x_preferred":[
         "Abnub"
@@ -43,7 +49,13 @@
     "name:ita_x_preferred":[
         "Abnub"
     ],
+    "name:mlg_x_preferred":[
+        "Abn\u016bb"
+    ],
     "name:nld_x_preferred":[
+        "Abnub"
+    ],
+    "name:nob_x_preferred":[
         "Abnub"
     ],
     "name:pol_x_preferred":[
@@ -94,7 +106,7 @@
         }
     ],
     "wof:id":890453477,
-    "wof:lastmodified":1566586576,
+    "wof:lastmodified":1690876063,
     "wof:name":"Abn\u016bb",
     "wof:parent_id":1092014043,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.