### PR TITLE
eg concordances, placetype local, and more

### DIFF
--- a/data/109/201/400/5/1092014005.geojson
+++ b/data/109/201/400/5/1092014005.geojson
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.UO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897110,
-    "wof:geomhash":"94b2421c0d25c411f3a4984ea1d271fa",
+    "wof:geomhash":"94e79ce2d9a75c95c834eabb3fc9636f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092014005,
-    "wof:lastmodified":1627522086,
+    "wof:lastmodified":1695886549,
     "wof:name":"10th Ramadan City",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/201/400/7/1092014007.geojson
+++ b/data/109/201/400/7/1092014007.geojson
@@ -82,9 +82,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.FM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897111,
-    "wof:geomhash":"810b705b483d95fc43d13a99e601111c",
+    "wof:geomhash":"c9dca1b156e3bdb6aba6854eb54a0baa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1092014007,
-    "wof:lastmodified":1627522086,
+    "wof:lastmodified":1695886549,
     "wof:name":"15 Mayo",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/400/9/1092014009.geojson
+++ b/data/109/201/400/9/1092014009.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00822,
-    "geom:area_square_m":88052568.67823,
+    "geom:area_square_m":88052568.678225,
     "geom:bbox":"30.824638,29.908207,30.978245,30.021497",
     "geom:latitude":29.965614,
     "geom:longitude":30.899814,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.JZ.SS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897113,
-    "wof:geomhash":"bcee6ac80c1b7779c80854e36eb4eab5",
+    "wof:geomhash":"188f4efb935f46fef8657b91e299a1e8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092014009,
-    "wof:lastmodified":1627522103,
+    "wof:lastmodified":1695886575,
     "wof:name":"6th October City",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/201/401/1/1092014011.geojson
+++ b/data/109/201/401/1/1092014011.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000158,
-    "geom:area_square_m":1686766.424329,
+    "geom:area_square_m":1686766.424328,
     "geom:bbox":"31.235851,30.039453,31.252382,30.053778",
     "geom:latitude":30.045936,
     "geom:longitude":31.244268,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.AB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897114,
-    "wof:geomhash":"8a2fe2ea5ef71abd769897067ea7921c",
+    "wof:geomhash":"5c224b8646f6744a4cf7eb889a4d683b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092014011,
-    "wof:lastmodified":1627522086,
+    "wof:lastmodified":1695886549,
     "wof:name":"Abdeen",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/404/3/1092014043.geojson
+++ b/data/109/201/404/3/1092014043.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01341,
-    "geom:area_square_m":147371846.89308,
+    "geom:area_square_m":147371846.89304,
     "geom:bbox":"30.951597,27.216296,31.20304,27.351488",
     "geom:latitude":27.281233,
     "geom:longitude":31.0897,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.AT.AB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897116,
-    "wof:geomhash":"b66f3d75d52a1b8cff24d48d0a79821a",
+    "wof:geomhash":"f4f711f9e6051e9a846c8358b58a1d3e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092014043,
-    "wof:lastmodified":1627522086,
+    "wof:lastmodified":1695886549,
     "wof:name":"Abnoob",
     "wof:parent_id":85671069,
     "wof:placetype":"county",

--- a/data/109/201/406/1/1092014061.geojson
+++ b/data/109/201/406/1/1092014061.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.13034,
-    "geom:area_square_m":1384343995.015812,
+    "geom:area_square_m":1384343995.015837,
     "geom:bbox":"29.852275,30.535462,30.358066,31.042865",
     "geom:latitude":30.804931,
     "geom:longitude":30.100623,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BH.AM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897117,
-    "wof:geomhash":"c52e4ce5af33fd11f9717bb7cc82999c",
+    "wof:geomhash":"89b2528598811ab0946090331dfc88b0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092014061,
-    "wof:lastmodified":1627522086,
+    "wof:lastmodified":1695886550,
     "wof:name":"Abu El-Matameer",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/201/410/3/1092014103.geojson
+++ b/data/109/201/410/3/1092014103.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025112,
-    "geom:area_square_m":267459778.922535,
+    "geom:area_square_m":267459778.922544,
     "geom:bbox":"31.577623,30.440271,31.824311,30.659986",
     "geom:latitude":30.533564,
     "geom:longitude":31.689563,
@@ -77,9 +77,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SQ.AH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897120,
-    "wof:geomhash":"589b7599c8ff0f82710f98e69e09dff9",
+    "wof:geomhash":"c92ed49794bae7ff3c06e4be2eecd6f6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1092014103,
-    "wof:lastmodified":1627522086,
+    "wof:lastmodified":1695886550,
     "wof:name":"Abu Hammad",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/201/413/3/1092014133.geojson
+++ b/data/109/201/413/3/1092014133.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050763,
-    "geom:area_square_m":537443281.825305,
+    "geom:area_square_m":537443281.825266,
     "geom:bbox":"30.141745,30.951081,30.510316,31.241753",
     "geom:latitude":31.106127,
     "geom:longitude":30.310873,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BH.AH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897121,
-    "wof:geomhash":"61c09ae64c2815dd620bdb29d290f6ee",
+    "wof:geomhash":"5d91410032295ee3aacff5b6306500bf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092014133,
-    "wof:lastmodified":1627522086,
+    "wof:lastmodified":1695886550,
     "wof:name":"Abu Homos",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/201/417/5/1092014175.geojson
+++ b/data/109/201/417/5/1092014175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018189,
-    "geom:area_square_m":193315103.110928,
+    "geom:area_square_m":193315103.11089,
     "geom:bbox":"31.601383,30.644368,31.792277,30.836936",
     "geom:latitude":30.736363,
     "geom:longitude":31.701558,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SQ.AK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897123,
-    "wof:geomhash":"0babfdc1d351b7e6ff1400ddd0930d86",
+    "wof:geomhash":"8848550a055f206c7727983a515e81f4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092014175,
-    "wof:lastmodified":1627522086,
+    "wof:lastmodified":1695886550,
     "wof:name":"Abu Kebeer",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/201/422/1/1092014221.geojson
+++ b/data/109/201/422/1/1092014221.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025716,
-    "geom:area_square_m":280943019.684731,
+    "geom:area_square_m":280943019.684686,
     "geom:bbox":"30.661833,27.83219,30.864957,28.023471",
     "geom:latitude":27.929599,
     "geom:longitude":30.769992,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MN.AK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897124,
-    "wof:geomhash":"9e6f6b716a515ad02c1484e81dcf5a91",
+    "wof:geomhash":"2020ac88309eb1d7dc1d1cb3f150d3f1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092014221,
-    "wof:lastmodified":1627522086,
+    "wof:lastmodified":1695886550,
     "wof:name":"Abu Qorqas",
     "wof:parent_id":85671049,
     "wof:placetype":"county",

--- a/data/109/201/426/7/1092014267.geojson
+++ b/data/109/201/426/7/1092014267.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.281228,
-    "geom:area_square_m":3049014126.777338,
+    "geom:area_square_m":3049014126.777306,
     "geom:bbox":"33.166574,28.454787,33.786318,28.995031",
     "geom:latitude":28.740967,
     "geom:longitude":33.489884,
@@ -82,9 +82,10 @@
     "wof:concordances":{
         "hasc:id":"EG.JS.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897126,
-    "wof:geomhash":"9240cf5a6811f6ef90406e9af51a1626",
+    "wof:geomhash":"de376010ae11d6d41f3c16e333d3bc4e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1092014267,
-    "wof:lastmodified":1627522086,
+    "wof:lastmodified":1695886550,
     "wof:name":"Abu Redeis",
     "wof:parent_id":85671089,
     "wof:placetype":"county",

--- a/data/109/201/431/3/1092014313.geojson
+++ b/data/109/201/431/3/1092014313.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011828,
-    "geom:area_square_m":130282769.338387,
+    "geom:area_square_m":130282769.338385,
     "geom:bbox":"31.219824,26.940401,31.358801,27.110361",
     "geom:latitude":27.025213,
     "geom:longitude":31.280538,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.AT.AT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897127,
-    "wof:geomhash":"ff704e90a58777d48d031578165fd52e",
+    "wof:geomhash":"ed20e9943d20555a7ffa1174e592cce9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092014313,
-    "wof:lastmodified":1627522086,
+    "wof:lastmodified":1695886550,
     "wof:name":"Abu Teeg",
     "wof:parent_id":85671069,
     "wof:placetype":"county",

--- a/data/109/201/435/7/1092014357.geojson
+++ b/data/109/201/435/7/1092014357.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017433,
-    "geom:area_square_m":193529566.799504,
+    "geom:area_square_m":193529566.79952,
     "geom:bbox":"31.982322,26.036464,32.183869,26.196891",
     "geom:latitude":26.128177,
     "geom:longitude":32.084324,
@@ -92,9 +92,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QN.AT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897129,
-    "wof:geomhash":"30c4e8c0da273966d883cec70d3ebdb7",
+    "wof:geomhash":"a9ad1c1d8872e96d6c05f1972f1d832c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1092014357,
-    "wof:lastmodified":1627522086,
+    "wof:lastmodified":1695886550,
     "wof:name":"Abu Tesht",
     "wof:parent_id":85671075,
     "wof:placetype":"county",

--- a/data/109/201/440/3/1092014403.geojson
+++ b/data/109/201/440/3/1092014403.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.300166,
-    "geom:area_square_m":3240098875.302201,
+    "geom:area_square_m":3240098875.30218,
     "geom:bbox":"32.814547,28.951589,33.782235,29.395746",
     "geom:latitude":29.194804,
     "geom:longitude":33.34349,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"EG.JS.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897130,
-    "wof:geomhash":"17ba4facc11838f355685959eb1d658e",
+    "wof:geomhash":"faf0b86660048a091235e89d009eb789",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092014403,
-    "wof:lastmodified":1627522086,
+    "wof:lastmodified":1695886551,
     "wof:name":"Abu Zeneimah",
     "wof:parent_id":85671089,
     "wof:placetype":"county",

--- a/data/109/201/443/9/1092014439.geojson
+++ b/data/109/201/443/9/1092014439.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022991,
-    "geom:area_square_m":243942621.371596,
+    "geom:area_square_m":243942621.371571,
     "geom:bbox":"31.224174,30.791434,31.401714,31.004997",
     "geom:latitude":30.898516,
     "geom:longitude":31.311788,
@@ -140,9 +140,10 @@
     "wof:concordances":{
         "hasc:id":"EG.DQ.AG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897132,
-    "wof:geomhash":"088af5196e9a224da713210a14c1e132",
+    "wof:geomhash":"7853d38cfe6754b97420e06c79312149",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":1092014439,
-    "wof:lastmodified":1602720860,
+    "wof:lastmodified":1695886294,
     "wof:name":"Aga",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/201/448/1/1092014481.geojson
+++ b/data/109/201/448/1/1092014481.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019042,
-    "geom:area_square_m":205760608.421129,
+    "geom:area_square_m":205760608.421113,
     "geom:bbox":"30.863125,28.99184,31.016144,29.19975",
     "geom:latitude":29.088008,
     "geom:longitude":30.936695,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BN.AH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897133,
-    "wof:geomhash":"c6669a300c2128aea56ab4e7e19239a0",
+    "wof:geomhash":"7965712f655aa73921bfe8add07728d9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092014481,
-    "wof:lastmodified":1627522087,
+    "wof:lastmodified":1695886551,
     "wof:name":"Ahnasya",
     "wof:parent_id":85671053,
     "wof:placetype":"county",

--- a/data/109/201/452/7/1092014527.geojson
+++ b/data/109/201/452/7/1092014527.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000863,
-    "geom:area_square_m":9227112.584997,
+    "geom:area_square_m":9227112.584999,
     "geom:bbox":"31.3138,30.107738,31.36845,30.143512",
     "geom:latitude":30.128233,
     "geom:longitude":31.337587,
@@ -127,9 +127,10 @@
         "hasc:id":"EG.QH.ES",
         "wd:id":"Q2662725"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897135,
-    "wof:geomhash":"5c4a1f7b452b71f12c5e910afc718e85",
+    "wof:geomhash":"c3cfdc14ba9334f894ed0dfe4de8908b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":1092014527,
-    "wof:lastmodified":1690876045,
+    "wof:lastmodified":1695886294,
     "wof:name":"Ain Shams",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/455/7/1092014557.geojson
+++ b/data/109/201/455/7/1092014557.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008317,
-    "geom:area_square_m":91983270.854329,
+    "geom:area_square_m":91983270.854324,
     "geom:bbox":"31.698088,26.420956,31.82797,26.663505",
     "geom:latitude":26.570908,
     "geom:longitude":31.752702,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SJ.AK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897136,
-    "wof:geomhash":"7756e937afbceb68dbc54cb32e6dc8c5",
+    "wof:geomhash":"52b27b0b74cd26f6620063f6388232f3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092014557,
-    "wof:lastmodified":1627522087,
+    "wof:lastmodified":1695886551,
     "wof:name":"Akhmeem",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/201/457/3/1092014573.geojson
+++ b/data/109/201/457/3/1092014573.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010589,
-    "geom:area_square_m":118050958.82186,
+    "geom:area_square_m":118050958.821882,
     "geom:bbox":"32.434914,25.526976,32.590052,25.686952",
     "geom:latitude":25.625841,
     "geom:longitude":32.503418,
@@ -77,9 +77,10 @@
     "wof:concordances":{
         "hasc:id":"EG.UQ.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897138,
-    "wof:geomhash":"37a7a0a8ed59fd4daba344862fc0bf97",
+    "wof:geomhash":"add3927223a47bb46592dce4fd0ec1f4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1092014573,
-    "wof:lastmodified":1627522089,
+    "wof:lastmodified":1695886555,
     "wof:name":"Armant",
     "wof:parent_id":85671075,
     "wof:placetype":"county",

--- a/data/109/201/462/1/1092014621.geojson
+++ b/data/109/201/462/1/1092014621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028903,
-    "geom:area_square_m":308561274.015816,
+    "geom:area_square_m":308561274.015833,
     "geom:bbox":"30.820313,30.199385,31.115134,30.397067",
     "geom:latitude":30.302495,
     "geom:longitude":30.993887,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MF.AS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897139,
-    "wof:geomhash":"105499fbbea16b838dc82c6be5f1d85f",
+    "wof:geomhash":"e1ef460931929a7b8d47e9d2f6faec75",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092014621,
-    "wof:lastmodified":1627522089,
+    "wof:lastmodified":1695886555,
     "wof:name":"Ashmoon",
     "wof:parent_id":85670995,
     "wof:placetype":"county",

--- a/data/109/201/463/3/1092014633.geojson
+++ b/data/109/201/463/3/1092014633.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017571,
-    "geom:area_square_m":193324737.382567,
+    "geom:area_square_m":193324737.382591,
     "geom:bbox":"31.006465,27.044538,31.297989,27.257912",
     "geom:latitude":27.154458,
     "geom:longitude":31.156959,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.AT.AY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897140,
-    "wof:geomhash":"6b6bfb51f2862d812092fd2b4f730f89",
+    "wof:geomhash":"289edbac539ec7e03af4a716cc7ee935",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092014633,
-    "wof:lastmodified":1627522089,
+    "wof:lastmodified":1695886555,
     "wof:name":"Asiut",
     "wof:parent_id":85671069,
     "wof:placetype":"county",

--- a/data/109/201/463/5/1092014635.geojson
+++ b/data/109/201/463/5/1092014635.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013951,
-    "geom:area_square_m":157551566.463867,
+    "geom:area_square_m":157551566.463917,
     "geom:bbox":"31.592071,22.365587,32.919603,24.335218",
     "geom:latitude":24.029509,
     "geom:longitude":32.827799,
@@ -275,9 +275,10 @@
     "wof:concordances":{
         "hasc:id":"EG.AN.AM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897142,
-    "wof:geomhash":"24e7031b584252fbc9b6ad4d620df060",
+    "wof:geomhash":"c06c0207407b0221e436f4ed2527e696",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -287,7 +288,7 @@
         }
     ],
     "wof:id":1092014635,
-    "wof:lastmodified":1636502266,
+    "wof:lastmodified":1695886054,
     "wof:name":"Aswan",
     "wof:parent_id":85671061,
     "wof:placetype":"county",

--- a/data/109/201/463/7/1092014637.geojson
+++ b/data/109/201/463/7/1092014637.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007009,
-    "geom:area_square_m":75200373.786096,
+    "geom:area_square_m":75200373.786084,
     "geom:bbox":"32.206353,29.256515,32.579174,30.091342",
     "geom:latitude":29.805891,
     "geom:longitude":32.43323,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SW.AT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897143,
-    "wof:geomhash":"2184015d7bfb1bff03a30a9e83666333",
+    "wof:geomhash":"b0aaeca8dfde7204fc9c320ff62a6688",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092014637,
-    "wof:lastmodified":1627522089,
+    "wof:lastmodified":1695886555,
     "wof:name":"Ataqah",
     "wof:parent_id":85671013,
     "wof:placetype":"county",

--- a/data/109/201/465/3/1092014653.geojson
+++ b/data/109/201/465/3/1092014653.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012302,
-    "geom:area_square_m":132558177.223621,
+    "geom:area_square_m":132558177.223673,
     "geom:bbox":"31.196991,29.192731,31.297943,29.488074",
     "geom:latitude":29.371349,
     "geom:longitude":31.245467,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.JZ.AT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897145,
-    "wof:geomhash":"748bfefb87551c16c8774ed7d7651c56",
+    "wof:geomhash":"656495d8dc9575d85f2cdda7ba9f1c96",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092014653,
-    "wof:lastmodified":1627522089,
+    "wof:lastmodified":1695886555,
     "wof:name":"Atfeeh",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/201/468/3/1092014683.geojson
+++ b/data/109/201/468/3/1092014683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042167,
-    "geom:area_square_m":455232363.833659,
+    "geom:area_square_m":455232363.833647,
     "geom:bbox":"30.54552,29.089022,30.861363,29.307776",
     "geom:latitude":29.181336,
     "geom:longitude":30.71936,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.FY.AT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897146,
-    "wof:geomhash":"a07234dd827c0b4b22f658ea0e7455c0",
+    "wof:geomhash":"fd6e77146c2de8914886dd02281a13aa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092014683,
-    "wof:lastmodified":1627522089,
+    "wof:lastmodified":1695886555,
     "wof:name":"Atsa",
     "wof:parent_id":85671037,
     "wof:placetype":"county",

--- a/data/109/201/472/7/1092014727.geojson
+++ b/data/109/201/472/7/1092014727.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001134,
-    "geom:area_square_m":12124839.467531,
+    "geom:area_square_m":12124839.467523,
     "geom:bbox":"31.226828,30.102809,31.268111,30.158986",
     "geom:latitude":30.127714,
     "geom:longitude":31.249974,
@@ -82,12 +82,13 @@
     "wof:concordances":{
         "hasc:id":"EG.QL.SF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897148,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"e1d7ff50a6352b1fd315f141acdede30",
+    "wof:geomhash":"7f40b0f2cfe9f79eda603222ce124890",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1092014727,
-    "wof:lastmodified":1627522102,
+    "wof:lastmodified":1695886574,
     "wof:name":"Awal Shobra El-Kheimah",
     "wof:parent_id":85671003,
     "wof:placetype":"county",

--- a/data/109/201/477/3/1092014773.geojson
+++ b/data/109/201/477/3/1092014773.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001368,
-    "geom:area_square_m":15048285.233279,
+    "geom:area_square_m":15048285.233283,
     "geom:bbox":"31.121035,27.151167,31.173415,27.204298",
     "geom:latitude":27.181795,
     "geom:longitude":31.148069,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.AT.AF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897149,
-    "wof:geomhash":"ed4e68f77081e3c20a2235613009f598",
+    "wof:geomhash":"eb22eb171bfc5bdf01bcbc23f866e167",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092014773,
-    "wof:lastmodified":1627522089,
+    "wof:lastmodified":1695886556,
     "wof:name":"Awel Asiut",
     "wof:parent_id":85671069,
     "wof:placetype":"county",

--- a/data/109/201/481/5/1092014815.geojson
+++ b/data/109/201/481/5/1092014815.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018989,
-    "geom:area_square_m":201230282.292882,
+    "geom:area_square_m":201230282.292869,
     "geom:bbox":"33.497004,30.909379,33.604518,31.125436",
     "geom:latitude":31.015848,
     "geom:longitude":33.550796,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SS.FO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897150,
-    "wof:geomhash":"60c87f90dd257ed527a42afe37afd389",
+    "wof:geomhash":"61dab5b5094e9b89e8e62e33c2aa55fc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092014815,
-    "wof:lastmodified":1627522094,
+    "wof:lastmodified":1695886564,
     "wof:name":"Awel El-Areesh",
     "wof:parent_id":85671093,
     "wof:placetype":"county",

--- a/data/109/201/484/5/1092014845.geojson
+++ b/data/109/201/484/5/1092014845.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001531,
-    "geom:area_square_m":16299594.801874,
+    "geom:area_square_m":16299594.801872,
     "geom:bbox":"32.222623,30.573915,32.329128,30.640922",
     "geom:latitude":30.596605,
     "geom:longitude":32.280793,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IS.IF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897152,
-    "wof:geomhash":"d4942dfc83b9bb20c014c22d35bb1303",
+    "wof:geomhash":"e17c56c303cd2b1bd5619a509ce999dd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092014845,
-    "wof:lastmodified":1627522087,
+    "wof:lastmodified":1695886551,
     "wof:name":"Awel El-Esmailiah",
     "wof:parent_id":85670989,
     "wof:placetype":"county",

--- a/data/109/201/489/1/1092014891.geojson
+++ b/data/109/201/489/1/1092014891.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001027,
-    "geom:area_square_m":10890137.524954,
+    "geom:area_square_m":10890137.524951,
     "geom:bbox":"31.128885,30.941001,31.186509,30.974376",
     "geom:latitude":30.95985,
     "geom:longitude":31.160757,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.GH.MS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897153,
-    "wof:geomhash":"6c03ae3d6a5267cbe9988a6cb44126d3",
+    "wof:geomhash":"9be2cc832298a89d437a213c69ad5f50",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092014891,
-    "wof:lastmodified":1627522095,
+    "wof:lastmodified":1695886565,
     "wof:name":"Awel El-Mahallah El-Kobra",
     "wof:parent_id":85670985,
     "wof:placetype":"county",

--- a/data/109/201/493/5/1092014935.geojson
+++ b/data/109/201/493/5/1092014935.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000907,
-    "geom:area_square_m":9602227.019259,
+    "geom:area_square_m":9602227.01926,
     "geom:bbox":"31.397681,31.052116,31.442768,31.087299",
     "geom:latitude":31.068148,
     "geom:longitude":31.423514,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.DQ.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897155,
-    "wof:geomhash":"6ce256002ee4a7c47b637d0b05cdfe6d",
+    "wof:geomhash":"f26d36fd012e0547c3f0adc1f525d240",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092014935,
-    "wof:lastmodified":1627522088,
+    "wof:lastmodified":1695886552,
     "wof:name":"Awel El-Mansourah",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/201/497/1/1092014971.geojson
+++ b/data/109/201/497/1/1092014971.geojson
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SQ.ZF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897156,
-    "wof:geomhash":"7e47a707331645f1f7aa734ad6ae94b7",
+    "wof:geomhash":"4b8314ffdac5914900a8dfd1862e5bbb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092014971,
-    "wof:lastmodified":1627522103,
+    "wof:lastmodified":1695886575,
     "wof:name":"Awel El-Zaqazeeq",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/201/501/3/1092015013.geojson
+++ b/data/109/201/501/3/1092015013.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000642,
-    "geom:area_square_m":7102826.98206,
+    "geom:area_square_m":7102826.982057,
     "geom:bbox":"31.678201,26.527428,31.710249,26.560552",
     "geom:latitude":26.543732,
     "geom:longitude":31.691322,
@@ -82,9 +82,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SJ.SF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897158,
-    "wof:geomhash":"08d9cbe05cf5eb3dc87d8e2d7cf161f3",
+    "wof:geomhash":"5ad07553e15ab545a94f12dd31852cc5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1092015013,
-    "wof:lastmodified":1627522103,
+    "wof:lastmodified":1695886575,
     "wof:name":"Awel Sohag",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/201/505/7/1092015057.geojson
+++ b/data/109/201/505/7/1092015057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001108,
-    "geom:area_square_m":11767112.048872,
+    "geom:area_square_m":11767112.048871,
     "geom:bbox":"30.97252,30.787327,31.029047,30.822535",
     "geom:latitude":30.802032,
     "geom:longitude":31.002561,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.GH.TF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897159,
-    "wof:geomhash":"9054317add384d9f0ecd5d79a6aac2cd",
+    "wof:geomhash":"05cee51b45b37198ba99ca05a4962ef9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092015057,
-    "wof:lastmodified":1627522103,
+    "wof:lastmodified":1695886576,
     "wof:name":"Awel Tanta",
     "wof:parent_id":85670985,
     "wof:placetype":"county",

--- a/data/109/201/510/5/1092015105.geojson
+++ b/data/109/201/510/5/1092015105.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029575,
-    "geom:area_square_m":313537607.868572,
+    "geom:area_square_m":313537607.868541,
     "geom:bbox":"31.671171,30.871595,31.891513,31.086449",
     "geom:latitude":30.977627,
     "geom:longitude":31.786194,
@@ -77,9 +77,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SQ.AS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897160,
-    "wof:geomhash":"0873e2f2d920ead75e21bec850212df1",
+    "wof:geomhash":"fca95662d544848058f0e0ba594efab2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1092015105,
-    "wof:lastmodified":1627522089,
+    "wof:lastmodified":1695886556,
     "wof:name":"Awlad Saqr",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/201/514/3/1092015143.geojson
+++ b/data/109/201/514/3/1092015143.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000099,
-    "geom:area_square_m":1063573.521754,
+    "geom:area_square_m":1063573.521753,
     "geom:bbox":"31.249253,30.054685,31.267988,30.063953",
     "geom:latitude":30.059705,
     "geom:longitude":31.259136,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.BE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897162,
-    "wof:geomhash":"0938a7ec5d85ef768a1bf35962b59914",
+    "wof:geomhash":"22a2a1b40effe2d2df13a1bbc73dad89",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092015143,
-    "wof:lastmodified":1627522089,
+    "wof:lastmodified":1695886556,
     "wof:name":"Bab El-Sha'reyah",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/518/3/1092015183.geojson
+++ b/data/109/201/518/3/1092015183.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000724,
-    "geom:area_square_m":7653366.29267,
+    "geom:area_square_m":7653366.292669,
     "geom:bbox":"29.900282,31.179786,29.937981,31.215455",
     "geom:latitude":31.197271,
     "geom:longitude":29.918233,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897164,
-    "wof:geomhash":"c78300f7d731169c33368236e4c0fc34",
+    "wof:geomhash":"21e2a5d6d946170864a58ba3477b37e3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092015183,
-    "wof:lastmodified":1627522089,
+    "wof:lastmodified":1695886556,
     "wof:name":"Bab Sharqy",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/201/522/9/1092015229.geojson
+++ b/data/109/201/522/9/1092015229.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00127,
-    "geom:area_square_m":13580188.559239,
+    "geom:area_square_m":13580188.559242,
     "geom:bbox":"31.717169,30.109951,31.75018,30.153212",
     "geom:latitude":30.132249,
     "geom:longitude":31.733954,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BH.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897165,
-    "wof:geomhash":"5b77f4cd5703307b0f65578b136f4d1c",
+    "wof:geomhash":"6daefa14f5c72bd512408829f9789e2c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092015229,
-    "wof:lastmodified":1627522089,
+    "wof:lastmodified":1695886556,
     "wof:name":"Badr City",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/525/3/1092015253.geojson
+++ b/data/109/201/525/3/1092015253.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01714,
-    "geom:area_square_m":182705025.04281,
+    "geom:area_square_m":182705025.042857,
     "geom:bbox":"31.094429,30.368985,31.310865,30.536084",
     "geom:latitude":30.449201,
     "geom:longitude":31.20466,
@@ -164,9 +164,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QL.BM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897167,
-    "wof:geomhash":"88f98625ecbfd3b1b94a9a6205988813",
+    "wof:geomhash":"b2382596762faf6d86cdd6811a55ce53",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -176,7 +177,7 @@
         }
     ],
     "wof:id":1092015253,
-    "wof:lastmodified":1602720861,
+    "wof:lastmodified":1695886295,
     "wof:name":"Banha",
     "wof:parent_id":85671003,
     "wof:placetype":"county",

--- a/data/109/201/529/5/1092015295.geojson
+++ b/data/109/201/529/5/1092015295.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026743,
-    "geom:area_square_m":290596751.830006,
+    "geom:area_square_m":290596751.830083,
     "geom:bbox":"30.62761,28.418569,30.873455,28.593324",
     "geom:latitude":28.5052,
     "geom:longitude":30.751507,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MN.BM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897168,
-    "wof:geomhash":"29ac5cd39f2678a5b64ab06e9f2c12ad",
+    "wof:geomhash":"aa65363b688ad7a09ae4efe3b6c39384",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092015295,
-    "wof:lastmodified":1627522090,
+    "wof:lastmodified":1695886557,
     "wof:name":"Bany Mazar",
     "wof:parent_id":85671049,
     "wof:placetype":"county",

--- a/data/109/201/534/1/1092015341.geojson
+++ b/data/109/201/534/1/1092015341.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019505,
-    "geom:area_square_m":210772798.931336,
+    "geom:area_square_m":210772798.931363,
     "geom:bbox":"30.971002,29.008574,31.205971,29.175283",
     "geom:latitude":29.083635,
     "geom:longitude":31.07332,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BN.BM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897170,
-    "wof:geomhash":"73e961e8e8a5ba83283b303be9f83f06",
+    "wof:geomhash":"2fe772c3ef77932e47f6e9e27ca43a00",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092015341,
-    "wof:lastmodified":1627522090,
+    "wof:lastmodified":1695886557,
     "wof:name":"Bany Sweif",
     "wof:parent_id":85671053,
     "wof:placetype":"county",

--- a/data/109/201/537/5/1092015375.geojson
+++ b/data/109/201/537/5/1092015375.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015943,
-    "geom:area_square_m":169064761.217194,
+    "geom:area_square_m":169064761.217163,
     "geom:bbox":"30.742124,30.872856,30.927952,31.040943",
     "geom:latitude":30.954593,
     "geom:longitude":30.829974,
@@ -101,9 +101,10 @@
     "wof:concordances":{
         "hasc:id":"EG.GH.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897171,
-    "wof:geomhash":"575a182a478f9b5af0453318ee77f9cf",
+    "wof:geomhash":"9ef178897cdc5194de932c5ae0a52b8a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092015375,
-    "wof:lastmodified":1602720861,
+    "wof:lastmodified":1695886295,
     "wof:name":"Basyoun",
     "wof:parent_id":85670985,
     "wof:placetype":"county",

--- a/data/109/201/541/5/1092015415.geojson
+++ b/data/109/201/541/5/1092015415.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01786,
-    "geom:area_square_m":193248467.710559,
+    "geom:area_square_m":193248467.710613,
     "geom:bbox":"30.862721,28.849639,31.064372,29.037111",
     "geom:latitude":28.949885,
     "geom:longitude":30.963044,
@@ -95,9 +95,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BN.BE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897172,
-    "wof:geomhash":"7fed350bfe74c1829ce6961cc2e53f0a",
+    "wof:geomhash":"6d22dd6d1b8b6d7e667f8e95db8edac2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1092015415,
-    "wof:lastmodified":1602720861,
+    "wof:lastmodified":1695886295,
     "wof:name":"Beba",
     "wof:parent_id":85671053,
     "wof:placetype":"county",

--- a/data/109/201/546/3/1092015463.geojson
+++ b/data/109/201/546/3/1092015463.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035678,
-    "geom:area_square_m":377061236.40537,
+    "geom:area_square_m":377061236.405389,
     "geom:bbox":"31.06378,31.140497,31.291521,31.502717",
     "geom:latitude":31.274618,
     "geom:longitude":31.20423,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"EG.KS.BE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897174,
-    "wof:geomhash":"19b6a7a24c2438ffff1cb7b1c533057e",
+    "wof:geomhash":"6ff40b67086489ba34368798a2f5c016",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1092015463,
-    "wof:lastmodified":1627522090,
+    "wof:lastmodified":1695886557,
     "wof:name":"Beela",
     "wof:parent_id":85671057,
     "wof:placetype":"county",

--- a/data/109/201/552/1/1092015521.geojson
+++ b/data/109/201/552/1/1092015521.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.26065,
-    "geom:area_square_m":2764915375.479815,
+    "geom:area_square_m":2764915375.47977,
     "geom:bbox":"32.674065,30.633543,33.514068,31.215616",
     "geom:latitude":30.930647,
     "geom:longitude":33.090041,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SS.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897176,
-    "wof:geomhash":"efbf80f6846c41e9f7d34e872995cdbf",
+    "wof:geomhash":"8019e3ba8166c1be4bdeace65a75dddc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092015521,
-    "wof:lastmodified":1627522090,
+    "wof:lastmodified":1695886557,
     "wof:name":"Beer El-Abd",
     "wof:parent_id":85671093,
     "wof:placetype":"county",

--- a/data/109/201/556/9/1092015569.geojson
+++ b/data/109/201/556/9/1092015569.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032443,
-    "geom:area_square_m":345954518.237397,
+    "geom:area_square_m":345954518.237392,
     "geom:bbox":"31.393174,30.311097,31.672745,30.515478",
     "geom:latitude":30.414979,
     "geom:longitude":31.534847,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SQ.BE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897178,
-    "wof:geomhash":"3944342423861cb74d28ca69e9a8d57c",
+    "wof:geomhash":"0f1a70cc50af1811be2de198b7548b3a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092015569,
-    "wof:lastmodified":1627522090,
+    "wof:lastmodified":1695886557,
     "wof:name":"Belbeis",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/201/561/1/1092015611.geojson
+++ b/data/109/201/561/1/1092015611.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062518,
-    "geom:area_square_m":660183258.950756,
+    "geom:area_square_m":660183258.950813,
     "geom:bbox":"31.256089,31.183407,31.563491,31.515551",
     "geom:latitude":31.350063,
     "geom:longitude":31.386203,
@@ -104,9 +104,10 @@
     "wof:concordances":{
         "hasc:id":"EG.DQ.BL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897179,
-    "wof:geomhash":"109d08d0cafdffd7de15f7b05271665b",
+    "wof:geomhash":"d5833e64bf158e6653795cb329f7f006",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092015611,
-    "wof:lastmodified":1627522090,
+    "wof:lastmodified":1695886557,
     "wof:name":"Belqas",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/201/565/3/1092015653.geojson
+++ b/data/109/201/565/3/1092015653.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011368,
-    "geom:area_square_m":120933003.112208,
+    "geom:area_square_m":120933003.112246,
     "geom:bbox":"31.013638,30.585183,31.199029,30.71654",
     "geom:latitude":30.64787,
     "geom:longitude":31.089353,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MF.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897181,
-    "wof:geomhash":"ddf4751bb1d7a4e5fd9073442d92698a",
+    "wof:geomhash":"c7abdd39d05faa3af3143168b52fac17",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092015653,
-    "wof:lastmodified":1627522090,
+    "wof:lastmodified":1695886558,
     "wof:name":"Berket El-Sab'",
     "wof:parent_id":85670995,
     "wof:placetype":"county",

--- a/data/109/201/569/5/1092015695.geojson
+++ b/data/109/201/569/5/1092015695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.142769,
-    "geom:area_square_m":1517996857.921212,
+    "geom:area_square_m":1517996857.921226,
     "geom:bbox":"29.438486,30.26259,29.984468,30.986103",
     "geom:latitude":30.701775,
     "geom:longitude":29.751977,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.UO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897182,
-    "wof:geomhash":"586b7dbce90722509b130335c8fed3f0",
+    "wof:geomhash":"dbc77ce85e704e829654e7f0b1512651",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092015695,
-    "wof:lastmodified":1627522090,
+    "wof:lastmodified":1695886558,
     "wof:name":"Borg El-Arab City",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/201/573/9/1092015739.geojson
+++ b/data/109/201/573/9/1092015739.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045937,
-    "geom:area_square_m":487439109.566902,
+    "geom:area_square_m":487439109.566896,
     "geom:bbox":"29.356734,30.74717,29.720388,31.05528",
     "geom:latitude":30.893316,
     "geom:longitude":29.536286,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897184,
-    "wof:geomhash":"7d669d90f8ba72fd5fd4614b6f7607b6",
+    "wof:geomhash":"c8841719e45807ce0043a5f319742e7c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092015739,
-    "wof:lastmodified":1627522090,
+    "wof:lastmodified":1695886558,
     "wof:name":"Borg El-Arab",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/201/578/7/1092015787.geojson
+++ b/data/109/201/578/7/1092015787.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000868,
-    "geom:area_square_m":9288189.872999,
+    "geom:area_square_m":9288189.872996,
     "geom:bbox":"31.172781,30.006161,31.205608,30.052822",
     "geom:latitude":30.027488,
     "geom:longitude":31.187715,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.JZ.BD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897185,
-    "wof:geomhash":"3e8af4bcb746fd08e8e74551318fb64e",
+    "wof:geomhash":"0f1bd5e9cc2dd3911bf9116519cda644",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092015787,
-    "wof:lastmodified":1627522090,
+    "wof:lastmodified":1695886558,
     "wof:name":"Boulaq El-Dakroor",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/201/583/9/1092015839.geojson
+++ b/data/109/201/583/9/1092015839.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000276,
-    "geom:area_square_m":2950592.584288,
+    "geom:area_square_m":2950592.58429,
     "geom:bbox":"31.22491,30.049746,31.24337,30.076299",
     "geom:latitude":30.062133,
     "geom:longitude":31.232214,
@@ -117,12 +117,13 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897187,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"9cc5387620c348bd8ef3009460e13456",
+    "wof:geomhash":"192c671e918b258e471bf9ded8432c9e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1092015839,
-    "wof:lastmodified":1602720861,
+    "wof:lastmodified":1695886295,
     "wof:name":"Boulaq",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/588/1/1092015881.geojson
+++ b/data/109/201/588/1/1092015881.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.104064,
-    "geom:area_square_m":1130926800.83633,
+    "geom:area_square_m":1130926800.836231,
     "geom:bbox":"34.197204,28.225245,34.610207,28.710204",
     "geom:latitude":28.490199,
     "geom:longitude":34.38647,
@@ -158,9 +158,10 @@
     "wof:concordances":{
         "hasc:id":"EG.JS.DH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897188,
-    "wof:geomhash":"4f313403a8cbd39ff02429452f325f45",
+    "wof:geomhash":"298ac986b14c46107eb5c9650bbc9e85",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -170,7 +171,7 @@
         }
     ],
     "wof:id":1092015881,
-    "wof:lastmodified":1602720862,
+    "wof:lastmodified":1695886295,
     "wof:name":"Dahab",
     "wof:parent_id":85671089,
     "wof:placetype":"county",

--- a/data/109/201/592/1/1092015921.geojson
+++ b/data/109/201/592/1/1092015921.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036956,
-    "geom:area_square_m":391652930.231398,
+    "geom:area_square_m":391652930.231452,
     "geom:bbox":"30.300755,30.902085,30.60491,31.145848",
     "geom:latitude":31.010805,
     "geom:longitude":30.455626,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BH.DS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897190,
-    "wof:geomhash":"99c3ceb08f72b8fe8bb70948cdf12e56",
+    "wof:geomhash":"fda706bf134e7d4bad430fd2c824cee3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092015921,
-    "wof:lastmodified":1627522090,
+    "wof:lastmodified":1695886558,
     "wof:name":"Damanhoor",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/201/594/7/1092015947.geojson
+++ b/data/109/201/594/7/1092015947.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018437,
-    "geom:area_square_m":204456534.045774,
+    "geom:area_square_m":204456534.045763,
     "geom:bbox":"31.817965,26.105413,32.217719,26.428974",
     "geom:latitude":26.255728,
     "geom:longitude":32.030645,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SJ.DS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897191,
-    "wof:geomhash":"59ab6e0203ec4a179ffda7af753610a1",
+    "wof:geomhash":"93c90690d852a5b0348aad5e98c7c477",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092015947,
-    "wof:lastmodified":1627522091,
+    "wof:lastmodified":1695886559,
     "wof:name":"Dar El-Salam",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/201/598/7/1092015987.geojson
+++ b/data/109/201/598/7/1092015987.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020515,
-    "geom:area_square_m":224950045.991642,
+    "geom:area_square_m":224950045.991625,
     "geom:bbox":"30.668685,27.431744,30.869749,27.615094",
     "geom:latitude":27.527725,
     "geom:longitude":30.77573,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.AT.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897193,
-    "wof:geomhash":"bb243de6e250cfc5ee4205a71237a78f",
+    "wof:geomhash":"43ac2abaeb4f39fdf9caac3cf660000a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092015987,
-    "wof:lastmodified":1627522091,
+    "wof:lastmodified":1695886559,
     "wof:name":"Dayroot",
     "wof:parent_id":85671069,
     "wof:placetype":"county",

--- a/data/109/201/603/3/1092016033.geojson
+++ b/data/109/201/603/3/1092016033.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018296,
-    "geom:area_square_m":200425411.207984,
+    "geom:area_square_m":200425411.208009,
     "geom:bbox":"30.66593,27.576852,30.899804,27.704996",
     "geom:latitude":27.636314,
     "geom:longitude":30.781715,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MN.DM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897194,
-    "wof:geomhash":"8ed8b9ffd5fbfb02db6debd58ba703f1",
+    "wof:geomhash":"33c5894abf3891fbdccc5cb429431e1e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092016033,
-    "wof:lastmodified":1627522091,
+    "wof:lastmodified":1695886559,
     "wof:name":"Deir Mowas",
     "wof:parent_id":85671049,
     "wof:placetype":"county",

--- a/data/109/201/607/9/1092016079.geojson
+++ b/data/109/201/607/9/1092016079.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020528,
-    "geom:area_square_m":218114062.627989,
+    "geom:area_square_m":218114062.627969,
     "geom:bbox":"31.365852,30.683793,31.579541,30.830614",
     "geom:latitude":30.762427,
     "geom:longitude":31.458327,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SQ.DN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897196,
-    "wof:geomhash":"639d3bb998b25986fd8bcee4e4171a29",
+    "wof:geomhash":"4e9e11f84436383adb378d8f765ea6d3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092016079,
-    "wof:lastmodified":1627522091,
+    "wof:lastmodified":1695886559,
     "wof:name":"Deirab Negm",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/201/611/5/1092016115.geojson
+++ b/data/109/201/611/5/1092016115.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006075,
-    "geom:area_square_m":68399441.927883,
+    "geom:area_square_m":68399441.927886,
     "geom:bbox":"32.866562,24.308138,32.940623,24.468557",
     "geom:latitude":24.413086,
     "geom:longitude":32.903741,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.AN.DR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897197,
-    "wof:geomhash":"a03ff66e665c28a16d33948f16826143",
+    "wof:geomhash":"98420ed3f19760083bda603266d531c9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092016115,
-    "wof:lastmodified":1627522091,
+    "wof:lastmodified":1695886559,
     "wof:name":"Deraw",
     "wof:parent_id":85671061,
     "wof:placetype":"county",

--- a/data/109/201/615/7/1092016157.geojson
+++ b/data/109/201/615/7/1092016157.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017076,
-    "geom:area_square_m":189547926.789896,
+    "geom:area_square_m":189547926.789898,
     "geom:bbox":"32.327316,26.067733,32.569412,26.20964",
     "geom:latitude":26.140785,
     "geom:longitude":32.447878,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QN.QJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897199,
-    "wof:geomhash":"0258c4f482459efc9c198a7e9ec454e9",
+    "wof:geomhash":"29116ed7ea75f4dd29ae31ca5148305d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092016157,
-    "wof:lastmodified":1627522091,
+    "wof:lastmodified":1695886559,
     "wof:name":"Deshna",
     "wof:parent_id":85671075,
     "wof:placetype":"county",

--- a/data/109/201/620/3/1092016203.geojson
+++ b/data/109/201/620/3/1092016203.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029595,
-    "geom:area_square_m":313137115.904026,
+    "geom:area_square_m":313137115.903993,
     "geom:bbox":"30.609319,31.00866,30.810069,31.284308",
     "geom:latitude":31.162997,
     "geom:longitude":30.718588,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.KS.DM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897200,
-    "wof:geomhash":"a21bddf703023d5e41905ecc6057108d",
+    "wof:geomhash":"53110069a3a942cb78b6896976d74f16",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092016203,
-    "wof:lastmodified":1627522091,
+    "wof:lastmodified":1695886559,
     "wof:name":"Desooq",
     "wof:parent_id":85671057,
     "wof:placetype":"county",

--- a/data/109/201/622/7/1092016227.geojson
+++ b/data/109/201/622/7/1092016227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03175,
-    "geom:area_square_m":336232063.800434,
+    "geom:area_square_m":336232063.800447,
     "geom:bbox":"31.499771,30.977462,31.864956,31.171025",
     "geom:latitude":31.081417,
     "geom:longitude":31.67273,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.DQ.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897201,
-    "wof:geomhash":"2b1703cbf70a221e2d63c52ce97af701",
+    "wof:geomhash":"fe68445298ec0dd1058f2ff78c8f2730",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092016227,
-    "wof:lastmodified":1627522091,
+    "wof:lastmodified":1695886560,
     "wof:name":"Dokornos",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/201/627/1/1092016271.geojson
+++ b/data/109/201/627/1/1092016271.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007031,
-    "geom:area_square_m":74173816.605317,
+    "geom:area_square_m":74173816.605313,
     "geom:bbox":"31.635227,31.40821,31.789768,31.479953",
     "geom:latitude":31.440419,
     "geom:longitude":31.706088,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.DT.DJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897203,
-    "wof:geomhash":"5a6061f29f029d9f295647d0e51c567c",
+    "wof:geomhash":"fa2b1254759f972127f6b6542f4341eb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092016271,
-    "wof:lastmodified":1627522091,
+    "wof:lastmodified":1695886560,
     "wof:name":"Domiat El-Gedidah City",
     "wof:parent_id":85671025,
     "wof:placetype":"county",

--- a/data/109/201/631/9/1092016319.geojson
+++ b/data/109/201/631/9/1092016319.geojson
@@ -69,7 +69,7 @@
     "wof:concordances":{},
     "wof:country":"EG",
     "wof:created":1473897204,
-    "wof:geomhash":"4ad589ecf33e35d85fc8762722165ae8",
+    "wof:geomhash":"10cc491b718ec52c203ed342facf3980",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1092016319,
-    "wof:lastmodified":1627522091,
+    "wof:lastmodified":1695886560,
     "wof:name":"Domiat El-Gedidah Port",
     "wof:parent_id":85671025,
     "wof:placetype":"county",

--- a/data/109/201/634/9/1092016349.geojson
+++ b/data/109/201/634/9/1092016349.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01987,
-    "geom:area_square_m":209604331.917796,
+    "geom:area_square_m":209604331.917783,
     "geom:bbox":"31.748388,31.346042,32.063652,31.535778",
     "geom:latitude":31.446564,
     "geom:longitude":31.869672,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.DT.DO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897206,
-    "wof:geomhash":"52fc21ea66b76371ffb5c3ffd47fc02b",
+    "wof:geomhash":"ade376d36e63ff5ec32690b03be68cf7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092016349,
-    "wof:lastmodified":1627522091,
+    "wof:lastmodified":1695886560,
     "wof:name":"Domiat",
     "wof:parent_id":85671025,
     "wof:placetype":"county",

--- a/data/109/201/639/1/1092016391.geojson
+++ b/data/109/201/639/1/1092016391.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036081,
-    "geom:area_square_m":388844460.282453,
+    "geom:area_square_m":388844460.282455,
     "geom:bbox":"30.404651,29.2383,30.791225,29.472585",
     "geom:latitude":29.359091,
     "geom:longitude":30.620337,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.FY.US"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897207,
-    "wof:geomhash":"a6b0ef9f87642bcc26432dfa4fff1e9d",
+    "wof:geomhash":"0ca52a37bccb5cd3051d91bfc8524f26",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092016391,
-    "wof:lastmodified":1627522092,
+    "wof:lastmodified":1695886560,
     "wof:name":"Ebshoway",
     "wof:parent_id":85671037,
     "wof:placetype":"county",

--- a/data/109/201/643/7/1092016437.geojson
+++ b/data/109/201/643/7/1092016437.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028265,
-    "geom:area_square_m":316719141.083921,
+    "geom:area_square_m":316719141.08392,
     "geom:bbox":"32.639172,24.647236,32.944537,25.233257",
     "geom:latitude":25.015708,
     "geom:longitude":32.828234,
@@ -198,9 +198,10 @@
     "wof:concordances":{
         "hasc:id":"EG.AN.ED"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897209,
-    "wof:geomhash":"3c1b077a8098b6c41c428bc7938ef256",
+    "wof:geomhash":"63062c13e28506385a0e22153bcd2341",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -210,7 +211,7 @@
         }
     ],
     "wof:id":1092016437,
-    "wof:lastmodified":1602720862,
+    "wof:lastmodified":1695886295,
     "wof:name":"Edfu",
     "wof:parent_id":85671061,
     "wof:placetype":"county",

--- a/data/109/201/648/1/1092016481.geojson
+++ b/data/109/201/648/1/1092016481.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015455,
-    "geom:area_square_m":163312316.358909,
+    "geom:area_square_m":163312316.358927,
     "geom:bbox":"30.141324,31.21611,30.426333,31.365745",
     "geom:latitude":31.287393,
     "geom:longitude":30.331298,
@@ -107,9 +107,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BH.ED"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897210,
-    "wof:geomhash":"8e733ba2587328dd0f6ba8dd4ee08630",
+    "wof:geomhash":"c595994464cefe4cb66ae708932790f5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1092016481,
-    "wof:lastmodified":1627522097,
+    "wof:lastmodified":1695886568,
     "wof:name":"Edku",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/201/650/5/1092016505.geojson
+++ b/data/109/201/650/5/1092016505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0144,
-    "geom:area_square_m":156196315.360333,
+    "geom:area_square_m":156196315.360281,
     "geom:bbox":"30.645362,28.616566,30.837608,28.75741",
     "geom:latitude":28.689577,
     "geom:longitude":30.738757,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MN.AD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897212,
-    "wof:geomhash":"1f8e08d14cc2c753510eeb2990b55f55",
+    "wof:geomhash":"b71b1ec78c189f0bb6982df6dfaf01b4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092016505,
-    "wof:lastmodified":1627522087,
+    "wof:lastmodified":1695886551,
     "wof:name":"El-Adwah",
     "wof:parent_id":85671049,
     "wof:placetype":"county",

--- a/data/109/201/654/5/1092016545.geojson
+++ b/data/109/201/654/5/1092016545.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000509,
-    "geom:area_square_m":5448330.778541,
+    "geom:area_square_m":5448330.77854,
     "geom:bbox":"31.189758,30.044995,31.219006,30.07301",
     "geom:latitude":30.059846,
     "geom:longitude":31.203534,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.JZ.AG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897213,
-    "wof:geomhash":"235146a9af537a059aa2e834d42af89a",
+    "wof:geomhash":"2cf8491e35263ddcc10c29d1b0b80e9e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092016545,
-    "wof:lastmodified":1627522087,
+    "wof:lastmodified":1695886551,
     "wof:name":"El-Agouzah",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/201/659/1/1092016591.geojson
+++ b/data/109/201/659/1/1092016591.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001702,
-    "geom:area_square_m":18228940.625051,
+    "geom:area_square_m":18228940.62506,
     "geom:bbox":"31.116466,29.949283,31.165247,30.02857",
     "geom:latitude":29.991069,
     "geom:longitude":31.14241,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.JZ.PY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897215,
-    "wof:geomhash":"aca6ab14ad70533f47a4aaa03109b90a",
+    "wof:geomhash":"26258e43ddbe12a9a77aa754f1378690",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092016591,
-    "wof:lastmodified":1627522092,
+    "wof:lastmodified":1695886560,
     "wof:name":"El-Ahram",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/201/662/3/1092016623.geojson
+++ b/data/109/201/662/3/1092016623.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.940379,
-    "geom:area_square_m":10114300008.083817,
+    "geom:area_square_m":10114300008.083843,
     "geom:bbox":"28.26558,28.774524,29.381569,31.000965",
     "geom:latitude":29.553279,
     "geom:longitude":28.67505,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MT.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897216,
-    "wof:geomhash":"978e07b288f0ac62be03413c9388c81e",
+    "wof:geomhash":"b1da6fba347df71163db1b26557d5add",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092016623,
-    "wof:lastmodified":1627522093,
+    "wof:lastmodified":1695886562,
     "wof:name":"El-Alamein",
     "wof:parent_id":85671031,
     "wof:placetype":"county",

--- a/data/109/201/666/7/1092016667.geojson
+++ b/data/109/201/666/7/1092016667.geojson
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.UO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897218,
-    "wof:geomhash":"34fe6b2d0adaecfc9d0ded643175deb3",
+    "wof:geomhash":"31e4bc4a53ff050ef4b1fe6733948d1f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092016667,
-    "wof:lastmodified":1627522094,
+    "wof:lastmodified":1695886564,
     "wof:name":"El-Amal",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/671/5/1092016715.geojson
+++ b/data/109/201/671/5/1092016715.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047648,
-    "geom:area_square_m":504808670.49768,
+    "geom:area_square_m":504808670.497691,
     "geom:bbox":"29.627918,30.898778,29.990922,31.192466",
     "geom:latitude":31.040795,
     "geom:longitude":29.826741,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.AM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897219,
-    "wof:geomhash":"47e3006c2ffbc1b7cd3b03bf7ef87c16",
+    "wof:geomhash":"d767e798715ef5320fed2483ec51868e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092016715,
-    "wof:lastmodified":1627522094,
+    "wof:lastmodified":1695886564,
     "wof:name":"El-Amreyah",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/201/676/7/1092016767.geojson
+++ b/data/109/201/676/7/1092016767.geojson
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BS.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897221,
-    "wof:geomhash":"3a57ccf1f76038d9c8b42cb69c276560",
+    "wof:geomhash":"79ac99204d04f48938b45d336421816e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092016767,
-    "wof:lastmodified":1627522094,
+    "wof:lastmodified":1695886564,
     "wof:name":"El-Arab",
     "wof:parent_id":85671021,
     "wof:placetype":"county",

--- a/data/109/201/680/3/1092016803.geojson
+++ b/data/109/201/680/3/1092016803.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002575,
-    "geom:area_square_m":27574458.094096,
+    "geom:area_square_m":27574458.094097,
     "geom:bbox":"32.477825,29.94951,32.544547,30.027325",
     "geom:latitude":29.981265,
     "geom:longitude":32.519101,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SW.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897222,
-    "wof:geomhash":"1dac453557d2877b58d9276f231e1134",
+    "wof:geomhash":"79a8122a482f3777dd574267c68abc02",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092016803,
-    "wof:lastmodified":1627522094,
+    "wof:lastmodified":1695886564,
     "wof:name":"El-Arbe'in",
     "wof:parent_id":85671013,
     "wof:placetype":"county",

--- a/data/109/201/685/1/1092016851.geojson
+++ b/data/109/201/685/1/1092016851.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000249,
-    "geom:area_square_m":2628717.882331,
+    "geom:area_square_m":2628717.882332,
     "geom:bbox":"29.890688,31.176731,29.909426,31.201615",
     "geom:latitude":31.188648,
     "geom:longitude":29.898336,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.AT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897224,
-    "wof:geomhash":"bf19931f67d09c78be9036d79b303211",
+    "wof:geomhash":"eb1fbe31b2348ebf3e7c64bf3c2fc617",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092016851,
-    "wof:lastmodified":1627522092,
+    "wof:lastmodified":1695886561,
     "wof:name":"El-Atareen",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/201/689/3/1092016893.geojson
+++ b/data/109/201/689/3/1092016893.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015347,
-    "geom:area_square_m":165048133.904834,
+    "geom:area_square_m":165048133.904838,
     "geom:bbox":"31.171169,29.396489,31.298294,29.728066",
     "geom:latitude":29.574227,
     "geom:longitude":31.238195,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.JZ.AY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897225,
-    "wof:geomhash":"ac55025492a1580bb534a5a3dacf1d2e",
+    "wof:geomhash":"2250750cff30f42ee48a4fb1b1526c29",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092016893,
-    "wof:lastmodified":1627522087,
+    "wof:lastmodified":1695886551,
     "wof:name":"El-Ayyat",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/201/692/9/1092016929.geojson
+++ b/data/109/201/692/9/1092016929.geojson
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.AZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897227,
-    "wof:geomhash":"91f5b6113c9e6c973bb62cd7bd0241ee",
+    "wof:geomhash":"c86add6da9ec6ce193d083cdeca60eb2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092016929,
-    "wof:lastmodified":1627522094,
+    "wof:lastmodified":1695886564,
     "wof:name":"El-Azbakeyah",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/697/5/1092016975.geojson
+++ b/data/109/201/697/5/1092016975.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007972,
-    "geom:area_square_m":87857884.37425,
+    "geom:area_square_m":87857884.374218,
     "geom:bbox":"31.337176,26.827849,31.509232,27.036084",
     "geom:latitude":26.959476,
     "geom:longitude":31.423994,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.AT.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897228,
-    "wof:geomhash":"a5ad396fce826d78e14751e1f1100388",
+    "wof:geomhash":"36a7d6bd2aa5cb01afca5a26e516de6d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092016975,
-    "wof:lastmodified":1627522092,
+    "wof:lastmodified":1695886561,
     "wof:name":"El-Badary",
     "wof:parent_id":85671069,
     "wof:placetype":"county",

--- a/data/109/201/701/9/1092017019.geojson
+++ b/data/109/201/701/9/1092017019.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011489,
-    "geom:area_square_m":123254715.228484,
+    "geom:area_square_m":123254715.228459,
     "geom:bbox":"31.184383,29.723329,31.296579,29.922509",
     "geom:latitude":29.819135,
     "geom:longitude":31.249472,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.JZ.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897229,
-    "wof:geomhash":"a086763125c8f508814141ff0b7e7c2d",
+    "wof:geomhash":"6471a0a2233230e270ae85485173a185",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092017019,
-    "wof:lastmodified":1627522087,
+    "wof:lastmodified":1695886551,
     "wof:name":"El-Badrashein",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/201/706/5/1092017065.geojson
+++ b/data/109/201/706/5/1092017065.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015893,
-    "geom:area_square_m":169460817.492808,
+    "geom:area_square_m":169460817.492815,
     "geom:bbox":"30.970097,30.334985,31.146161,30.488418",
     "geom:latitude":30.420252,
     "geom:longitude":31.056637,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MF.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897231,
-    "wof:geomhash":"1b5f3c780938984642b9ad64dc6bc327",
+    "wof:geomhash":"3d0859578fbf57bdf5a2a5735f2d0550",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092017065,
-    "wof:lastmodified":1627522094,
+    "wof:lastmodified":1695886564,
     "wof:name":"El-Bagoor",
     "wof:parent_id":85670995,
     "wof:placetype":"county",

--- a/data/109/201/710/1/1092017101.geojson
+++ b/data/109/201/710/1/1092017101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001342,
-    "geom:area_square_m":14372180.970656,
+    "geom:area_square_m":14372180.970655,
     "geom:bbox":"31.225436,29.961796,31.288394,29.997383",
     "geom:latitude":29.980556,
     "geom:longitude":31.257976,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.BT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897232,
-    "wof:geomhash":"48f235b3dcdd6e37e10e413df780740a",
+    "wof:geomhash":"b379f6cf7b6d59495cc62edd4e899bb8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092017101,
-    "wof:lastmodified":1627522092,
+    "wof:lastmodified":1695886561,
     "wof:name":"El-Basateen",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/714/3/1092017143.geojson
+++ b/data/109/201/714/3/1092017143.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014218,
-    "geom:area_square_m":157709541.963131,
+    "geom:area_square_m":157709541.963155,
     "geom:bbox":"31.866611,26.152625,32.008422,26.313419",
     "geom:latitude":26.229771,
     "geom:longitude":31.948163,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SJ.BL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897234,
-    "wof:geomhash":"b0459ce32201d4420f292d6a072959da",
+    "wof:geomhash":"d0fdb80e4bc4ba6523ede5a4667e114f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092017143,
-    "wof:lastmodified":1627522094,
+    "wof:lastmodified":1695886564,
     "wof:name":"El-Beleena",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/201/718/9/1092017189.geojson
+++ b/data/109/201/718/9/1092017189.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024243,
-    "geom:area_square_m":255488555.933274,
+    "geom:area_square_m":255488555.933271,
     "geom:bbox":"30.795594,31.442573,31.370612,31.599093",
     "geom:latitude":31.539541,
     "geom:longitude":31.160262,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.KS.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897235,
-    "wof:geomhash":"0b7d7014a0b9f7fdb92fc3543363e025",
+    "wof:geomhash":"f4d60e15ad6d255f6a6f331a74462cd4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092017189,
-    "wof:lastmodified":1627522090,
+    "wof:lastmodified":1695886558,
     "wof:name":"El-Borolos",
     "wof:parent_id":85671057,
     "wof:placetype":"county",

--- a/data/109/201/722/7/1092017227.geojson
+++ b/data/109/201/722/7/1092017227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.435373,
-    "geom:area_square_m":15368237664.316948,
+    "geom:area_square_m":15368237664.316902,
     "geom:bbox":"27.67372,28.807763,28.63818,31.097751",
     "geom:latitude":30.007993,
     "geom:longitude":28.089028,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MT.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897237,
-    "wof:geomhash":"fdfedf2743b688fcd5eaca7e0326d6f8",
+    "wof:geomhash":"3192de4957bd972afad1da9627599525",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092017227,
-    "wof:lastmodified":1627522094,
+    "wof:lastmodified":1695886564,
     "wof:name":"El-Dab'ah",
     "wof:parent_id":85671031,
     "wof:placetype":"county",

--- a/data/109/201/727/3/1092017273.geojson
+++ b/data/109/201/727/3/1092017273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000182,
-    "geom:area_square_m":1942471.046092,
+    "geom:area_square_m":1942471.046091,
     "geom:bbox":"31.252258,30.053891,31.280069,30.073394",
     "geom:latitude":30.063654,
     "geom:longitude":31.267804,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.ZA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897238,
-    "wof:geomhash":"f8046eeb6f6a5ef070db80512c8389d7",
+    "wof:geomhash":"cb27085ad54c1ba6df9b8b76aa14cc55",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092017273,
-    "wof:lastmodified":1627522090,
+    "wof:lastmodified":1695886558,
     "wof:name":"El-Daher",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/731/7/1092017317.geojson
+++ b/data/109/201/731/7/1092017317.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034634,
-    "geom:area_square_m":367741851.385052,
+    "geom:area_square_m":367741851.385068,
     "geom:bbox":"30.360062,30.716214,30.62037,30.952732",
     "geom:latitude":30.828442,
     "geom:longitude":30.496163,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BH.DE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897239,
-    "wof:geomhash":"be9a0984ccb8756c4b91930b9593cad4",
+    "wof:geomhash":"da7f8fafefc219a419f8fd2e4889d158",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092017317,
-    "wof:lastmodified":1627522094,
+    "wof:lastmodified":1695886565,
     "wof:name":"El-Dalangat",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/201/735/9/1092017359.geojson
+++ b/data/109/201/735/9/1092017359.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000136,
-    "geom:area_square_m":1453896.722851,
+    "geom:area_square_m":1453896.72285,
     "geom:bbox":"31.25025,30.035707,31.269599,30.049341",
     "geom:latitude":30.042426,
     "geom:longitude":31.258862,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897241,
-    "wof:geomhash":"0def2610fb73922d6c97828875709b1b",
+    "wof:geomhash":"b59de8478365629b0c90fe0fa836be0b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092017359,
-    "wof:lastmodified":1627522094,
+    "wof:lastmodified":1695886565,
     "wof:name":"El-Darb El-Ahmar",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/739/7/1092017397.geojson
+++ b/data/109/201/739/7/1092017397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049615,
-    "geom:area_square_m":525306729.776823,
+    "geom:area_square_m":525306729.776831,
     "geom:bbox":"32.054547,30.911736,32.316575,31.269537",
     "geom:latitude":31.102808,
     "geom:longitude":32.22294,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BS.JB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897242,
-    "wof:geomhash":"d49bf9ab0614911761d9f11229ab3c77",
+    "wof:geomhash":"678eed410949bba161d94f586eef80ed",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092017397,
-    "wof:lastmodified":1627522092,
+    "wof:lastmodified":1695886561,
     "wof:name":"El-Dawahy",
     "wof:parent_id":85671021,
     "wof:placetype":"county",

--- a/data/109/201/744/1/1092017441.geojson
+++ b/data/109/201/744/1/1092017441.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003841,
-    "geom:area_square_m":40666821.868352,
+    "geom:area_square_m":40666821.868367,
     "geom:bbox":"29.728883,31.074821,29.85074,31.149062",
     "geom:latitude":31.110857,
     "geom:longitude":29.78988,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.DK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897244,
-    "wof:geomhash":"c630b042eceb80b0e379df7eecd8b037",
+    "wof:geomhash":"6596708f7074876c1acffd9328966524",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092017441,
-    "wof:lastmodified":1627522091,
+    "wof:lastmodified":1695886560,
     "wof:name":"El-Dekheilah",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/201/748/9/1092017489.geojson
+++ b/data/109/201/748/9/1092017489.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000518,
-    "geom:area_square_m":5548867.474383,
+    "geom:area_square_m":5548867.474381,
     "geom:bbox":"31.193472,30.028149,31.227771,30.055955",
     "geom:latitude":30.040674,
     "geom:longitude":31.208173,
@@ -82,12 +82,13 @@
     "wof:concordances":{
         "hasc:id":"EG.JZ.DO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897245,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"ebceddf43f804f46328798cc0d3b44c0",
+    "wof:geomhash":"40d91cd1dc9edc981cf778222402dda2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1092017489,
-    "wof:lastmodified":1627522091,
+    "wof:lastmodified":1695886560,
     "wof:name":"El-Dokky",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/201/753/5/1092017535.geojson
+++ b/data/109/201/753/5/1092017535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023068,
-    "geom:area_square_m":245674226.06623,
+    "geom:area_square_m":245674226.066203,
     "geom:bbox":"32.065988,30.483124,32.340415,30.619027",
     "geom:latitude":30.538725,
     "geom:longitude":32.196912,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IS.IM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897247,
-    "wof:geomhash":"2d6c1de1963d16692ec2906440b75a8a",
+    "wof:geomhash":"4b43b69265d1c0d6f37f683f5e924d8b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092017535,
-    "wof:lastmodified":1627522087,
+    "wof:lastmodified":1695886552,
     "wof:name":"El-Esmailiah",
     "wof:parent_id":85670989,
     "wof:placetype":"county",

--- a/data/109/201/758/5/1092017585.geojson
+++ b/data/109/201/758/5/1092017585.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.536667,
-    "geom:area_square_m":83044674330.788605,
+    "geom:area_square_m":83044674330.788422,
     "geom:bbox":"25.0,26.283844,30.759223,27.67669",
     "geom:latitude":26.983504,
     "geom:longitude":27.767309,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.WJ.FA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897248,
-    "wof:geomhash":"cfee3ab6fe0fbcf224141e3e0b788c47",
+    "wof:geomhash":"e4bb61fb0e2689cd1d35a3055bc24bd7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092017585,
-    "wof:lastmodified":1627522087,
+    "wof:lastmodified":1695886552,
     "wof:name":"El-Farafrah",
     "wof:parent_id":85671071,
     "wof:placetype":"county",

--- a/data/109/201/762/7/1092017627.geojson
+++ b/data/109/201/762/7/1092017627.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023753,
-    "geom:area_square_m":257382185.51524,
+    "geom:area_square_m":257382185.515261,
     "geom:bbox":"30.731772,28.698053,30.92236,28.891504",
     "geom:latitude":28.799146,
     "geom:longitude":30.839068,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BN.FA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897250,
-    "wof:geomhash":"dc729d2f90696d104f21f9f17287a1d7",
+    "wof:geomhash":"6c50633bfe9116ea13af45d02d3a62b8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092017627,
-    "wof:lastmodified":1627522087,
+    "wof:lastmodified":1695886552,
     "wof:name":"El-Fashn",
     "wof:parent_id":85671053,
     "wof:placetype":"county",

--- a/data/109/201/766/9/1092017669.geojson
+++ b/data/109/201/766/9/1092017669.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009247,
-    "geom:area_square_m":101694932.663635,
+    "geom:area_square_m":101694932.663643,
     "geom:bbox":"31.104142,27.141795,31.29732,27.266098",
     "geom:latitude":27.201769,
     "geom:longitude":31.198892,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.AT.FA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897251,
-    "wof:geomhash":"160dbbf57a2ec290de8979fe538d04d0",
+    "wof:geomhash":"69595caf353dff1a3405d873b63d1e15",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092017669,
-    "wof:lastmodified":1627522092,
+    "wof:lastmodified":1695886561,
     "wof:name":"El-Fath",
     "wof:parent_id":85671069,
     "wof:placetype":"county",

--- a/data/109/201/770/5/1092017705.geojson
+++ b/data/109/201/770/5/1092017705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036771,
-    "geom:area_square_m":396499707.906062,
+    "geom:area_square_m":396499707.906104,
     "geom:bbox":"30.715915,29.190039,31.055692,29.398111",
     "geom:latitude":29.303423,
     "geom:longitude":30.908368,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.FY.FM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897253,
-    "wof:geomhash":"003cb8d95444d45f6a2e90ad1bda8986",
+    "wof:geomhash":"947173e016af8de6eb7d70d990208fb8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092017705,
-    "wof:lastmodified":1627522092,
+    "wof:lastmodified":1695886561,
     "wof:name":"El-Fayoum",
     "wof:parent_id":85671037,
     "wof:placetype":"county",

--- a/data/109/201/775/5/1092017755.geojson
+++ b/data/109/201/775/5/1092017755.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000185,
-    "geom:area_square_m":1977801.084901,
+    "geom:area_square_m":1977801.084902,
     "geom:bbox":"31.254988,30.045251,31.276673,30.063507",
     "geom:latitude":30.052868,
     "geom:longitude":31.266264,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.DQ.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897254,
-    "wof:geomhash":"d68fb938e80cfc0ead33fd89cfba0ea4",
+    "wof:geomhash":"e86771c4e129ef0a87fd7c7dc4002163",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092017755,
-    "wof:lastmodified":1627522094,
+    "wof:lastmodified":1695886565,
     "wof:name":"El-Gamaleyah",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/779/7/1092017797.geojson
+++ b/data/109/201/779/7/1092017797.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006208,
-    "geom:area_square_m":65649033.231354,
+    "geom:area_square_m":65649033.231349,
     "geom:bbox":"31.82248,31.142936,31.9001,31.2915",
     "geom:latitude":31.221402,
     "geom:longitude":31.852625,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897256,
-    "wof:geomhash":"4e42f172345c7d29bb6da5bc64aac3b3",
+    "wof:geomhash":"89a9f1f5ddbaf300b29735a9ef810015",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092017797,
-    "wof:lastmodified":1627522094,
+    "wof:lastmodified":1695886565,
     "wof:name":"El-Gamaleyah",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/201/782/7/1092017827.geojson
+++ b/data/109/201/782/7/1092017827.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024113,
-    "geom:area_square_m":257824552.503721,
+    "geom:area_square_m":257824552.503744,
     "geom:bbox":"32.392781,29.932468,32.607711,30.285552",
     "geom:latitude":30.149408,
     "geom:longitude":32.526451,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SW.GN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897257,
-    "wof:geomhash":"39d995ce0cd5cc07a527bb493cf0812c",
+    "wof:geomhash":"d4ba4e5321840390f1e79b400aa2dcaa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092017827,
-    "wof:lastmodified":1627522087,
+    "wof:lastmodified":1695886552,
     "wof:name":"El-Ganayen",
     "wof:parent_id":85671013,
     "wof:placetype":"county",

--- a/data/109/201/787/3/1092017873.geojson
+++ b/data/109/201/787/3/1092017873.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004197,
-    "geom:area_square_m":46283496.488446,
+    "geom:area_square_m":46283496.488442,
     "geom:bbox":"31.27934,26.850104,31.371721,26.970744",
     "geom:latitude":26.902105,
     "geom:longitude":31.321459,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.AT.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897259,
-    "wof:geomhash":"80a33ab4c286fb7006a0a06c4e83b1eb",
+    "wof:geomhash":"d2b7e6842811beb2b9e019f86ba4802e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092017873,
-    "wof:lastmodified":1627522094,
+    "wof:lastmodified":1695886565,
     "wof:name":"El-Ghanayem",
     "wof:parent_id":85671069,
     "wof:placetype":"county",

--- a/data/109/201/791/7/1092017917.geojson
+++ b/data/109/201/791/7/1092017917.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000251,
-    "geom:area_square_m":2657825.111474,
+    "geom:area_square_m":2657825.111471,
     "geom:bbox":"29.852968,31.186392,29.890428,31.213183",
     "geom:latitude":31.19905,
     "geom:longitude":29.875414,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897260,
-    "wof:geomhash":"027f02a3d26e6309543908c81da8ae5e",
+    "wof:geomhash":"0665713c9111fe46b82ecf4fe7601bb0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092017917,
-    "wof:lastmodified":1627522092,
+    "wof:lastmodified":1695886561,
     "wof:name":"El-Gomrok",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/201/795/3/1092017953.geojson
+++ b/data/109/201/795/3/1092017953.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.660428,
-    "geom:area_square_m":17770652370.143204,
+    "geom:area_square_m":17770652370.143341,
     "geom:bbox":"28.498101,29.236454,30.336177,30.889503",
     "geom:latitude":30.05044,
     "geom:longitude":29.263291,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MT.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897262,
-    "wof:geomhash":"b4646969092319538b0c1f724658b142",
+    "wof:geomhash":"7ddd296d126a5b6c9c92c7704e71cb52",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092017953,
-    "wof:lastmodified":1627522092,
+    "wof:lastmodified":1695886561,
     "wof:name":"El-Hamam",
     "wof:parent_id":85671031,
     "wof:placetype":"county",

--- a/data/109/201/799/3/1092017993.geojson
+++ b/data/109/201/799/3/1092017993.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055132,
-    "geom:area_square_m":581953211.488371,
+    "geom:area_square_m":581953211.488356,
     "geom:bbox":"30.947347,31.226281,31.233098,31.546501",
     "geom:latitude":31.387455,
     "geom:longitude":31.099857,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.KS.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897263,
-    "wof:geomhash":"4e1bc4201578b654101c5934f84b12d9",
+    "wof:geomhash":"e9e2c5ec9e6e120cd03bf6199dd511fb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092017993,
-    "wof:lastmodified":1627522095,
+    "wof:lastmodified":1695886565,
     "wof:name":"El-Hamool",
     "wof:parent_id":85671057,
     "wof:placetype":"county",

--- a/data/109/201/804/1/1092018041.geojson
+++ b/data/109/201/804/1/1092018041.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.902485,
-    "geom:area_square_m":9612709754.396957,
+    "geom:area_square_m":9612709754.397068,
     "geom:bbox":"32.634682,30.167998,34.403929,30.931809",
     "geom:latitude":30.524266,
     "geom:longitude":33.535633,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SS.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897265,
-    "wof:geomhash":"fefe87cfc1b3e7485ed3253edc8ed5e5",
+    "wof:geomhash":"c1f70e71b0b0e078e5af13aa63d53ee9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092018041,
-    "wof:lastmodified":1627522087,
+    "wof:lastmodified":1695886552,
     "wof:name":"El-Hasanah",
     "wof:parent_id":85671093,
     "wof:placetype":"county",

--- a/data/109/201/806/5/1092018065.geojson
+++ b/data/109/201/806/5/1092018065.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002079,
-    "geom:area_square_m":22279529.567579,
+    "geom:area_square_m":22279529.567584,
     "geom:bbox":"31.22139,29.86841,31.28294,29.93379",
     "geom:latitude":29.903596,
     "geom:longitude":31.25964,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.JZ.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897266,
-    "wof:geomhash":"352e63a4e368d03dc4b0043254bc9e5a",
+    "wof:geomhash":"d6ebb46b1fd1fdd57513aea7834a440c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092018065,
-    "wof:lastmodified":1627522087,
+    "wof:lastmodified":1695886552,
     "wof:name":"El-Hawamdeyah",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/201/809/1/1092018091.geojson
+++ b/data/109/201/809/1/1092018091.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.158529,
-    "geom:area_square_m":1682884959.351387,
+    "geom:area_square_m":1682884959.351491,
     "geom:bbox":"31.699813,30.549899,32.213823,31.130349",
     "geom:latitude":30.850183,
     "geom:longitude":32.019378,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SQ.HE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897267,
-    "wof:geomhash":"dbcacae9f39b946ffc8ed12ec55a76e8",
+    "wof:geomhash":"94036d9437973f060b89673e3c006e51",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092018091,
-    "wof:lastmodified":1627522095,
+    "wof:lastmodified":1695886565,
     "wof:name":"El-Hoseineyah",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/201/810/7/1092018107.geojson
+++ b/data/109/201/810/7/1092018107.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007223,
-    "geom:area_square_m":76768228.191645,
+    "geom:area_square_m":76768228.191643,
     "geom:bbox":"31.501643,30.691097,31.624502,30.783883",
     "geom:latitude":30.738985,
     "geom:longitude":31.563393,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SQ.EB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897269,
-    "wof:geomhash":"af985f342e0d203e067c777fafd9518d",
+    "wof:geomhash":"51aa6140502003dace08c9cc682b8eac",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092018107,
-    "wof:lastmodified":1627522087,
+    "wof:lastmodified":1695886552,
     "wof:name":"El-Ibrahimeyah",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/201/812/7/1092018127.geojson
+++ b/data/109/201/812/7/1092018127.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001102,
-    "geom:area_square_m":11798758.819441,
+    "geom:area_square_m":11798758.819447,
     "geom:bbox":"31.24883,29.993591,31.29632,30.042083",
     "geom:latitude":30.017398,
     "geom:longitude":31.267711,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897270,
-    "wof:geomhash":"621ff89bc9125f215e033c6cd96bbb43",
+    "wof:geomhash":"059dab9861889b75d5b94b067977686e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092018127,
-    "wof:lastmodified":1627522095,
+    "wof:lastmodified":1695886565,
     "wof:name":"El-Khalifah",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/814/3/1092018143.geojson
+++ b/data/109/201/814/3/1092018143.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026269,
-    "geom:area_square_m":280652629.508117,
+    "geom:area_square_m":280652629.508104,
     "geom:bbox":"31.301463,30.143752,31.622314,30.312289",
     "geom:latitude":30.228919,
     "geom:longitude":31.4287,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QL.AB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897272,
-    "wof:geomhash":"cd538e4b4148b157637d627b6eb9d262",
+    "wof:geomhash":"04053b8710a0c832c9843f70a8afd6bb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092018143,
-    "wof:lastmodified":1627522088,
+    "wof:lastmodified":1695886552,
     "wof:name":"El-Khankah",
     "wof:parent_id":85671003,
     "wof:placetype":"county",

--- a/data/109/201/816/1/1092018161.geojson
+++ b/data/109/201/816/1/1092018161.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000163,
-    "geom:area_square_m":1729085.09041,
+    "geom:area_square_m":1729085.090409,
     "geom:bbox":"29.880591,31.173361,29.895291,31.193228",
     "geom:latitude":31.183494,
     "geom:longitude":29.887399,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897274,
-    "wof:geomhash":"9ce19e495e180baedc8a568300292a8d",
+    "wof:geomhash":"fd2f58e26f69b8ab811cceb293fd2185",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092018161,
-    "wof:lastmodified":1627522095,
+    "wof:lastmodified":1695886566,
     "wof:name":"El-Labban",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/201/820/3/1092018203.geojson
+++ b/data/109/201/820/3/1092018203.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000613,
-    "geom:area_square_m":6567892.594842,
+    "geom:area_square_m":6567892.594844,
     "geom:bbox":"31.240988,29.946828,31.287706,29.977037",
     "geom:latitude":29.960627,
     "geom:longitude":31.263377,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897276,
-    "wof:geomhash":"faaec7d66fa8264604aa66e3a0fbdf9a",
+    "wof:geomhash":"552fe1ca0b9dc7350575708f0704b3d7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092018203,
-    "wof:lastmodified":1627522098,
+    "wof:lastmodified":1695886569,
     "wof:name":"El-Maadi",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/824/5/1092018245.geojson
+++ b/data/109/201/824/5/1092018245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041125,
-    "geom:area_square_m":435752065.953095,
+    "geom:area_square_m":435752065.953088,
     "geom:bbox":"31.025668,30.87297,31.244284,31.163715",
     "geom:latitude":31.029903,
     "geom:longitude":31.134865,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.GH.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897277,
-    "wof:geomhash":"356fc542205f969b865672432b82a7f4",
+    "wof:geomhash":"3d34ae2149667b5bc94eb22b1247e3d8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092018245,
-    "wof:lastmodified":1627522095,
+    "wof:lastmodified":1695886566,
     "wof:name":"El-Mahallah El-Kobra",
     "wof:parent_id":85670985,
     "wof:placetype":"county",

--- a/data/109/201/827/7/1092018277.geojson
+++ b/data/109/201/827/7/1092018277.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016052,
-    "geom:area_square_m":169818928.044918,
+    "geom:area_square_m":169818928.044963,
     "geom:bbox":"30.41888,31.102827,30.610759,31.277271",
     "geom:latitude":31.178652,
     "geom:longitude":30.500119,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BH.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897278,
-    "wof:geomhash":"6c296d3f99d8ee754f30da67f30ccc0f",
+    "wof:geomhash":"3b029e1dc7e8e72fc48aedca0ecc1787",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092018277,
-    "wof:lastmodified":1627522098,
+    "wof:lastmodified":1695886569,
     "wof:name":"El-Mahmoudeyah",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/201/832/5/1092018325.geojson
+++ b/data/109/201/832/5/1092018325.geojson
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BS.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897280,
-    "wof:geomhash":"dc637e289ca85944b53a45b171d97f15",
+    "wof:geomhash":"2965a56783ce5ed62f4450e8772cd3d0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092018325,
-    "wof:lastmodified":1627522092,
+    "wof:lastmodified":1695886561,
     "wof:name":"El-Manakh",
     "wof:parent_id":85671021,
     "wof:placetype":"county",

--- a/data/109/201/836/9/1092018369.geojson
+++ b/data/109/201/836/9/1092018369.geojson
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.MN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897281,
-    "wof:geomhash":"74107e26db8a745ff527ef3e9476b423",
+    "wof:geomhash":"56e6a251eadcda5df4293f89b40ebd79",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092018369,
-    "wof:lastmodified":1627522095,
+    "wof:lastmodified":1695886566,
     "wof:name":"El-Mansheyah",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/201/839/5/1092018395.geojson
+++ b/data/109/201/839/5/1092018395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031251,
-    "geom:area_square_m":331074119.650551,
+    "geom:area_square_m":331074119.65054,
     "geom:bbox":"31.307828,30.934151,31.609313,31.183867",
     "geom:latitude":31.043659,
     "geom:longitude":31.475518,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.DQ.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897283,
-    "wof:geomhash":"2cdc8dbe8a4d0b7a6fc5863b5021e611",
+    "wof:geomhash":"c5f75d18aa08db95cd7b04b72c2ec535",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092018395,
-    "wof:lastmodified":1627522099,
+    "wof:lastmodified":1695886571,
     "wof:name":"El-Mansourah",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/201/839/7/1092018397.geojson
+++ b/data/109/201/839/7/1092018397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021646,
-    "geom:area_square_m":229029635.169244,
+    "geom:area_square_m":229029635.169256,
     "geom:bbox":"31.838221,31.08204,32.088591,31.248507",
     "geom:latitude":31.164819,
     "geom:longitude":31.943438,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.DQ.MZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897284,
-    "wof:geomhash":"13d43dbe72c10f07924d6d0ddeafa793",
+    "wof:geomhash":"b16aa347a1784594ba23d3a82e1032cf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092018397,
-    "wof:lastmodified":1627522092,
+    "wof:lastmodified":1695886561,
     "wof:name":"El-Manzalah",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/201/839/9/1092018399.geojson
+++ b/data/109/201/839/9/1092018399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01482,
-    "geom:area_square_m":163773180.708405,
+    "geom:area_square_m":163773180.708406,
     "geom:bbox":"31.500484,26.5722,31.638468,26.749696",
     "geom:latitude":26.655786,
     "geom:longitude":31.56954,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SJ.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897286,
-    "wof:geomhash":"8298f6a13ac7174d3f156d14a4804990",
+    "wof:geomhash":"e86dd2849b885386f7a996522eaffa32",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092018399,
-    "wof:lastmodified":1627522088,
+    "wof:lastmodified":1695886552,
     "wof:name":"El-Maraghah",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/201/840/1/1092018401.geojson
+++ b/data/109/201/840/1/1092018401.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001292,
-    "geom:area_square_m":13811382.718689,
+    "geom:area_square_m":13811382.718684,
     "geom:bbox":"31.313896,30.132362,31.377592,30.173814",
     "geom:latitude":30.151653,
     "geom:longitude":31.345717,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897287,
-    "wof:geomhash":"e9813ba6f785dafaaf463123fface08f",
+    "wof:geomhash":"fdaa69618e81e2929352f8db01680f24",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092018401,
-    "wof:lastmodified":1627522088,
+    "wof:lastmodified":1695886553,
     "wof:name":"El-Marg",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/843/3/1092018433.geojson
+++ b/data/109/201/843/3/1092018433.geojson
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.MT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897289,
-    "wof:geomhash":"06ce1ce16c6d285bdb1fe99f54dc2a80",
+    "wof:geomhash":"cd1fe7efa65010d0dddeaf2ffe0021c1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092018433,
-    "wof:lastmodified":1627522088,
+    "wof:lastmodified":1695886553,
     "wof:name":"El-Matareyah",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/847/9/1092018479.geojson
+++ b/data/109/201/847/9/1092018479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003463,
-    "geom:area_square_m":36626667.125331,
+    "geom:area_square_m":36626667.125346,
     "geom:bbox":"31.979506,31.166839,32.061477,31.242063",
     "geom:latitude":31.200333,
     "geom:longitude":32.01655,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.DQ.MT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897291,
-    "wof:geomhash":"80e031bd9c1624190337daa8e4341578",
+    "wof:geomhash":"485247928064647ccf38f7f40e00c69b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092018479,
-    "wof:lastmodified":1627522088,
+    "wof:lastmodified":1695886553,
     "wof:name":"El-Matareyah",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/201/851/3/1092018513.geojson
+++ b/data/109/201/851/3/1092018513.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001366,
-    "geom:area_square_m":14898880.067314,
+    "geom:area_square_m":14898880.067316,
     "geom:bbox":"30.792605,28.088084,30.821329,28.136304",
     "geom:latitude":28.112037,
     "geom:longitude":30.806798,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.UO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897292,
-    "wof:geomhash":"f6f2c28ab8e84990d50ec5de8f457d9b",
+    "wof:geomhash":"74e5cbba51d7c965a8819059cd39f190",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092018513,
-    "wof:lastmodified":1627522095,
+    "wof:lastmodified":1695886566,
     "wof:name":"El-Menya El-Gedidah",
     "wof:parent_id":85671085,
     "wof:placetype":"county",

--- a/data/109/201/855/7/1092018557.geojson
+++ b/data/109/201/855/7/1092018557.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031392,
-    "geom:area_square_m":342464714.619904,
+    "geom:area_square_m":342464714.619848,
     "geom:bbox":"30.600079,27.970355,30.83629,28.204719",
     "geom:latitude":28.083561,
     "geom:longitude":30.705901,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MN.MM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897293,
-    "wof:geomhash":"24702f3501b9367aeec3e5a19ba03522",
+    "wof:geomhash":"624e738d5c037361465e1a875faeab18",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092018557,
-    "wof:lastmodified":1627522088,
+    "wof:lastmodified":1695886553,
     "wof:name":"El-Menya",
     "wof:parent_id":85671049,
     "wof:placetype":"county",

--- a/data/109/201/859/9/1092018599.geojson
+++ b/data/109/201/859/9/1092018599.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016281,
-    "geom:area_square_m":180262698.882118,
+    "geom:area_square_m":180262698.882132,
     "geom:bbox":"31.685662,26.34169,31.868789,26.562953",
     "geom:latitude":26.44031,
     "geom:longitude":31.772766,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SJ.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897295,
-    "wof:geomhash":"2448c4133e6da80776f8a3d6c8296192",
+    "wof:geomhash":"a718417b03835300b0676a08eb5b206e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092018599,
-    "wof:lastmodified":1627522088,
+    "wof:lastmodified":1695886553,
     "wof:name":"El-Monshaeh",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/201/864/9/1092018649.geojson
+++ b/data/109/201/864/9/1092018649.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007798,
-    "geom:area_square_m":82427162.492022,
+    "geom:area_square_m":82427162.492034,
     "geom:bbox":"29.965263,31.194371,30.087226,31.329745",
     "geom:latitude":31.256006,
     "geom:longitude":30.03214,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897296,
-    "wof:geomhash":"24af49a8cca4a92fee0b39cd35b0b1e8",
+    "wof:geomhash":"5b8ac636a5284445e83713b9b7997fb8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092018649,
-    "wof:lastmodified":1627522092,
+    "wof:lastmodified":1695886562,
     "wof:name":"El-Montazah",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/201/867/9/1092018679.geojson
+++ b/data/109/201/867/9/1092018679.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000072,
-    "geom:area_square_m":775817.295365,
+    "geom:area_square_m":775817.295364,
     "geom:bbox":"31.247244,30.046112,31.257647,30.057174",
     "geom:latitude":30.052232,
     "geom:longitude":31.252342,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897298,
-    "wof:geomhash":"5edd53c52ece0559c06a8dfc06638d55",
+    "wof:geomhash":"297139321e1fed1e1d8fa73efb4dd35a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092018679,
-    "wof:lastmodified":1627522093,
+    "wof:lastmodified":1695886562,
     "wof:name":"El-Mosky",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/872/5/1092018725.geojson
+++ b/data/109/201/872/5/1092018725.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.082941,
-    "geom:area_square_m":874861209.622261,
+    "geom:area_square_m":874861209.622242,
     "geom:bbox":"25.980463,31.311656,26.397076,31.614125",
     "geom:latitude":31.458023,
     "geom:longitude":26.164093,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MT.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897299,
-    "wof:geomhash":"b7939f42e769a28b5965a4b576479d46",
+    "wof:geomhash":"17d07567f64c4bb103b90a609a091f55",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092018725,
-    "wof:lastmodified":1627522095,
+    "wof:lastmodified":1695886566,
     "wof:name":"El-Negielah",
     "wof:parent_id":85671031,
     "wof:placetype":"county",

--- a/data/109/201/876/3/1092018763.geojson
+++ b/data/109/201/876/3/1092018763.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.063115,
-    "geom:area_square_m":672660060.744547,
+    "geom:area_square_m":672660060.744555,
     "geom:bbox":"30.227253,30.32745,30.665896,30.590036",
     "geom:latitude":30.478702,
     "geom:longitude":30.459406,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.UO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897301,
-    "wof:geomhash":"eebbe4be3773c9822a4723a6c586ad96",
+    "wof:geomhash":"094e69904da267779760127cad805cd9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092018763,
-    "wof:lastmodified":1627522095,
+    "wof:lastmodified":1695886566,
     "wof:name":"El-Nobareyah City",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/201/879/5/1092018795.geojson
+++ b/data/109/201/879/5/1092018795.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002134,
-    "geom:area_square_m":22827912.679502,
+    "geom:area_square_m":22827912.679497,
     "geom:bbox":"31.324949,30.079496,31.418496,30.149198",
     "geom:latitude":30.114816,
     "geom:longitude":31.365242,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.NO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897302,
-    "wof:geomhash":"c3733d433f237037262bd5633ba4dcc9",
+    "wof:geomhash":"b42c3cca168d9bdf409ab84d7f556dd9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092018795,
-    "wof:lastmodified":1627522095,
+    "wof:lastmodified":1695886566,
     "wof:name":"El-Nozhah",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/883/9/1092018839.geojson
+++ b/data/109/201/883/9/1092018839.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021342,
-    "geom:area_square_m":237815754.047008,
+    "geom:area_square_m":237815754.047035,
     "geom:bbox":"32.463708,25.540774,32.737329,25.817437",
     "geom:latitude":25.687654,
     "geom:longitude":32.625967,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.UQ.UM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897304,
-    "wof:geomhash":"a95bfb4c480c202b55f9cb8ba18af23e",
+    "wof:geomhash":"41036c33e552d9c9c659e493903e7319",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092018839,
-    "wof:lastmodified":1627522098,
+    "wof:lastmodified":1695886570,
     "wof:name":"El-Oksor",
     "wof:parent_id":85671097,
     "wof:placetype":"county",

--- a/data/109/201/889/1/1092018891.geojson
+++ b/data/109/201/889/1/1092018891.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001816,
-    "geom:area_square_m":19443405.985298,
+    "geom:area_square_m":19443405.985292,
     "geom:bbox":"31.14532,29.968127,31.209251,30.015762",
     "geom:latitude":29.993369,
     "geom:longitude":31.180647,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.JZ.AM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897305,
-    "wof:geomhash":"ea73bc7348069f0fe112fe1858942129",
+    "wof:geomhash":"b2bc1994114e4c897177c9f8fa0afdcb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092018891,
-    "wof:lastmodified":1627522093,
+    "wof:lastmodified":1695886562,
     "wof:name":"El-Omraneyah",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/201/893/5/1092018935.geojson
+++ b/data/109/201/893/5/1092018935.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010499,
-    "geom:area_square_m":112184302.588285,
+    "geom:area_square_m":112184302.588226,
     "geom:bbox":"31.087954,30.127512,31.234319,30.297316",
     "geom:latitude":30.218425,
     "geom:longitude":31.149799,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QL.KN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897306,
-    "wof:geomhash":"3fbdc4322dcfc5c952ac9bfc4c7b39f5",
+    "wof:geomhash":"70ced24595e6e3e56d3fbdf1c2cacde2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092018935,
-    "wof:lastmodified":1627522100,
+    "wof:lastmodified":1695886572,
     "wof:name":"El-Qanater El-Khaireyah",
     "wof:parent_id":85671003,
     "wof:placetype":"county",

--- a/data/109/201/897/9/1092018979.geojson
+++ b/data/109/201/897/9/1092018979.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001711,
-    "geom:area_square_m":18201264.101297,
+    "geom:area_square_m":18201264.101295,
     "geom:bbox":"31.441199,30.614429,31.502196,30.66181",
     "geom:latitude":30.635853,
     "geom:longitude":31.469554,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SQ.KE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897308,
-    "wof:geomhash":"c57f7f94bf45d5ab90340e8af6f4a480",
+    "wof:geomhash":"7a7aa806b08c5cc3c2d49bcb513d121c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092018979,
-    "wof:lastmodified":1627522093,
+    "wof:lastmodified":1695886562,
     "wof:name":"El-Qanayat",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/201/902/7/1092019027.geojson
+++ b/data/109/201/902/7/1092019027.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013331,
-    "geom:area_square_m":142003682.545858,
+    "geom:area_square_m":142003682.545879,
     "geom:bbox":"32.302638,30.266038,32.646806,30.954549",
     "geom:latitude":30.520818,
     "geom:longitude":32.381917,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IS.EK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897310,
-    "wof:geomhash":"64cb9bd964be445162a6d8b936f4fc0a",
+    "wof:geomhash":"78b8cd9d4949cd776cfea206a9bccb90",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092019027,
-    "wof:lastmodified":1627522093,
+    "wof:lastmodified":1695886563,
     "wof:name":"El-Qantarah Sharq",
     "wof:parent_id":85670989,
     "wof:placetype":"county",

--- a/data/109/201/907/1/1092019071.geojson
+++ b/data/109/201/907/1/1092019071.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046396,
-    "geom:area_square_m":493005192.88513,
+    "geom:area_square_m":493005192.885165,
     "geom:bbox":"32.122264,30.590276,32.346132,30.916778",
     "geom:latitude":30.756638,
     "geom:longitude":32.244893,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IS.KN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897311,
-    "wof:geomhash":"60ae37631ad33bd6cb85909b60d25526",
+    "wof:geomhash":"4681805f63eece5cdcfc33103363b598",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092019071,
-    "wof:lastmodified":1627522093,
+    "wof:lastmodified":1695886563,
     "wof:name":"El-Qantarah",
     "wof:parent_id":85670989,
     "wof:placetype":"county",

--- a/data/109/201/910/5/1092019105.geojson
+++ b/data/109/201/910/5/1092019105.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002036,
-    "geom:area_square_m":21660796.288482,
+    "geom:area_square_m":21660796.288483,
     "geom:bbox":"31.719023,30.590606,31.780502,30.646721",
     "geom:latitude":30.622642,
     "geom:longitude":31.747594,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SQ.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897313,
-    "wof:geomhash":"0272d47c5832e6d2a45edc34ec566e5c",
+    "wof:geomhash":"f2950a3214471fa3650b0cd83ba11623",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092019105,
-    "wof:lastmodified":1627522095,
+    "wof:lastmodified":1695886566,
     "wof:name":"El-Qareen",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/201/914/7/1092019147.geojson
+++ b/data/109/201/914/7/1092019147.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.184051,
-    "geom:area_square_m":1957509494.534693,
+    "geom:area_square_m":1957509494.534647,
     "geom:bbox":"33.899048,30.282877,34.645544,30.959837",
     "geom:latitude":30.673578,
     "geom:longitude":34.325429,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SS.RF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897314,
-    "wof:geomhash":"4e9dfe5d6a0b63031703c108bce183c9",
+    "wof:geomhash":"9cfc702dc01a9267a4ba0564b7382e7f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092019147,
-    "wof:lastmodified":1627522093,
+    "wof:lastmodified":1695886563,
     "wof:name":"El-Qaseemah",
     "wof:parent_id":85671093,
     "wof:placetype":"county",

--- a/data/109/201/919/3/1092019193.geojson
+++ b/data/109/201/919/3/1092019193.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.091302,
-    "geom:area_square_m":12169417235.82679,
+    "geom:area_square_m":12169417235.82667,
     "geom:bbox":"33.341598,25.101429,34.815631,26.228186",
     "geom:latitude":25.598524,
     "geom:longitude":34.016486,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BA.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897316,
-    "wof:geomhash":"e5f375bda3093b55b546fc19ac1385b3",
+    "wof:geomhash":"9836cee72d96b9158fb1a52b8d0cad96",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092019193,
-    "wof:lastmodified":1627522093,
+    "wof:lastmodified":1695886563,
     "wof:name":"El-Qoseir",
     "wof:parent_id":85671085,
     "wof:placetype":"county",

--- a/data/109/201/922/9/1092019229.geojson
+++ b/data/109/201/922/9/1092019229.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017508,
-    "geom:area_square_m":192207919.754795,
+    "geom:area_square_m":192207919.754832,
     "geom:bbox":"30.715756,27.305889,30.896311,27.518787",
     "geom:latitude":27.39727,
     "geom:longitude":30.807666,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.AT.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897317,
-    "wof:geomhash":"1cd3730a9e94fefea42486a6e4b3e01e",
+    "wof:geomhash":"f71521c0c47f479f14e9e252cc88e0b4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092019229,
-    "wof:lastmodified":1627522095,
+    "wof:lastmodified":1695886566,
     "wof:name":"El-Qoweisah",
     "wof:parent_id":85671069,
     "wof:placetype":"county",

--- a/data/109/201/927/3/1092019273.geojson
+++ b/data/109/201/927/3/1092019273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012037,
-    "geom:area_square_m":127458148.524759,
+    "geom:area_square_m":127458148.524783,
     "geom:bbox":"30.507086,31.034651,30.705698,31.1679",
     "geom:latitude":31.092582,
     "geom:longitude":30.599887,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BH.RH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897319,
-    "wof:geomhash":"81d525e34a459c53ccbea6377cfb1261",
+    "wof:geomhash":"09e4695ada95e63a37765b8fdf146926",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092019273,
-    "wof:lastmodified":1627522093,
+    "wof:lastmodified":1695886563,
     "wof:name":"El-Rahmaneyah",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/201/931/5/1092019315.geojson
+++ b/data/109/201/931/5/1092019315.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003386,
-    "geom:area_square_m":35816206.667605,
+    "geom:area_square_m":35816206.667607,
     "geom:bbox":"29.939814,31.171097,30.046933,31.247042",
     "geom:latitude":31.203223,
     "geom:longitude":29.992125,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.RS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897320,
-    "wof:geomhash":"ae2ea3355922846d4f292aba90c42608",
+    "wof:geomhash":"a0b06649efb5e664481e8851f2814f12",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092019315,
-    "wof:lastmodified":1627522095,
+    "wof:lastmodified":1695886566,
     "wof:name":"El-Raml",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/201/936/1/1092019361.geojson
+++ b/data/109/201/936/1/1092019361.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025435,
-    "geom:area_square_m":268678655.746329,
+    "geom:area_square_m":268678655.746354,
     "geom:bbox":"30.841472,31.183531,31.010051,31.455101",
     "geom:latitude":31.320672,
     "geom:longitude":30.925639,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.KS.RE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897322,
-    "wof:geomhash":"2cc37f0d18449b66281cc44cad69681c",
+    "wof:geomhash":"4820c972ac56755f1914946f7daf4ffd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092019361,
-    "wof:lastmodified":1627522096,
+    "wof:lastmodified":1695886566,
     "wof:name":"El-Reyad",
     "wof:parent_id":85671057,
     "wof:placetype":"county",

--- a/data/109/201/940/5/1092019405.geojson
+++ b/data/109/201/940/5/1092019405.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025276,
-    "geom:area_square_m":269652027.066076,
+    "geom:area_square_m":269652027.066082,
     "geom:bbox":"30.540842,30.308303,30.872711,30.460365",
     "geom:latitude":30.370796,
     "geom:longitude":30.703079,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MF.EC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897323,
-    "wof:geomhash":"7b97d2200c90f6468ea9a08cbe2e973f",
+    "wof:geomhash":"61b98c40ab9b135eff62ec84849b3d1f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092019405,
-    "wof:lastmodified":1627522101,
+    "wof:lastmodified":1695886573,
     "wof:name":"El-Sadat City",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/201/945/3/1092019453.geojson
+++ b/data/109/201/945/3/1092019453.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013598,
-    "geom:area_square_m":146161990.258991,
+    "geom:area_square_m":146161990.259012,
     "geom:bbox":"31.248718,29.465995,31.335292,29.767995",
     "geom:latitude":29.625433,
     "geom:longitude":31.294391,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.JZ.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897325,
-    "wof:geomhash":"6b5fde473c9496469be0eef29fa29d5d",
+    "wof:geomhash":"1e14f3128f386bde1ed7479d4ed7abd4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092019453,
-    "wof:lastmodified":1627522096,
+    "wof:lastmodified":1695886567,
     "wof:name":"El-Saf",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/201/949/9/1092019499.geojson
+++ b/data/109/201/949/9/1092019499.geojson
@@ -82,12 +82,13 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.SL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897326,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"e340f17b7460dd59756cce318df577dc",
+    "wof:geomhash":"384cc29acc345b6eec2e854e89dce278",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1092019499,
-    "wof:lastmodified":1627522096,
+    "wof:lastmodified":1695886567,
     "wof:name":"El-Sahel",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/953/5/1092019535.geojson
+++ b/data/109/201/953/5/1092019535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003674,
-    "geom:area_square_m":39280731.584144,
+    "geom:area_square_m":39280731.584146,
     "geom:bbox":"31.360538,30.135735,31.465639,30.192982",
     "geom:latitude":30.167781,
     "geom:longitude":31.415219,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897328,
-    "wof:geomhash":"8b2c47d90bcd4b5f8c0a3ad83b5f4e96",
+    "wof:geomhash":"dba39819f1b3b34320d93e5ef7d623de",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092019535,
-    "wof:lastmodified":1627522096,
+    "wof:lastmodified":1695886567,
     "wof:name":"El-Salam",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/957/7/1092019577.geojson
+++ b/data/109/201/957/7/1092019577.geojson
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SQ.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897329,
-    "wof:geomhash":"352dac42ced77078e49da8ce1180cfc7",
+    "wof:geomhash":"c541fbd4d405e8c91d5b3eff1f74476c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092019577,
-    "wof:lastmodified":1627522089,
+    "wof:lastmodified":1695886556,
     "wof:name":"El-Salheyah El-Gedidah",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/201/962/1/1092019621.geojson
+++ b/data/109/201/962/1/1092019621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.256347,
-    "geom:area_square_m":13384654462.006969,
+    "geom:area_square_m":13384654462.00675,
     "geom:bbox":"24.692899,29.45328,25.603806,31.670021",
     "geom:latitude":30.499252,
     "geom:longitude":25.194534,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MT.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897331,
-    "wof:geomhash":"ac2f3041b4f86e32605ac4a964f3dc2e",
+    "wof:geomhash":"0377545ba434fb953430d783ddc3f92f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092019621,
-    "wof:lastmodified":1627522096,
+    "wof:lastmodified":1695886567,
     "wof:name":"El-Saloom",
     "wof:parent_id":85671031,
     "wof:placetype":"county",

--- a/data/109/201/964/9/1092019649.geojson
+++ b/data/109/201/964/9/1092019649.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020649,
-    "geom:area_square_m":219385515.187308,
+    "geom:area_square_m":219385515.187355,
     "geom:bbox":"31.032088,30.665896,31.177695,30.882324",
     "geom:latitude":30.76843,
     "geom:longitude":31.114099,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.GH.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897332,
-    "wof:geomhash":"335a8dafd73298e08c804d1e71407217",
+    "wof:geomhash":"0d2c0fbacbe7d788da80cd9df089383f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092019649,
-    "wof:lastmodified":1627522093,
+    "wof:lastmodified":1695886563,
     "wof:name":"El-Santah",
     "wof:parent_id":85670985,
     "wof:placetype":"county",

--- a/data/109/201/969/3/1092019693.geojson
+++ b/data/109/201/969/3/1092019693.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000351,
-    "geom:area_square_m":3753010.32994,
+    "geom:area_square_m":3753010.329938,
     "geom:bbox":"31.229409,30.020987,31.253237,30.041425",
     "geom:latitude":30.031076,
     "geom:longitude":31.241919,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.EZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897334,
-    "wof:geomhash":"34ab1445fc10bf5343c2ba395f77f195",
+    "wof:geomhash":"63c749bef290ce436830cbc07245397f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092019693,
-    "wof:lastmodified":1627522096,
+    "wof:lastmodified":1695886567,
     "wof:name":"El-Sayedah Zeinab",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/974/1/1092019741.geojson
+++ b/data/109/201/974/1/1092019741.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028911,
-    "geom:area_square_m":306808007.993549,
+    "geom:area_square_m":306808007.993513,
     "geom:bbox":"31.343727,30.806891,31.645439,30.96912",
     "geom:latitude":30.880406,
     "geom:longitude":31.488339,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.DQ.SE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897335,
-    "wof:geomhash":"aa207258edf520c9074c3205b4d23c22",
+    "wof:geomhash":"7c1eeb61ff4d58257842a71cdae522c7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092019741,
-    "wof:lastmodified":1627522088,
+    "wof:lastmodified":1695886553,
     "wof:name":"El-Senbelawein",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/201/978/7/1092019787.geojson
+++ b/data/109/201/978/7/1092019787.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.053869,
-    "geom:area_square_m":57549330167.359749,
+    "geom:area_square_m":57549330167.360077,
     "geom:bbox":"33.418624,21.999539,36.907099,24.165294",
     "geom:latitude":22.931636,
     "geom:longitude":34.719853,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BA.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897337,
-    "wof:geomhash":"4598096c286516c54e9ec5eadaf72c70",
+    "wof:geomhash":"3579ceb932240390286404ee33c8dfa7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092019787,
-    "wof:lastmodified":1627522102,
+    "wof:lastmodified":1695886574,
     "wof:name":"El-Shalateen",
     "wof:parent_id":85671085,
     "wof:placetype":"county",

--- a/data/109/201/983/1/1092019831.geojson
+++ b/data/109/201/983/1/1092019831.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000305,
-    "geom:area_square_m":3261793.09842,
+    "geom:area_square_m":3261793.098421,
     "geom:bbox":"31.253323,30.066688,31.271078,30.098501",
     "geom:latitude":30.080711,
     "geom:longitude":31.261695,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897338,
-    "wof:geomhash":"9ad0abe360f13ea7b683a28c3429ec7f",
+    "wof:geomhash":"039ca9def36cf3e31c91c395722b6cbd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092019831,
-    "wof:lastmodified":1627522088,
+    "wof:lastmodified":1695886553,
     "wof:name":"El-Sharabeyah",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/201/987/7/1092019877.geojson
+++ b/data/109/201/987/7/1092019877.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000293,
-    "geom:area_square_m":3093626.914733,
+    "geom:area_square_m":3093626.914734,
     "geom:bbox":"32.288192,31.243959,32.317122,31.27355",
     "geom:latitude":31.26112,
     "geom:longitude":32.301958,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BS.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897340,
-    "wof:geomhash":"f84e8f0fbfe41b0b38956f476036c6ea",
+    "wof:geomhash":"f0cdef8f7c944572e776b3fc8c98a359",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092019877,
-    "wof:lastmodified":1627522096,
+    "wof:lastmodified":1695886567,
     "wof:name":"El-Sharq",
     "wof:parent_id":85671021,
     "wof:placetype":"county",

--- a/data/109/201/992/1/1092019921.geojson
+++ b/data/109/201/992/1/1092019921.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069112,
-    "geom:area_square_m":731946243.498379,
+    "geom:area_square_m":731946243.498396,
     "geom:bbox":"33.899048,30.931809,34.204209,31.264804",
     "geom:latitude":31.074969,
     "geom:longitude":34.064049,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SS.SZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897341,
-    "wof:geomhash":"6b9368fcce24ae6910d3e26e1f906456",
+    "wof:geomhash":"fe11902c9c32e1b891c4db5e18fc45af",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092019921,
-    "wof:lastmodified":1627522102,
+    "wof:lastmodified":1695886574,
     "wof:name":"El-Sheikh Zoweid",
     "wof:parent_id":85671093,
     "wof:placetype":"county",

--- a/data/109/201/994/9/1092019949.geojson
+++ b/data/109/201/994/9/1092019949.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015074,
-    "geom:area_square_m":160437048.659783,
+    "geom:area_square_m":160437048.659806,
     "geom:bbox":"30.788554,30.519118,30.955402,30.67575",
     "geom:latitude":30.598084,
     "geom:longitude":30.864176,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MF.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897343,
-    "wof:geomhash":"4611ccefa2362f328ceea6dc3d5ee1f4",
+    "wof:geomhash":"82c75d95a6982a68628883072c055983",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092019949,
-    "wof:lastmodified":1627522102,
+    "wof:lastmodified":1695886574,
     "wof:name":"El-Shohada",
     "wof:parent_id":85670995,
     "wof:placetype":"county",

--- a/data/109/201/999/7/1092019997.geojson
+++ b/data/109/201/999/7/1092019997.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0016,
-    "geom:area_square_m":17136679.1397,
+    "geom:area_square_m":17136679.139706,
     "geom:bbox":"32.538079,29.959809,32.583834,30.034888",
     "geom:latitude":30.00917,
     "geom:longitude":32.557886,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SW.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897344,
-    "wof:geomhash":"6a3f98cdca787a4b1fc6318dff4406f7",
+    "wof:geomhash":"e7fc1ded19181694ceca47d107b2dcd4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092019997,
-    "wof:lastmodified":1627522103,
+    "wof:lastmodified":1695886576,
     "wof:name":"El-Suez",
     "wof:parent_id":85671013,
     "wof:placetype":"county",

--- a/data/109/202/003/9/1092020039.geojson
+++ b/data/109/202/003/9/1092020039.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020174,
-    "geom:area_square_m":214855769.760914,
+    "geom:area_square_m":214855769.760921,
     "geom:bbox":"31.754936,30.460765,32.07393,30.586251",
     "geom:latitude":30.535693,
     "geom:longitude":31.896974,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IS.TE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897346,
-    "wof:geomhash":"38ec30e6502891202e7f32574ee3839d",
+    "wof:geomhash":"491125f7053c1d5597079ae10007d223",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092020039,
-    "wof:lastmodified":1627522093,
+    "wof:lastmodified":1695886563,
     "wof:name":"El-Tal El-Kebeer",
     "wof:parent_id":85670989,
     "wof:placetype":"county",

--- a/data/109/202/007/5/1092020075.geojson
+++ b/data/109/202/007/5/1092020075.geojson
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.TB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897347,
-    "wof:geomhash":"1b52e8d5399b2c3b5ddef158b9bd7ade",
+    "wof:geomhash":"cde15f6cd6c46520d2b187f130f169d9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092020075,
-    "wof:lastmodified":1627522096,
+    "wof:lastmodified":1695886567,
     "wof:name":"El-Tebeen",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/011/3/1092020113.geojson
+++ b/data/109/202/011/3/1092020113.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.268564,
-    "geom:area_square_m":2925991381.397625,
+    "geom:area_square_m":2925991381.397593,
     "geom:bbox":"33.361745,27.827362,34.197204,28.496001",
     "geom:latitude":28.224736,
     "geom:longitude":33.841252,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.JS.TO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897349,
-    "wof:geomhash":"23341da0ec03be4584c6f12e8b6d1c0c",
+    "wof:geomhash":"261a897ea4eee105ef043631e47eaff9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092020113,
-    "wof:lastmodified":1627522096,
+    "wof:lastmodified":1695886567,
     "wof:name":"El-Tour",
     "wof:parent_id":85671089,
     "wof:placetype":"county",

--- a/data/109/202/015/5/1092020155.geojson
+++ b/data/109/202/015/5/1092020155.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008506,
-    "geom:area_square_m":92487689.677959,
+    "geom:area_square_m":92487689.677952,
     "geom:bbox":"28.709923,28.369773,29.105284,28.593464",
     "geom:latitude":28.442395,
     "geom:longitude":28.856477,
@@ -82,9 +82,10 @@
     "wof:concordances":{
         "hasc:id":"EG.JZ.WB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897350,
-    "wof:geomhash":"a4de9080b95347133b92798f3908887b",
+    "wof:geomhash":"c9304b62c0874830e270aaef2246c2b3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1092020155,
-    "wof:lastmodified":1627522088,
+    "wof:lastmodified":1695886554,
     "wof:name":"El-Wahat El-Bahareyah",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/202/020/1/1092020201.geojson
+++ b/data/109/202/020/1/1092020201.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":21.042836,
-    "geom:area_square_m":237362581081.583252,
+    "geom:area_square_m":237362581081.583496,
     "geom:bbox":"25.0,22.0,30.196317,26.288819",
     "geom:latitude":24.153939,
     "geom:longitude":27.455035,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.WJ.WD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897351,
-    "wof:geomhash":"3896baf2ef78e6f3fad914b0a07982b1",
+    "wof:geomhash":"b2ec4f615d3414d25f4194ad1827dce1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092020201,
-    "wof:lastmodified":1627522088,
+    "wof:lastmodified":1695886554,
     "wof:name":"El-Wahat El-Dakhlah",
     "wof:parent_id":85671071,
     "wof:placetype":"county",

--- a/data/109/202/022/3/1092020223.geojson
+++ b/data/109/202/022/3/1092020223.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":11.174158,
-    "geom:area_square_m":125793153503.980225,
+    "geom:area_square_m":125793153503.980377,
     "geom:bbox":"29.869777,22.0,32.743283,27.161601",
     "geom:latitude":24.405636,
     "geom:longitude":31.13675,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.WJ.WK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897353,
-    "wof:geomhash":"33eee64a163e3c7d1dc8092d59ece4d2",
+    "wof:geomhash":"67e41a73a5dd197ab6e8ba89b5458c22",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092020223,
-    "wof:lastmodified":1627522088,
+    "wof:lastmodified":1695886554,
     "wof:name":"El-Wahat El-Khargah",
     "wof:parent_id":85671071,
     "wof:placetype":"county",

--- a/data/109/202/027/3/1092020273.geojson
+++ b/data/109/202/027/3/1092020273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000462,
-    "geom:area_square_m":4946592.421601,
+    "geom:area_square_m":4946592.421599,
     "geom:bbox":"31.270026,30.057065,31.302597,30.087751",
     "geom:latitude":30.073497,
     "geom:longitude":31.285654,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.WA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897354,
-    "wof:geomhash":"be77add3db1766a57546ec90acef681c",
+    "wof:geomhash":"889c1db77cacfa3e995950ef344565aa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092020273,
-    "wof:lastmodified":1627522093,
+    "wof:lastmodified":1695886563,
     "wof:name":"El-Waily",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/031/5/1092020315.geojson
+++ b/data/109/202/031/5/1092020315.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004574,
-    "geom:area_square_m":50791887.123889,
+    "geom:area_square_m":50791887.123883,
     "geom:bbox":"32.351718,26.054884,32.552013,26.116309",
     "geom:latitude":26.089199,
     "geom:longitude":32.447891,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QN.WA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897356,
-    "wof:geomhash":"ba1db69df13f549537eecae6ae902ba2",
+    "wof:geomhash":"e822e7afb52a6ed27365721407f3bfd8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092020315,
-    "wof:lastmodified":1627522088,
+    "wof:lastmodified":1695886554,
     "wof:name":"El-Waqf",
     "wof:parent_id":85671075,
     "wof:placetype":"county",

--- a/data/109/202/034/9/1092020349.geojson
+++ b/data/109/202/034/9/1092020349.geojson
@@ -82,12 +82,13 @@
     "wof:concordances":{
         "hasc:id":"EG.JZ.WR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897357,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"4a63009047c1192732bc9e7e532a5d00",
+    "wof:geomhash":"395bb634e06a5afbfefc38717f1aeef1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1092020349,
-    "wof:lastmodified":1627522093,
+    "wof:lastmodified":1695886563,
     "wof:name":"El-Warraq",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/202/039/5/1092020395.geojson
+++ b/data/109/202/039/5/1092020395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019047,
-    "geom:area_square_m":205388232.095113,
+    "geom:area_square_m":205388232.095183,
     "geom:bbox":"31.040012,29.213097,31.231901,29.429033",
     "geom:latitude":29.300167,
     "geom:longitude":31.1614,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BN.WA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897359,
-    "wof:geomhash":"1342470c34c34ff4a94b903a538a9c09",
+    "wof:geomhash":"b06c5e081377bc34a8f93073c577f9c7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092020395,
-    "wof:lastmodified":1627522093,
+    "wof:lastmodified":1695886563,
     "wof:name":"El-Wasty",
     "wof:parent_id":85671053,
     "wof:placetype":"county",

--- a/data/109/202/043/7/1092020437.geojson
+++ b/data/109/202/043/7/1092020437.geojson
@@ -82,12 +82,13 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.ZM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897360,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"86025deaf599267a7ccc1b21874aff6c",
+    "wof:geomhash":"cdd077a2d53f273dc3abe220e898ec33",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1092020437,
-    "wof:lastmodified":1627522104,
+    "wof:lastmodified":1695886577,
     "wof:name":"El-Zamalek",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/047/9/1092020479.geojson
+++ b/data/109/202/047/9/1092020479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029681,
-    "geom:area_square_m":315933420.0031,
+    "geom:area_square_m":315933420.003097,
     "geom:bbox":"31.341119,30.483321,31.651543,30.700104",
     "geom:latitude":30.590807,
     "geom:longitude":31.49723,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SQ.ZA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897361,
-    "wof:geomhash":"900d22caca8971e1c00a1cafe0343089",
+    "wof:geomhash":"7d397b6fb4c7b78b757e17a37fdedfa5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092020479,
-    "wof:lastmodified":1627522103,
+    "wof:lastmodified":1695886576,
     "wof:name":"El-Zaqazeeq",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/202/050/9/1092020509.geojson
+++ b/data/109/202/050/9/1092020509.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006488,
-    "geom:area_square_m":68604989.502889,
+    "geom:area_square_m":68604989.502871,
     "geom:bbox":"31.592035,31.1673,31.773278,31.267033",
     "geom:latitude":31.226837,
     "geom:longitude":31.675044,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.DT.ZR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897363,
-    "wof:geomhash":"ca2d8117afdd896fc1f12df41e83e78a",
+    "wof:geomhash":"1c773d7108dff4de2104fc5002e5eb7b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092020509,
-    "wof:lastmodified":1627522088,
+    "wof:lastmodified":1695886554,
     "wof:name":"El-Zarqah",
     "wof:parent_id":85671025,
     "wof:placetype":"county",

--- a/data/109/202/055/1/1092020551.geojson
+++ b/data/109/202/055/1/1092020551.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000442,
-    "geom:area_square_m":4723775.146592,
+    "geom:area_square_m":4723775.146594,
     "geom:bbox":"31.25711,30.083054,31.283537,30.113992",
     "geom:latitude":30.101079,
     "geom:longitude":31.269687,
@@ -82,12 +82,13 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.ZK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897364,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"4b35fa9dcc74d5739db3ab476607bc85",
+    "wof:geomhash":"62fb0891493d0ff954247564be959092",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1092020551,
-    "wof:lastmodified":1627522093,
+    "wof:lastmodified":1695886564,
     "wof:name":"El-Zawyah El-Hamra",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/059/9/1092020599.geojson
+++ b/data/109/202/059/9/1092020599.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000713,
-    "geom:area_square_m":7631372.362755,
+    "geom:area_square_m":7631372.362754,
     "geom:bbox":"31.282659,30.086116,31.324949,30.116677",
     "geom:latitude":30.104348,
     "geom:longitude":31.302853,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.ZY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897366,
-    "wof:geomhash":"b56c9328d2fdaa7468831865e8a5489b",
+    "wof:geomhash":"b0efc7c07b1b8cf7491bf8779cce3c55",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092020599,
-    "wof:lastmodified":1627522104,
+    "wof:lastmodified":1695886577,
     "wof:name":"El-Zaytoon",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/063/1/1092020631.geojson
+++ b/data/109/202/063/1/1092020631.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027412,
-    "geom:area_square_m":293026677.645261,
+    "geom:area_square_m":293026677.645013,
     "geom:bbox":"30.808799,29.996262,31.192797,30.342287",
     "geom:latitude":30.174784,
     "geom:longitude":31.023679,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.JZ.EK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897367,
-    "wof:geomhash":"0c337eea9dd48e5ad5985ed2bb7cad98",
+    "wof:geomhash":"5aabc9c97d0d15b2c9af7a356e40d156",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092020631,
-    "wof:lastmodified":1627522097,
+    "wof:lastmodified":1695886568,
     "wof:name":"Embabah",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/202/068/3/1092020683.geojson
+++ b/data/109/202/068/3/1092020683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000689,
-    "geom:area_square_m":7368645.878015,
+    "geom:area_square_m":7368645.878013,
     "geom:bbox":"31.182281,30.067161,31.230103,30.089614",
     "geom:latitude":30.078633,
     "geom:longitude":31.20647,
@@ -82,12 +82,13 @@
     "wof:concordances":{
         "hasc:id":"EG.JZ.EM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897369,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"e57c0e7ae23e1f79e7a98c531cb93a5a",
+    "wof:geomhash":"394ffaa1246679d371d9645ce3c17d6c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1092020683,
-    "wof:lastmodified":1627522097,
+    "wof:lastmodified":1695886568,
     "wof:name":"Embabah",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/202/072/1/1092020721.geojson
+++ b/data/109/202/072/1/1092020721.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022024,
-    "geom:area_square_m":246098766.519382,
+    "geom:area_square_m":246098766.51936,
     "geom:bbox":"32.452363,25.181794,32.663067,25.543322",
     "geom:latitude":25.353645,
     "geom:longitude":32.541544,
@@ -170,9 +170,10 @@
     "wof:concordances":{
         "hasc:id":"EG.UQ.IS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897371,
-    "wof:geomhash":"81c7b884f0e8394013e98331147c65e7",
+    "wof:geomhash":"1308233d9afa4450eaa2f0524dece578",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -182,7 +183,7 @@
         }
     ],
     "wof:id":1092020721,
-    "wof:lastmodified":1602720866,
+    "wof:lastmodified":1695886295,
     "wof:name":"Esna",
     "wof:parent_id":85671075,
     "wof:placetype":"county",

--- a/data/109/202/074/9/1092020749.geojson
+++ b/data/109/202/074/9/1092020749.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028662,
-    "geom:area_square_m":304152074.008787,
+    "geom:area_square_m":304152074.008778,
     "geom:bbox":"30.525402,30.789232,30.792552,30.972074",
     "geom:latitude":30.884829,
     "geom:longitude":30.66173,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BH.EB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897372,
-    "wof:geomhash":"b2633732b5566f7421283637d93124a0",
+    "wof:geomhash":"310e365120d572f48f3f9f7a7f248c8a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092020749,
-    "wof:lastmodified":1627522097,
+    "wof:lastmodified":1695886568,
     "wof:name":"Etay El-Barood",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/202/078/9/1092020789.geojson
+++ b/data/109/202/078/9/1092020789.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004945,
-    "geom:area_square_m":54958270.077013,
+    "geom:area_square_m":54958270.076997,
     "geom:bbox":"32.776758,25.943171,32.849786,26.053207",
     "geom:latitude":26.000577,
     "geom:longitude":32.812271,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QN.QA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897374,
-    "wof:geomhash":"98a59e7c55c1a4bbcb371dd9b2fbf018",
+    "wof:geomhash":"b389fdd2606a3689fe901e1c6303cf9c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092020789,
-    "wof:lastmodified":1627522096,
+    "wof:lastmodified":1695886567,
     "wof:name":"Faqat",
     "wof:parent_id":85671075,
     "wof:placetype":"county",

--- a/data/109/202/083/3/1092020833.geojson
+++ b/data/109/202/083/3/1092020833.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039705,
-    "geom:area_square_m":421923202.438338,
+    "geom:area_square_m":421923202.438255,
     "geom:bbox":"31.712792,30.614156,32.05507,30.902865",
     "geom:latitude":30.752994,
     "geom:longitude":31.855981,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SQ.FM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897375,
-    "wof:geomhash":"3ca0a7042eb7e4f9e6e961a837670095",
+    "wof:geomhash":"19cd17bef089319752a0f2eff480d6d4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092020833,
-    "wof:lastmodified":1627522096,
+    "wof:lastmodified":1695886567,
     "wof:name":"Faqoos",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/202/086/5/1092020865.geojson
+++ b/data/109/202/086/5/1092020865.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010892,
-    "geom:area_square_m":115064663.767781,
+    "geom:area_square_m":115064663.767793,
     "geom:bbox":"31.661956,31.24649,31.807694,31.394237",
     "geom:latitude":31.313969,
     "geom:longitude":31.743828,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.DT.FA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897377,
-    "wof:geomhash":"b8c94e6355b6e92a86ba8d5835736ab7",
+    "wof:geomhash":"6553ed3a1a1b2aea6cf202592f44585d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092020865,
-    "wof:lastmodified":1627522096,
+    "wof:lastmodified":1695886568,
     "wof:name":"Farasko",
     "wof:parent_id":85671025,
     "wof:placetype":"county",

--- a/data/109/202/090/3/1092020903.geojson
+++ b/data/109/202/090/3/1092020903.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005798,
-    "geom:area_square_m":64415252.238586,
+    "geom:area_square_m":64415252.238599,
     "geom:bbox":"32.106914,25.996412,32.195846,26.106375",
     "geom:latitude":26.04944,
     "geom:longitude":32.15636,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QN.FR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897379,
-    "wof:geomhash":"1684b4879af2eebfacdb90d21ccbfd79",
+    "wof:geomhash":"e80e2733607783d00118888909c6ffa8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092020903,
-    "wof:lastmodified":1627522096,
+    "wof:lastmodified":1695886568,
     "wof:name":"Farshoot",
     "wof:parent_id":85671075,
     "wof:placetype":"county",

--- a/data/109/202/094/5/1092020945.geojson
+++ b/data/109/202/094/5/1092020945.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009129,
-    "geom:area_square_m":97378082.219021,
+    "geom:area_square_m":97378082.219034,
     "geom:bbox":"32.273777,30.250081,32.432129,30.508038",
     "geom:latitude":30.379333,
     "geom:longitude":32.328471,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IS.FA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897380,
-    "wof:geomhash":"1725066c7c0a7961d0be4789bc60bbfc",
+    "wof:geomhash":"71083b7d20627d541be7a559bed885e4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1092020945,
-    "wof:lastmodified":1627522096,
+    "wof:lastmodified":1695886568,
     "wof:name":"Fayed",
     "wof:parent_id":85670989,
     "wof:placetype":"county",

--- a/data/109/202/097/9/1092020979.geojson
+++ b/data/109/202/097/9/1092020979.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006654,
-    "geom:area_square_m":71218233.602341,
+    "geom:area_square_m":71218233.602335,
     "geom:bbox":"32.445605,29.980157,32.544488,30.119243",
     "geom:latitude":30.048384,
     "geom:longitude":32.492731,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SW.FI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897382,
-    "wof:geomhash":"9c8b45ceebfe02c0c738cbad463d898c",
+    "wof:geomhash":"c8902ecb8606df4e5a550c440dee3473",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092020979,
-    "wof:lastmodified":1627522096,
+    "wof:lastmodified":1695886568,
     "wof:name":"Feisal",
     "wof:parent_id":85671013,
     "wof:placetype":"county",

--- a/data/109/202/100/1/1092021001.geojson
+++ b/data/109/202/100/1/1092021001.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003109,
-    "geom:area_square_m":32881530.245956,
+    "geom:area_square_m":32881530.24595,
     "geom:bbox":"32.305458,31.12503,32.345935,31.266569",
     "geom:latitude":31.206439,
     "geom:longitude":32.320825,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BS.PM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897383,
-    "wof:geomhash":"c4d2ff84cf53b9cd87181812db2c7cc3",
+    "wof:geomhash":"3bf195e0e0cfe912c8ea2de5b7e3b997",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092021001,
-    "wof:lastmodified":1627522097,
+    "wof:lastmodified":1695886568,
     "wof:name":"Fouad Port",
     "wof:parent_id":85671021,
     "wof:placetype":"county",

--- a/data/109/202/104/5/1092021045.geojson
+++ b/data/109/202/104/5/1092021045.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009238,
-    "geom:area_square_m":97683265.148103,
+    "geom:area_square_m":97683265.148108,
     "geom:bbox":"30.499851,31.169492,30.670279,31.282797",
     "geom:latitude":31.226457,
     "geom:longitude":30.579152,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.KS.FO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897385,
-    "wof:geomhash":"14a08a76e50ac8130b8b75528d9e2f6a",
+    "wof:geomhash":"1632a4bba914b61b889b1531755892be",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092021045,
-    "wof:lastmodified":1627522097,
+    "wof:lastmodified":1695886568,
     "wof:name":"Fowah",
     "wof:parent_id":85671057,
     "wof:placetype":"county",

--- a/data/109/202/108/3/1092021083.geojson
+++ b/data/109/202/108/3/1092021083.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000616,
-    "geom:area_square_m":6821680.120209,
+    "geom:area_square_m":6821680.120212,
     "geom:bbox":"31.864194,26.324275,31.903803,26.358281",
     "geom:latitude":26.33965,
     "geom:longitude":31.884702,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SJ.GM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897387,
-    "wof:geomhash":"1cf5a3387b48026274b0a29ffb51ea65",
+    "wof:geomhash":"1585f3b76188c9dff272b4e10b3da170",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092021083,
-    "wof:lastmodified":1627522097,
+    "wof:lastmodified":1695886569,
     "wof:name":"Gerga City",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/202/112/7/1092021127.geojson
+++ b/data/109/202/112/7/1092021127.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013062,
-    "geom:area_square_m":144780066.064375,
+    "geom:area_square_m":144780066.064365,
     "geom:bbox":"31.765344,26.226431,31.938256,26.377696",
     "geom:latitude":26.30987,
     "geom:longitude":31.848807,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SJ.GK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897388,
-    "wof:geomhash":"a45d63a16a1b1915e71efcbc85d23fcb",
+    "wof:geomhash":"444656f0f36b1c88093d63e52168c598",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092021127,
-    "wof:lastmodified":1627522097,
+    "wof:lastmodified":1695886569,
     "wof:name":"Gerga",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/202/117/3/1092021173.geojson
+++ b/data/109/202/117/3/1092021173.geojson
@@ -305,9 +305,10 @@
     "wof:concordances":{
         "hasc:id":"EG.JZ.GK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897390,
-    "wof:geomhash":"4a2e3e11a4cccb3da2de2e702ae356f7",
+    "wof:geomhash":"2c4a555785d75ab632af44955cbc741a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -317,7 +318,7 @@
         }
     ],
     "wof:id":1092021173,
-    "wof:lastmodified":1602720867,
+    "wof:lastmodified":1695886295,
     "wof:name":"Giza",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/202/120/3/1092021203.geojson
+++ b/data/109/202/120/3/1092021203.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001281,
-    "geom:area_square_m":13720616.01141,
+    "geom:area_square_m":13720616.011408,
     "geom:bbox":"31.193696,29.965153,31.234259,30.032637",
     "geom:latitude":29.996324,
     "geom:longitude":31.215167,
@@ -305,9 +305,10 @@
     "wof:concordances":{
         "hasc:id":"EG.JZ.GM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897391,
-    "wof:geomhash":"cf700a8fdb8ad432d370cf34dedb7173",
+    "wof:geomhash":"9d6352b1022e29ba72e260cf3753c2cd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -317,7 +318,7 @@
         }
     ],
     "wof:id":1092021203,
-    "wof:lastmodified":1602720867,
+    "wof:lastmodified":1695886295,
     "wof:name":"Giza",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/202/123/3/1092021233.geojson
+++ b/data/109/202/123/3/1092021233.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011168,
-    "geom:area_square_m":123387364.63112,
+    "geom:area_square_m":123387364.631104,
     "geom:bbox":"31.394349,26.605998,31.546407,26.750216",
     "geom:latitude":26.682317,
     "geom:longitude":31.470067,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SJ.WG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897392,
-    "wof:geomhash":"48e9996dbaaad8ce51003f58939fc268",
+    "wof:geomhash":"217b88f5f2bb2775f5867cea90991466",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092021233,
-    "wof:lastmodified":1627522097,
+    "wof:lastmodified":1695886569,
     "wof:name":"Gohaynah El-Gharbeyah",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/202/127/5/1092021275.geojson
+++ b/data/109/202/127/5/1092021275.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000463,
-    "geom:area_square_m":4955642.087996,
+    "geom:area_square_m":4955642.087994,
     "geom:bbox":"31.265668,30.070322,31.293783,30.108688",
     "geom:latitude":30.090817,
     "geom:longitude":31.281813,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.QB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897394,
-    "wof:geomhash":"528a952de38a080e1a4ec278dd28c684",
+    "wof:geomhash":"6f28aea46d9ef6d1f8e0cd63e9b0015c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092021275,
-    "wof:lastmodified":1627522097,
+    "wof:lastmodified":1695886569,
     "wof:name":"Hadayeq El-Qobbah",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/131/9/1092021319.geojson
+++ b/data/109/202/131/9/1092021319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012499,
-    "geom:area_square_m":132945704.083542,
+    "geom:area_square_m":132945704.083537,
     "geom:bbox":"31.493948,30.601323,31.68633,30.714282",
     "geom:latitude":30.661422,
     "geom:longitude":31.595539,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SQ.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897395,
-    "wof:geomhash":"58326f1f0f199958d326baa69ed76612",
+    "wof:geomhash":"74ff086de285ce166215d7ff8a586787",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092021319,
-    "wof:lastmodified":1627522097,
+    "wof:lastmodified":1695886569,
     "wof:name":"Hahya",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/202/134/9/1092021349.geojson
+++ b/data/109/202/134/9/1092021349.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047527,
-    "geom:area_square_m":544187699.433633,
+    "geom:area_square_m":544187699.433648,
     "geom:bbox":"36.475766,22.068823,36.816556,22.350428",
     "geom:latitude":22.184828,
     "geom:longitude":36.608716,
@@ -118,9 +118,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BA.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897397,
-    "wof:geomhash":"bd4815332f73dca478673e2eddd60c6a",
+    "wof:geomhash":"787bce8f481eab5bde012d7d0f5dce04",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1092021349,
-    "wof:lastmodified":1602720867,
+    "wof:lastmodified":1695886295,
     "wof:name":"Halayeb",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/202/138/7/1092021387.geojson
+++ b/data/109/202/138/7/1092021387.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000825,
-    "geom:area_square_m":8828091.096634,
+    "geom:area_square_m":8828091.096635,
     "geom:bbox":"31.296035,30.075306,31.358685,30.107738",
     "geom:latitude":30.091295,
     "geom:longitude":31.324337,
@@ -152,9 +152,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.HP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897399,
-    "wof:geomhash":"443ec3b8ac41a989a203080fe531632c",
+    "wof:geomhash":"7dbe8e563ac706a94cf387ad2d658557",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -164,7 +165,7 @@
         }
     ],
     "wof:id":1092021387,
-    "wof:lastmodified":1602720867,
+    "wof:lastmodified":1695886295,
     "wof:name":"Heliopolis",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/142/7/1092021427.geojson
+++ b/data/109/202/142/7/1092021427.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004349,
-    "geom:area_square_m":46641541.295028,
+    "geom:area_square_m":46641541.29504,
     "geom:bbox":"31.280477,29.802747,31.350522,29.927879",
     "geom:latitude":29.859512,
     "geom:longitude":31.310512,
@@ -161,9 +161,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.HW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897400,
-    "wof:geomhash":"f410a68dd14e1794365bee52a4ce69bb",
+    "wof:geomhash":"fbe1c83854f83bb4a9e4133676d6d8b5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -173,7 +174,7 @@
         }
     ],
     "wof:id":1092021427,
-    "wof:lastmodified":1602720867,
+    "wof:lastmodified":1695886295,
     "wof:name":"Helwan",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/145/9/1092021459.geojson
+++ b/data/109/202/145/9/1092021459.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026096,
-    "geom:area_square_m":276961164.662433,
+    "geom:area_square_m":276961164.662413,
     "geom:bbox":"30.23143,30.778817,30.465929,30.985251",
     "geom:latitude":30.874313,
     "geom:longitude":30.318339,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BH.HE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897402,
-    "wof:geomhash":"129d921e6fba0bdccdce19c98f655307",
+    "wof:geomhash":"0fbc39299a8b02d273815774fadb1e49",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092021459,
-    "wof:lastmodified":1627522097,
+    "wof:lastmodified":1695886569,
     "wof:name":"Housh Eisa",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/202/149/7/1092021497.geojson
+++ b/data/109/202/149/7/1092021497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.717988,
-    "geom:area_square_m":7901693219.483961,
+    "geom:area_square_m":7901693219.484074,
     "geom:bbox":"32.655866,26.71702,33.93826,27.480466",
     "geom:latitude":27.128441,
     "geom:longitude":33.245102,
@@ -240,9 +240,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BA.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897404,
-    "wof:geomhash":"75f607806da54fd96ff994d308b5c68c",
+    "wof:geomhash":"f184f3cfe7826fc6ba33c82e4b058e51",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -252,7 +253,7 @@
         }
     ],
     "wof:id":1092021497,
-    "wof:lastmodified":1602720867,
+    "wof:lastmodified":1695886295,
     "wof:name":"Hurghada",
     "wof:parent_id":85671085,
     "wof:placetype":"county",

--- a/data/109/202/154/1/1092021541.geojson
+++ b/data/109/202/154/1/1092021541.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054104,
-    "geom:area_square_m":572765291.417988,
+    "geom:area_square_m":572765291.418021,
     "geom:bbox":"29.937431,30.964747,30.241981,31.278882",
     "geom:latitude":31.11304,
     "geom:longitude":30.095811,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BH.KM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897405,
-    "wof:geomhash":"71e42b9779742e04b8d20d54fd10d845",
+    "wof:geomhash":"bb8bc790a267b36ad41c4c6a144dabab",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092021541,
-    "wof:lastmodified":1627522097,
+    "wof:lastmodified":1695886569,
     "wof:name":"Kafr El-Dawwar",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/202/158/1/1092021581.geojson
+++ b/data/109/202/158/1/1092021581.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040116,
-    "geom:area_square_m":424485360.139729,
+    "geom:area_square_m":424485360.139668,
     "geom:bbox":"30.796312,31.027608,31.087884,31.371514",
     "geom:latitude":31.157621,
     "geom:longitude":30.967281,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.KS.KM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897407,
-    "wof:geomhash":"723f56348c0f8c5610bd3c4d93ad206f",
+    "wof:geomhash":"4fb9c90d59ee7fd14fe5fd1f6bfe9c87",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092021581,
-    "wof:lastmodified":1627522097,
+    "wof:lastmodified":1695886569,
     "wof:name":"Kafr El-Sheikh",
     "wof:parent_id":85671057,
     "wof:placetype":"county",

--- a/data/109/202/162/3/1092021623.geojson
+++ b/data/109/202/162/3/1092021623.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019329,
-    "geom:area_square_m":205288625.2815,
+    "geom:area_square_m":205288625.281521,
     "geom:bbox":"30.753832,30.693485,30.897307,30.913532",
     "geom:latitude":30.801736,
     "geom:longitude":30.82938,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.GH.KZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897408,
-    "wof:geomhash":"bfdf8e7936a20222ed3964b493467bbf",
+    "wof:geomhash":"d4d92bab04cd54e2e2042ee3eb6f9688",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092021623,
-    "wof:lastmodified":1627522097,
+    "wof:lastmodified":1695886569,
     "wof:name":"Kafr El-Zayyat",
     "wof:parent_id":85670985,
     "wof:placetype":"county",

--- a/data/109/202/167/3/1092021673.geojson
+++ b/data/109/202/167/3/1092021673.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025054,
-    "geom:area_square_m":264511189.024237,
+    "geom:area_square_m":264511189.024255,
     "geom:bbox":"31.483703,31.272914,31.793255,31.453329",
     "geom:latitude":31.371803,
     "geom:longitude":31.629888,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.DT.KS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897410,
-    "wof:geomhash":"f910d753e4d608f7bfed7a16e1043058",
+    "wof:geomhash":"050824e5c17f301533e41f81de6a9d9d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092021673,
-    "wof:lastmodified":1627522098,
+    "wof:lastmodified":1695886570,
     "wof:name":"Kafr Sa'd",
     "wof:parent_id":85671025,
     "wof:placetype":"county",

--- a/data/109/202/171/5/1092021715.geojson
+++ b/data/109/202/171/5/1092021715.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017674,
-    "geom:area_square_m":187645821.625477,
+    "geom:area_square_m":187645821.62549,
     "geom:bbox":"31.546469,30.756975,31.76481,30.930325",
     "geom:latitude":30.839373,
     "geom:longitude":31.664357,
@@ -95,9 +95,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SQ.FS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897411,
-    "wof:geomhash":"55450394161cd39fe7e7fa4a25f0b1c8",
+    "wof:geomhash":"6f8c18abb1cca1023ea50776ad5ac0bb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1092021715,
-    "wof:lastmodified":1627522098,
+    "wof:lastmodified":1695886570,
     "wof:name":"Kafr Saqr",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/202/174/7/1092021747.geojson
+++ b/data/109/202/174/7/1092021747.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005646,
-    "geom:area_square_m":60115498.668811,
+    "geom:area_square_m":60115498.668807,
     "geom:bbox":"31.221711,30.495046,31.348347,30.613527",
     "geom:latitude":30.555969,
     "geom:longitude":31.277611,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QL.KS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897414,
-    "wof:geomhash":"3eb9246fa50031da9934a18d5a54a045",
+    "wof:geomhash":"b0546a86d347a3141b6c65dba88cbcce",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092021747,
-    "wof:lastmodified":1627522098,
+    "wof:lastmodified":1695886570,
     "wof:name":"Kafr Shokr",
     "wof:parent_id":85671003,
     "wof:placetype":"county",

--- a/data/109/202/179/1/1092021791.geojson
+++ b/data/109/202/179/1/1092021791.geojson
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.AM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897415,
-    "wof:geomhash":"0ea484d1b260092c7024475fb6fdb028",
+    "wof:geomhash":"ba643ea3c9903553ad0db0aa50a352c7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092021791,
-    "wof:lastmodified":1627522098,
+    "wof:lastmodified":1695886570,
     "wof:name":"Karmooz",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/202/182/9/1092021829.geojson
+++ b/data/109/202/182/9/1092021829.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014638,
-    "geom:area_square_m":155018741.926584,
+    "geom:area_square_m":155018741.926583,
     "geom:bbox":"30.765634,31.007646,30.914963,31.158471",
     "geom:latitude":31.079587,
     "geom:longitude":30.834056,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.KS.KE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897417,
-    "wof:geomhash":"54c11f7c817751c7a3dece0daf1dad9c",
+    "wof:geomhash":"ff7b65ed1e9a3395df78ab5226d8546f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092021829,
-    "wof:lastmodified":1627522098,
+    "wof:lastmodified":1695886570,
     "wof:name":"Keleen",
     "wof:parent_id":85671057,
     "wof:placetype":"county",

--- a/data/109/202/188/1/1092021881.geojson
+++ b/data/109/202/188/1/1092021881.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.140727,
-    "geom:area_square_m":1497381387.96159,
+    "geom:area_square_m":1497381387.961581,
     "geom:bbox":"30.187498,30.376243,30.850735,30.830342",
     "geom:latitude":30.625431,
     "geom:longitude":30.579736,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BH.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897419,
-    "wof:geomhash":"0352cdf2fc36ecdb7f7824be233f9b11",
+    "wof:geomhash":"2f19e2fd44b092edd1af339d4fb517b8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092021881,
-    "wof:lastmodified":1627522098,
+    "wof:lastmodified":1695886570,
     "wof:name":"Koum Hamadah",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/202/192/7/1092021927.geojson
+++ b/data/109/202/192/7/1092021927.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025217,
-    "geom:area_square_m":283662301.842011,
+    "geom:area_square_m":283662301.842043,
     "geom:bbox":"32.857799,24.374243,33.040138,24.854023",
     "geom:latitude":24.534224,
     "geom:longitude":32.941192,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.AN.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897420,
-    "wof:geomhash":"6b9b72f83a1947182bb17b69995a29e3",
+    "wof:geomhash":"e1e4e8b978fa6308de3cf918be2e69d5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092021927,
-    "wof:lastmodified":1627522098,
+    "wof:lastmodified":1695886570,
     "wof:name":"Koum Ombu",
     "wof:parent_id":85671061,
     "wof:placetype":"county",

--- a/data/109/202/196/5/1092021965.geojson
+++ b/data/109/202/196/5/1092021965.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021462,
-    "geom:area_square_m":232948316.491353,
+    "geom:area_square_m":232948316.491337,
     "geom:bbox":"30.640219,28.539726,30.895778,28.721539",
     "geom:latitude":28.622303,
     "geom:longitude":30.783684,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MN.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897422,
-    "wof:geomhash":"e2df2aca947dda2266e5ddfb234ac32d",
+    "wof:geomhash":"4ac5f665d267226ed75a9a5eea53b1ab",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092021965,
-    "wof:lastmodified":1627522098,
+    "wof:lastmodified":1695886570,
     "wof:name":"Maghaghah",
     "wof:parent_id":85671049,
     "wof:placetype":"county",

--- a/data/109/202/200/5/1092022005.geojson
+++ b/data/109/202/200/5/1092022005.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028818,
-    "geom:area_square_m":315322301.743303,
+    "geom:area_square_m":315322301.743244,
     "geom:bbox":"30.690718,27.642258,30.903162,27.879364",
     "geom:latitude":27.762713,
     "geom:longitude":30.788327,
@@ -82,9 +82,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MN.ML"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897423,
-    "wof:geomhash":"c4084a1d2a40e406fa02896f4cb07811",
+    "wof:geomhash":"303513564ffb0b7abfbc02722abdc61e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1092022005,
-    "wof:lastmodified":1627522098,
+    "wof:lastmodified":1695886571,
     "wof:name":"Mallawy",
     "wof:parent_id":85671049,
     "wof:placetype":"county",

--- a/data/109/202/204/5/1092022045.geojson
+++ b/data/109/202/204/5/1092022045.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018085,
-    "geom:area_square_m":198739308.446358,
+    "geom:area_square_m":198739308.446288,
     "geom:bbox":"30.830672,27.188962,31.039438,27.383726",
     "geom:latitude":27.288966,
     "geom:longitude":30.938527,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.AT.MN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897425,
-    "wof:geomhash":"74ac92cc1422b1957f60c543c7911d2d",
+    "wof:geomhash":"53aa90d1be0cfce3bb38057ce590b7f2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092022045,
-    "wof:lastmodified":1627522098,
+    "wof:lastmodified":1695886571,
     "wof:name":"Manfalout",
     "wof:parent_id":85671069,
     "wof:placetype":"county",

--- a/data/109/202/209/3/1092022093.geojson
+++ b/data/109/202/209/3/1092022093.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.885878,
-    "geom:area_square_m":21209344470.080147,
+    "geom:area_square_m":21209344470.080246,
     "geom:bbox":"33.445637,23.929275,35.456798,25.209475",
     "geom:latitude":24.562918,
     "geom:longitude":34.283961,
@@ -128,9 +128,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BA.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897426,
-    "wof:geomhash":"b47f16416cc1abda32646afe19b9b310",
+    "wof:geomhash":"a0020ae4c1f4b50957f6aeb90f680fcc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1092022093,
-    "wof:lastmodified":1602720860,
+    "wof:lastmodified":1695886294,
     "wof:name":"Marsa Alam",
     "wof:parent_id":85671085,
     "wof:placetype":"county",

--- a/data/109/202/211/5/1092022115.geojson
+++ b/data/109/202/211/5/1092022115.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.302319,
-    "geom:area_square_m":35276220834.572372,
+    "geom:area_square_m":35276220834.572411,
     "geom:bbox":"26.302833,28.922264,27.909531,31.514413",
     "geom:latitude":30.239351,
     "geom:longitude":27.059197,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MT.MM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897428,
-    "wof:geomhash":"faa331b0a1451ef6f16e42d84251fd1d",
+    "wof:geomhash":"407d95237f0228f8e715ecbf08b6cbf7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092022115,
-    "wof:lastmodified":1627522099,
+    "wof:lastmodified":1695886571,
     "wof:name":"Marsa Matrooh",
     "wof:parent_id":85671031,
     "wof:placetype":"county",

--- a/data/109/202/216/5/1092022165.geojson
+++ b/data/109/202/216/5/1092022165.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006817,
-    "geom:area_square_m":72718340.649644,
+    "geom:area_square_m":72718340.649662,
     "geom:bbox":"31.330107,30.294237,31.42634,30.431722",
     "geom:latitude":30.374697,
     "geom:longitude":31.378658,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SQ.MS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897429,
-    "wof:geomhash":"57d41463c51adcd1327c1c9e76f28221",
+    "wof:geomhash":"127473efd971706c0b84fce1687b0e8a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092022165,
-    "wof:lastmodified":1627522099,
+    "wof:lastmodified":1695886571,
     "wof:name":"Mashtool El-Sooq",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/202/221/1/1092022211.geojson
+++ b/data/109/202/221/1/1092022211.geojson
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.AC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897431,
-    "wof:geomhash":"b2306ee6148751bdccf18550e24473c1",
+    "wof:geomhash":"c811206ab6d356c636b81194c6daa856",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092022211,
-    "wof:lastmodified":1627522099,
+    "wof:lastmodified":1695886571,
     "wof:name":"Masr El-Qadeemah",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/223/9/1092022239.geojson
+++ b/data/109/202/223/9/1092022239.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014974,
-    "geom:area_square_m":162855703.203573,
+    "geom:area_square_m":162855703.203597,
     "geom:bbox":"30.599559,28.3501,30.827913,28.48823",
     "geom:latitude":28.412605,
     "geom:longitude":30.716159,
@@ -83,9 +83,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MN.MT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897432,
-    "wof:geomhash":"9425ee79a8ca93d23d6e5b5c2ab9179b",
+    "wof:geomhash":"eeb4675883d6e900c8db05a85360f251",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1092022239,
-    "wof:lastmodified":1627522099,
+    "wof:lastmodified":1695886571,
     "wof:name":"Matay",
     "wof:parent_id":85671049,
     "wof:placetype":"county",

--- a/data/109/202/227/7/1092022277.geojson
+++ b/data/109/202/227/7/1092022277.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023809,
-    "geom:area_square_m":253102058.72867,
+    "geom:area_square_m":253102058.728647,
     "geom:bbox":"31.231669,30.589724,31.392092,30.832151",
     "geom:latitude":30.714323,
     "geom:longitude":31.319513,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.DQ.MC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897434,
-    "wof:geomhash":"3712718e2719e89665abf2b2c8da267e",
+    "wof:geomhash":"09dde304d24e98e2264b5b706674c661",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092022277,
-    "wof:lastmodified":1627522099,
+    "wof:lastmodified":1695886571,
     "wof:name":"Meet Ghamr",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/202/232/5/1092022325.geojson
+++ b/data/109/202/232/5/1092022325.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009668,
-    "geom:area_square_m":102192687.810315,
+    "geom:area_square_m":102192687.810308,
     "geom:bbox":"31.762998,31.122225,31.876569,31.356272",
     "geom:latitude":31.256176,
     "geom:longitude":31.812066,
@@ -82,9 +82,10 @@
     "wof:concordances":{
         "hasc:id":"EG.DQ.MS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897435,
-    "wof:geomhash":"ac777b27ec16ee111c777c728f114f75",
+    "wof:geomhash":"155297e11500570f919b5b16ad57b697",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1092022325,
-    "wof:lastmodified":1627522099,
+    "wof:lastmodified":1695886571,
     "wof:name":"Meet Salseel",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/202/236/9/1092022369.geojson
+++ b/data/109/202/236/9/1092022369.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019548,
-    "geom:area_square_m":208355319.848336,
+    "geom:area_square_m":208355319.848335,
     "geom:bbox":"30.830066,30.364867,31.007847,30.549245",
     "geom:latitude":30.460979,
     "geom:longitude":30.912992,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MF.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897437,
-    "wof:geomhash":"b722c78ae5098cbcd1830b6e10ad142d",
+    "wof:geomhash":"e4d5fcc3d1a4717e6950c7d3f76ead9e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092022369,
-    "wof:lastmodified":1627522099,
+    "wof:lastmodified":1695886571,
     "wof:name":"Menoof",
     "wof:parent_id":85670995,
     "wof:placetype":"county",

--- a/data/109/202/240/3/1092022403.geojson
+++ b/data/109/202/240/3/1092022403.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027104,
-    "geom:area_square_m":288753680.652892,
+    "geom:area_square_m":288753680.652872,
     "geom:bbox":"31.266602,30.401053,31.49064,30.618204",
     "geom:latitude":30.506026,
     "geom:longitude":31.367671,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SQ.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897438,
-    "wof:geomhash":"9729a0a850e65d38b0092d42376611aa",
+    "wof:geomhash":"e7c690a9abb562d0a693fe3abd2452dc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092022403,
-    "wof:lastmodified":1627522099,
+    "wof:lastmodified":1695886572,
     "wof:name":"Menya El-Qamh",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/202/245/1/1092022451.geojson
+++ b/data/109/202/245/1/1092022451.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01757,
-    "geom:area_square_m":185897565.786798,
+    "geom:area_square_m":185897565.786799,
     "geom:bbox":"31.605217,31.092963,31.828142,31.234568",
     "geom:latitude":31.1653,
     "geom:longitude":31.709644,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.DQ.MN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897440,
-    "wof:geomhash":"f381831ae9adc789cdad6ca84df75c4c",
+    "wof:geomhash":"5210984466a2e18bede0d7ea5dcc54a0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092022451,
-    "wof:lastmodified":1627522099,
+    "wof:lastmodified":1695886572,
     "wof:name":"Menyet El-Nasr",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/202/249/9/1092022499.geojson
+++ b/data/109/202/249/9/1092022499.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001314,
-    "geom:area_square_m":13899900.46725,
+    "geom:area_square_m":13899900.467239,
     "geom:bbox":"29.838403,31.13082,29.891645,31.185802",
     "geom:latitude":31.156478,
     "geom:longitude":29.865961,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897441,
-    "wof:geomhash":"657626c158ba075103e55bee3c1f4bac",
+    "wof:geomhash":"2dee21639c50dab46282fab00820d167",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092022499,
-    "wof:lastmodified":1627522099,
+    "wof:lastmodified":1695886572,
     "wof:name":"Mina El-Basal",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/202/252/5/1092022525.geojson
+++ b/data/109/202/252/5/1092022525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000471,
-    "geom:area_square_m":4981511.328711,
+    "geom:area_square_m":4981511.32871,
     "geom:bbox":"29.896957,31.168623,29.942111,31.187856",
     "geom:latitude":31.177899,
     "geom:longitude":29.918697,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897442,
-    "wof:geomhash":"f9fd49b86fb26eb1bddd08f740f535eb",
+    "wof:geomhash":"c53e2136be2ba51f45adc19cff50603c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1092022525,
-    "wof:lastmodified":1627522099,
+    "wof:lastmodified":1695886572,
     "wof:name":"Moharam Bek",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/202/257/1/1092022571.geojson
+++ b/data/109/202/257/1/1092022571.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000455,
-    "geom:area_square_m":4867010.99974,
+    "geom:area_square_m":4867010.999739,
     "geom:bbox":"31.261002,30.031783,31.296617,30.057769",
     "geom:latitude":30.045099,
     "geom:longitude":31.281746,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.MN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897444,
-    "wof:geomhash":"4d02955f6a5c8cbdfe85c464091777dd",
+    "wof:geomhash":"b828b5be64b7058bdeb7f13cd7249145",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092022571,
-    "wof:lastmodified":1627522099,
+    "wof:lastmodified":1695886572,
     "wof:name":"Monshaet Naser",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/261/7/1092022617.geojson
+++ b/data/109/202/261/7/1092022617.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027573,
-    "geom:area_square_m":291088777.505437,
+    "geom:area_square_m":291088777.505514,
     "geom:bbox":"30.345215,31.250082,30.652844,31.511115",
     "geom:latitude":31.377521,
     "geom:longitude":30.514573,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.KS.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897445,
-    "wof:geomhash":"b6989a56e42b522ec506ce75b728f036",
+    "wof:geomhash":"b363cbcd311572f5d77b05bfc818ad01",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092022617,
-    "wof:lastmodified":1627522100,
+    "wof:lastmodified":1695886572,
     "wof:name":"Motobas",
     "wof:parent_id":85671057,
     "wof:placetype":"county",

--- a/data/109/202/265/3/1092022653.geojson
+++ b/data/109/202/265/3/1092022653.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018227,
-    "geom:area_square_m":202478911.841615,
+    "geom:area_square_m":202478911.841632,
     "geom:bbox":"32.176743,25.98615,32.418098,26.140991",
     "geom:latitude":26.051714,
     "geom:longitude":32.274918,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QN.NH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897447,
-    "wof:geomhash":"9abb4284b7cbf7b3564425b3989d90e4",
+    "wof:geomhash":"1745d1c9ea68626119a4d2760634bb53",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092022653,
-    "wof:lastmodified":1627522100,
+    "wof:lastmodified":1695886572,
     "wof:name":"Nag' Hammady",
     "wof:parent_id":85671075,
     "wof:placetype":"county",

--- a/data/109/202/269/7/1092022697.geojson
+++ b/data/109/202/269/7/1092022697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.958436,
-    "geom:area_square_m":10265925477.15167,
+    "geom:area_square_m":10265925477.151482,
     "geom:bbox":"32.782451,29.509729,34.89731,30.283426",
     "geom:latitude":29.975625,
     "geom:longitude":34.00309,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SS.NK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897449,
-    "wof:geomhash":"8bb6cdd0ea5b03604b7c34cc5d2725da",
+    "wof:geomhash":"026f54c8090ffcb0f80a96eb6dafc7b8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1092022697,
-    "wof:lastmodified":1627522100,
+    "wof:lastmodified":1695886572,
     "wof:name":"Nakhl",
     "wof:parent_id":85671093,
     "wof:placetype":"county",

--- a/data/109/202/273/9/1092022739.geojson
+++ b/data/109/202/273/9/1092022739.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008413,
-    "geom:area_square_m":93592430.88034,
+    "geom:area_square_m":93592430.880353,
     "geom:bbox":"32.692618,25.7857,32.777403,25.994035",
     "geom:latitude":25.885627,
     "geom:longitude":32.731029,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QN.NE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897450,
-    "wof:geomhash":"3dd4e7874ee591724b7804b60e8a69fd",
+    "wof:geomhash":"2a61fbb8ef10ae5b81912cca5ecd80a7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092022739,
-    "wof:lastmodified":1627522100,
+    "wof:lastmodified":1695886572,
     "wof:name":"Naqadah",
     "wof:parent_id":85671075,
     "wof:placetype":"county",

--- a/data/109/202/277/9/1092022779.geojson
+++ b/data/109/202/277/9/1092022779.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019755,
-    "geom:area_square_m":213264649.465799,
+    "geom:area_square_m":213264649.465786,
     "geom:bbox":"30.967012,29.107121,31.210743,29.255706",
     "geom:latitude":29.184539,
     "geom:longitude":31.092731,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BN.NB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897452,
-    "wof:geomhash":"e7a4e68ff7d9956403960d6301982dab",
+    "wof:geomhash":"cb3fe4a846fe1eb0dbb0c53bb80fb02e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1092022779,
-    "wof:lastmodified":1602720867,
+    "wof:lastmodified":1695886295,
     "wof:name":"Naser",
     "wof:parent_id":85671053,
     "wof:placetype":"county",

--- a/data/109/202/282/3/1092022823.geojson
+++ b/data/109/202/282/3/1092022823.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004727,
-    "geom:area_square_m":50594421.741621,
+    "geom:area_square_m":50594421.741627,
     "geom:bbox":"31.313645,30.018365,31.412704,30.088469",
     "geom:latitude":30.05628,
     "geom:longitude":31.365738,
@@ -98,9 +98,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.NC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897454,
-    "wof:geomhash":"6aab853e7b44c27e70f302dc69676745",
+    "wof:geomhash":"9e9a2932f3b3a063ae5817a4e22ca90f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092022823,
-    "wof:lastmodified":1627522100,
+    "wof:lastmodified":1695886573,
     "wof:name":"Nasr City",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/286/7/1092022867.geojson
+++ b/data/109/202/286/7/1092022867.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015511,
-    "geom:area_square_m":174503921.573932,
+    "geom:area_square_m":174503921.573918,
     "geom:bbox":"32.914789,24.354221,33.130493,24.656529",
     "geom:latitude":24.518759,
     "geom:longitude":33.008547,
@@ -104,9 +104,10 @@
     "wof:concordances":{
         "hasc:id":"EG.AN.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897455,
-    "wof:geomhash":"ebf23c128c1cf7ff949c89e39bb750a7",
+    "wof:geomhash":"67558b002f513c36d60184e2bff59671",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092022867,
-    "wof:lastmodified":1602720868,
+    "wof:lastmodified":1695886295,
     "wof:name":"Nasr",
     "wof:parent_id":85671061,
     "wof:placetype":"county",

--- a/data/109/202/288/5/1092022885.geojson
+++ b/data/109/202/288/5/1092022885.geojson
@@ -48,6 +48,7 @@
     "wof:concordances":{
         "hasc:id":"EG.JZ.UO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897456,
     "wof:geomhash":"b482ae5a268a5d29b4ded35539b61b78",
@@ -60,7 +61,7 @@
         }
     ],
     "wof:id":1092022885,
-    "wof:lastmodified":1694492371,
+    "wof:lastmodified":1695886647,
     "wof:name":"",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/202/290/5/1092022905.geojson
+++ b/data/109/202/290/5/1092022905.geojson
@@ -48,6 +48,7 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.UO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897456,
     "wof:geomhash":"b0b212257619549d7e4e010399046e00",
@@ -60,7 +61,7 @@
         }
     ],
     "wof:id":1092022905,
-    "wof:lastmodified":1694492372,
+    "wof:lastmodified":1695886647,
     "wof:name":"",
     "wof:parent_id":85671085,
     "wof:placetype":"county",

--- a/data/109/202/291/5/1092022915.geojson
+++ b/data/109/202/291/5/1092022915.geojson
@@ -48,6 +48,7 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.UO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897457,
     "wof:geomhash":"8993ebc3cb545c7f68c708b1ad4fa0f4",
@@ -60,7 +61,7 @@
         }
     ],
     "wof:id":1092022915,
-    "wof:lastmodified":1694492372,
+    "wof:lastmodified":1695886648,
     "wof:name":"",
     "wof:parent_id":85671061,
     "wof:placetype":"county",

--- a/data/109/202/293/7/1092022937.geojson
+++ b/data/109/202/293/7/1092022937.geojson
@@ -48,6 +48,7 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.UO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897458,
     "wof:geomhash":"63424c8e1d3cba1bd00b9cadcd228047",
@@ -60,7 +61,7 @@
         }
     ],
     "wof:id":1092022937,
-    "wof:lastmodified":1694492372,
+    "wof:lastmodified":1695886647,
     "wof:name":"",
     "wof:parent_id":85671085,
     "wof:placetype":"county",

--- a/data/109/202/295/9/1092022959.geojson
+++ b/data/109/202/295/9/1092022959.geojson
@@ -48,6 +48,7 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.UO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897458,
     "wof:geomhash":"04dd3318ca34e3e5df395e4b402ef049",
@@ -60,7 +61,7 @@
         }
     ],
     "wof:id":1092022959,
-    "wof:lastmodified":1694492372,
+    "wof:lastmodified":1695886647,
     "wof:name":"",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/202/297/9/1092022979.geojson
+++ b/data/109/202/297/9/1092022979.geojson
@@ -48,6 +48,7 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.UO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897459,
     "wof:geomhash":"038f1508fbce70ed93d08015e6bbcb3f",
@@ -60,7 +61,7 @@
         }
     ],
     "wof:id":1092022979,
-    "wof:lastmodified":1694492372,
+    "wof:lastmodified":1695886648,
     "wof:name":"",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/202/299/7/1092022997.geojson
+++ b/data/109/202/299/7/1092022997.geojson
@@ -48,6 +48,7 @@
     "wof:concordances":{
         "hasc:id":"EG.JZ.UO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897460,
     "wof:geomhash":"c466e3fdd53a2ddbd6c1cac8967afee9",
@@ -60,7 +61,7 @@
         }
     ],
     "wof:id":1092022997,
-    "wof:lastmodified":1694492372,
+    "wof:lastmodified":1695886648,
     "wof:name":"",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/302/1/1092023021.geojson
+++ b/data/109/202/302/1/1092023021.geojson
@@ -48,6 +48,7 @@
     "wof:concordances":{
         "hasc:id":"EG.IS.IM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897460,
     "wof:geomhash":"b374d146d3abf09f65cf8e2b78c4db41",
@@ -60,7 +61,7 @@
         }
     ],
     "wof:id":1092023021,
-    "wof:lastmodified":1694492372,
+    "wof:lastmodified":1695886647,
     "wof:name":"",
     "wof:parent_id":85670989,
     "wof:placetype":"county",

--- a/data/109/202/304/3/1092023043.geojson
+++ b/data/109/202/304/3/1092023043.geojson
@@ -48,6 +48,7 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.UO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897461,
     "wof:geomhash":"902fee95e145144c8ae8a294647d6183",
@@ -60,7 +61,7 @@
         }
     ],
     "wof:id":1092023043,
-    "wof:lastmodified":1694492372,
+    "wof:lastmodified":1695886647,
     "wof:name":"",
     "wof:parent_id":85671049,
     "wof:placetype":"county",

--- a/data/109/202/306/3/1092023063.geojson
+++ b/data/109/202/306/3/1092023063.geojson
@@ -47,6 +47,7 @@
     "wof:concordances":{
         "hasc:id":"EG.MF.EC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897462,
     "wof:geomhash":"5a209b6caed2b0db0099d23004c2e8b7",
@@ -59,7 +60,7 @@
         }
     ],
     "wof:id":1092023063,
-    "wof:lastmodified":1694492371,
+    "wof:lastmodified":1695886647,
     "wof:name":"",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/202/307/5/1092023075.geojson
+++ b/data/109/202/307/5/1092023075.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052936,
-    "geom:area_square_m":560662304.973546,
+    "geom:area_square_m":560662304.973597,
     "geom:bbox":"32.298806,30.916778,32.592786,31.273291",
     "geom:latitude":31.07052,
     "geom:longitude":32.414037,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BS.EM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897462,
-    "wof:geomhash":"76b994d2a7b8bccf03c4138637ef4256",
+    "wof:geomhash":"0e19dfd0d3797e1fd8b57ad8532924bc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092023075,
-    "wof:lastmodified":1627522100,
+    "wof:lastmodified":1695886573,
     "wof:name":"Mubarak - Sharq at-Tafri'tah",
     "wof:parent_id":85671021,
     "wof:placetype":"county",

--- a/data/109/202/309/5/1092023095.geojson
+++ b/data/109/202/309/5/1092023095.geojson
@@ -48,6 +48,7 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.UO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897463,
     "wof:geomhash":"8bd694b5ff4c53afe8348004de0e9700",
@@ -60,7 +61,7 @@
         }
     ],
     "wof:id":1092023095,
-    "wof:lastmodified":1694492371,
+    "wof:lastmodified":1695886647,
     "wof:name":"",
     "wof:parent_id":85671003,
     "wof:placetype":"county",

--- a/data/109/202/311/5/1092023115.geojson
+++ b/data/109/202/311/5/1092023115.geojson
@@ -48,6 +48,7 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.UO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897463,
     "wof:geomhash":"d49c023b03ffe7db36e43f670e7f03bb",
@@ -60,7 +61,7 @@
         }
     ],
     "wof:id":1092023115,
-    "wof:lastmodified":1694492372,
+    "wof:lastmodified":1695886648,
     "wof:name":"",
     "wof:parent_id":85671085,
     "wof:placetype":"county",

--- a/data/109/202/313/7/1092023137.geojson
+++ b/data/109/202/313/7/1092023137.geojson
@@ -48,6 +48,7 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.UO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897464,
     "wof:geomhash":"33eb9d42c5e6da86d32cecf06b9eab59",
@@ -60,7 +61,7 @@
         }
     ],
     "wof:id":1092023137,
-    "wof:lastmodified":1694492372,
+    "wof:lastmodified":1695886647,
     "wof:name":"",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/202/315/7/1092023157.geojson
+++ b/data/109/202/315/7/1092023157.geojson
@@ -48,6 +48,7 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.UO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897465,
     "wof:geomhash":"f5335bd100ec85adcf9ee2a08a5ea190",
@@ -60,7 +61,7 @@
         }
     ],
     "wof:id":1092023157,
-    "wof:lastmodified":1694492372,
+    "wof:lastmodified":1695886647,
     "wof:name":"",
     "wof:parent_id":85671085,
     "wof:placetype":"county",

--- a/data/109/202/317/7/1092023177.geojson
+++ b/data/109/202/317/7/1092023177.geojson
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":1092023177,
-    "wof:lastmodified":1694492372,
+    "wof:lastmodified":1695886648,
     "wof:name":"",
     "wof:parent_id":85671089,
     "wof:placetype":"county",

--- a/data/109/202/319/7/1092023197.geojson
+++ b/data/109/202/319/7/1092023197.geojson
@@ -48,6 +48,7 @@
     "wof:concordances":{
         "hasc:id":"EG.SW.AT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897466,
     "wof:geomhash":"36a391e232940e4055cc777dcfe1c905",
@@ -60,7 +61,7 @@
         }
     ],
     "wof:id":1092023197,
-    "wof:lastmodified":1694492372,
+    "wof:lastmodified":1695886648,
     "wof:name":"",
     "wof:parent_id":85671013,
     "wof:placetype":"county",

--- a/data/109/202/324/1/1092023241.geojson
+++ b/data/109/202/324/1/1092023241.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.46699,
-    "geom:area_square_m":5036948974.291376,
+    "geom:area_square_m":5036948974.291168,
     "geom:bbox":"33.880823,28.697138,34.906926,29.777964",
     "geom:latitude":29.273866,
     "geom:longitude":34.411174,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.JS.NW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897467,
-    "wof:geomhash":"9ce1b1eb7cbcb7f2693cd49bf43e23f1",
+    "wof:geomhash":"d11977cb1e78e3d134f98e1824d75029",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092023241,
-    "wof:lastmodified":1627522100,
+    "wof:lastmodified":1695886573,
     "wof:name":"Noweiba'",
     "wof:parent_id":85671089,
     "wof:placetype":"county",

--- a/data/109/202/328/3/1092023283.geojson
+++ b/data/109/202/328/3/1092023283.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004961,
-    "geom:area_square_m":53063258.92946,
+    "geom:area_square_m":53063258.929479,
     "geom:bbox":"31.095365,30.063282,31.196223,30.173249",
     "geom:latitude":30.1236,
     "geom:longitude":31.145679,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.JZ.WR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897469,
-    "wof:geomhash":"19f7631b91dce697d07da380be9fb440",
+    "wof:geomhash":"cafbcd499fb60b0290a57cc737590ed6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092023283,
-    "wof:lastmodified":1627522100,
+    "wof:lastmodified":1695886573,
     "wof:name":"Oseem",
     "wof:parent_id":85671047,
     "wof:placetype":"county",

--- a/data/109/202/333/1/1092023331.geojson
+++ b/data/109/202/333/1/1092023331.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001199,
-    "geom:area_square_m":12845580.586896,
+    "geom:area_square_m":12845580.586893,
     "geom:bbox":"32.544547,29.935341,32.588526,30.006383",
     "geom:latitude":29.969991,
     "geom:longitude":32.568632,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SW.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897470,
-    "wof:geomhash":"af572316f4ef892537fcfcd6d3f0ac02",
+    "wof:geomhash":"a78623b865907fe20cb3e336fbd8caa2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092023331,
-    "wof:lastmodified":1627522092,
+    "wof:lastmodified":1695886562,
     "wof:name":"Police staion of Suez Port",
     "wof:parent_id":85671013,
     "wof:placetype":"county",

--- a/data/109/202/337/3/1092023373.geojson
+++ b/data/109/202/337/3/1092023373.geojson
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897472,
-    "wof:geomhash":"f123dc4fc533ae3bc00602d716f91060",
+    "wof:geomhash":"866ccd8050da191ac5cf992050beaf7b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092023373,
-    "wof:lastmodified":1627522089,
+    "wof:lastmodified":1695886556,
     "wof:name":"Police station of Alexandria Port",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/202/340/5/1092023405.geojson
+++ b/data/109/202/340/5/1092023405.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000084,
-    "geom:area_square_m":889766.181522,
+    "geom:area_square_m":889766.181521,
     "geom:bbox":"32.297062,31.246329,32.320395,31.273963",
     "geom:latitude":31.257136,
     "geom:longitude":32.304567,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BS.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897473,
-    "wof:geomhash":"fcd03d9993023ecbb6fcd0cf93494f46",
+    "wof:geomhash":"e5530cf7dd4081dd850cd480952b859a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092023405,
-    "wof:lastmodified":1627522100,
+    "wof:lastmodified":1695886573,
     "wof:name":"Police station of Port Said Port",
     "wof:parent_id":85671021,
     "wof:placetype":"county",

--- a/data/109/202/344/7/1092023447.geojson
+++ b/data/109/202/344/7/1092023447.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011502,
-    "geom:area_square_m":122920176.98618,
+    "geom:area_square_m":122920176.986209,
     "geom:bbox":"31.151941,30.136277,31.31204,30.279279",
     "geom:latitude":30.204,
     "geom:longitude":31.229014,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QL.KM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897474,
-    "wof:geomhash":"b9c216b6d865052fad2e095e583454a6",
+    "wof:geomhash":"920633cd17b5add58508ca8f64ae530c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092023447,
-    "wof:lastmodified":1627522100,
+    "wof:lastmodified":1695886573,
     "wof:name":"Qalyoub",
     "wof:parent_id":85671003,
     "wof:placetype":"county",

--- a/data/109/202/349/3/1092023493.geojson
+++ b/data/109/202/349/3/1092023493.geojson
@@ -82,12 +82,13 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.KN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897476,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"16f25646b99240fbd81331c0f2b87292",
+    "wof:geomhash":"e66f1e43052ef55242390ad4582f91c6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1092023493,
-    "wof:lastmodified":1627522100,
+    "wof:lastmodified":1695886573,
     "wof:name":"Qasr El-Nil",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/352/7/1092023527.geojson
+++ b/data/109/202/352/7/1092023527.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02034,
-    "geom:area_square_m":225818599.891431,
+    "geom:area_square_m":225818599.891418,
     "geom:bbox":"32.530814,25.983842,32.828416,26.2088",
     "geom:latitude":26.123254,
     "geom:longitude":32.689606,
@@ -173,9 +173,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QN.QM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897477,
-    "wof:geomhash":"cfab259cfd40ed70255cdef7abdde312",
+    "wof:geomhash":"533eb75def3648053afb57a0cb3dfdbc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -185,7 +186,7 @@
         }
     ],
     "wof:id":1092023527,
-    "wof:lastmodified":1602720868,
+    "wof:lastmodified":1695886295,
     "wof:name":"Qena",
     "wof:parent_id":85671075,
     "wof:placetype":"county",

--- a/data/109/202/358/1/1092023581.geojson
+++ b/data/109/202/358/1/1092023581.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015255,
-    "geom:area_square_m":169716101.952414,
+    "geom:area_square_m":169716101.952429,
     "geom:bbox":"32.718735,25.734864,32.846736,25.980235",
     "geom:latitude":25.879229,
     "geom:longitude":32.781865,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QN.QS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897479,
-    "wof:geomhash":"35d7346a7e7d6f32d2a01d6458042da8",
+    "wof:geomhash":"0b04a5684230e23c8dae8451ed24aed3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092023581,
-    "wof:lastmodified":1627522101,
+    "wof:lastmodified":1695886573,
     "wof:name":"Qoos",
     "wof:parent_id":85671075,
     "wof:placetype":"county",

--- a/data/109/202/362/7/1092023627.geojson
+++ b/data/109/202/362/7/1092023627.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022475,
-    "geom:area_square_m":238288820.971821,
+    "geom:area_square_m":238288820.971834,
     "geom:bbox":"30.84705,30.888811,31.076694,31.050028",
     "geom:latitude":30.970462,
     "geom:longitude":30.972486,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.GH.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897481,
-    "wof:geomhash":"8e65b87ee0dcd83425e23c4dfc362d16",
+    "wof:geomhash":"21dec2d563e16bf513ec46c9cacad188",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092023627,
-    "wof:lastmodified":1627522101,
+    "wof:lastmodified":1695886573,
     "wof:name":"Qotoor",
     "wof:parent_id":85670985,
     "wof:placetype":"county",

--- a/data/109/202/367/1/1092023671.geojson
+++ b/data/109/202/367/1/1092023671.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019579,
-    "geom:area_square_m":208481689.167553,
+    "geom:area_square_m":208481689.167562,
     "geom:bbox":"31.050333,30.474057,31.261058,30.645572",
     "geom:latitude":30.556004,
     "geom:longitude":31.153369,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MF.KE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897482,
-    "wof:geomhash":"0bb66538afe711c41c6a78fc64f01159",
+    "wof:geomhash":"32ab52782786e894f5ee2b782a1bae62",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092023671,
-    "wof:lastmodified":1627522101,
+    "wof:lastmodified":1695886573,
     "wof:name":"Qoweisna",
     "wof:parent_id":85670995,
     "wof:placetype":"county",

--- a/data/109/202/371/5/1092023715.geojson
+++ b/data/109/202/371/5/1092023715.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028857,
-    "geom:area_square_m":305687614.982905,
+    "geom:area_square_m":305687614.982914,
     "geom:bbox":"33.806638,30.927456,33.968691,31.174338",
     "geom:latitude":31.056337,
     "geom:longitude":33.879318,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SS.SZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897484,
-    "wof:geomhash":"4af4f9a7a88297f399acd3048d44cdcc",
+    "wof:geomhash":"537a41bf1d3f6b02536a2a7d69d82a67",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092023715,
-    "wof:lastmodified":1627522101,
+    "wof:lastmodified":1695886573,
     "wof:name":"Rabe' El-Areesh",
     "wof:parent_id":85671093,
     "wof:placetype":"county",

--- a/data/109/202/376/3/1092023763.geojson
+++ b/data/109/202/376/3/1092023763.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045014,
-    "geom:area_square_m":476494866.698985,
+    "geom:area_square_m":476494866.699006,
     "geom:bbox":"34.126847,30.949588,34.362765,31.326074",
     "geom:latitude":31.118514,
     "geom:longitude":34.240827,
@@ -191,9 +191,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SS.RF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897485,
-    "wof:geomhash":"865372756604f3bac79daa651885812a",
+    "wof:geomhash":"c33babf4faa8d8069934c1b9a7ad27f2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -203,7 +204,7 @@
         }
     ],
     "wof:id":1092023763,
-    "wof:lastmodified":1602720868,
+    "wof:lastmodified":1695886295,
     "wof:name":"Rafah",
     "wof:parent_id":85671093,
     "wof:placetype":"county",

--- a/data/109/202/379/9/1092023799.geojson
+++ b/data/109/202/379/9/1092023799.geojson
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.DT.DO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897487,
-    "wof:geomhash":"6dac0291633bddd8be47180d5288f748",
+    "wof:geomhash":"db56eacf95527b0685aeeeb07e0855a8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092023799,
-    "wof:lastmodified":1627522101,
+    "wof:lastmodified":1695886573,
     "wof:name":"Ras El-Bar",
     "wof:parent_id":85671025,
     "wof:placetype":"county",

--- a/data/109/202/382/5/1092023825.geojson
+++ b/data/109/202/382/5/1092023825.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.444475,
-    "geom:area_square_m":15730869100.924007,
+    "geom:area_square_m":15730869100.923553,
     "geom:bbox":"31.780817,27.452415,33.640953,29.132942",
     "geom:latitude":28.266836,
     "geom:longitude":32.691282,
@@ -113,9 +113,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BA.RG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897488,
-    "wof:geomhash":"76058e3a8a9477f8ea8d8d2acebf14f2",
+    "wof:geomhash":"37b538c2fd78dcbe5d4e8eb2e4ca80e5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1092023825,
-    "wof:lastmodified":1627522101,
+    "wof:lastmodified":1695886574,
     "wof:name":"Ras Ghareb",
     "wof:parent_id":85671085,
     "wof:placetype":"county",

--- a/data/109/202/387/3/1092023873.geojson
+++ b/data/109/202/387/3/1092023873.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.623013,
-    "geom:area_square_m":6695627551.324019,
+    "geom:area_square_m":6695627551.323982,
     "geom:bbox":"32.618492,29.368056,34.017965,29.94119",
     "geom:latitude":29.640019,
     "geom:longitude":33.29189,
@@ -101,9 +101,10 @@
     "wof:concordances":{
         "hasc:id":"EG.JS.RS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897489,
-    "wof:geomhash":"4c5d068c1cf3745bc1f26600391917d4",
+    "wof:geomhash":"68f42ab5cb8eade7c0f8ef2e2fa12981",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092023873,
-    "wof:lastmodified":1602720868,
+    "wof:lastmodified":1695886295,
     "wof:name":"Ras Sedr",
     "wof:parent_id":85671089,
     "wof:placetype":"county",

--- a/data/109/202/392/1/1092023921.geojson
+++ b/data/109/202/392/1/1092023921.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018456,
-    "geom:area_square_m":194897681.628766,
+    "geom:area_square_m":194897681.628725,
     "geom:bbox":"30.326474,31.249917,30.522488,31.502089",
     "geom:latitude":31.349464,
     "geom:longitude":30.424053,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BH.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897491,
-    "wof:geomhash":"dd0ed61b477640f3418b593c5bb7b893",
+    "wof:geomhash":"3fbfa9d20487aac036e407c9d2743e4c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092023921,
-    "wof:lastmodified":1627522101,
+    "wof:lastmodified":1695886574,
     "wof:name":"Rasheed",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/202/395/3/1092023953.geojson
+++ b/data/109/202/395/3/1092023953.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.066207,
-    "geom:area_square_m":702904274.634741,
+    "geom:area_square_m":702904274.63475,
     "geom:bbox":"32.584006,30.558335,32.921998,31.14946",
     "geom:latitude":30.804337,
     "geom:longitude":32.699145,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SS.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897492,
-    "wof:geomhash":"8458a42d9f03c26ce697cd78ecc4ce61",
+    "wof:geomhash":"db2e4ceecb0330c3a5974915e41c9df9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092023953,
-    "wof:lastmodified":1627522101,
+    "wof:lastmodified":1695886574,
     "wof:name":"Rommanah",
     "wof:parent_id":85671093,
     "wof:placetype":"county",

--- a/data/109/202/399/5/1092023995.geojson
+++ b/data/109/202/399/5/1092023995.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00027,
-    "geom:area_square_m":2885910.208443,
+    "geom:area_square_m":2885910.208442,
     "geom:bbox":"31.226357,30.063978,31.246229,30.086557",
     "geom:latitude":30.07557,
     "geom:longitude":31.237593,
@@ -82,12 +82,13 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.RF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897494,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"160a697b9902590a56bd255adcf959e6",
+    "wof:geomhash":"182237a608f90b82b6e376fb061d13a4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1092023995,
-    "wof:lastmodified":1627522101,
+    "wof:lastmodified":1695886574,
     "wof:name":"Roud El-Farag",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/403/9/1092024039.geojson
+++ b/data/109/202/403/9/1092024039.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007431,
-    "geom:area_square_m":81919232.988059,
+    "geom:area_square_m":81919232.988041,
     "geom:bbox":"31.301059,26.875988,31.437852,26.990725",
     "geom:latitude":26.937879,
     "geom:longitude":31.361579,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.AT.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897495,
-    "wof:geomhash":"6e5b440a5bc4bc8c9fb67d83246965c8",
+    "wof:geomhash":"0c89213a7fde919312df49087c792035",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092024039,
-    "wof:lastmodified":1627522101,
+    "wof:lastmodified":1695886574,
     "wof:name":"Sadfa",
     "wof:parent_id":85671069,
     "wof:placetype":"county",

--- a/data/109/202/408/7/1092024087.geojson
+++ b/data/109/202/408/7/1092024087.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.595787,
-    "geom:area_square_m":6592225583.743973,
+    "geom:area_square_m":6592225583.743881,
     "geom:bbox":"32.913065,26.043156,34.214902,26.931468",
     "geom:latitude":26.509437,
     "geom:longitude":33.649608,
@@ -155,9 +155,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BA.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897497,
-    "wof:geomhash":"fef36708ba0932792c93c77081baabb4",
+    "wof:geomhash":"0f90501ad5ad6f1dbea5786f804072a8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -167,7 +168,7 @@
         }
     ],
     "wof:id":1092024087,
-    "wof:lastmodified":1602720868,
+    "wof:lastmodified":1695886295,
     "wof:name":"Safaga",
     "wof:parent_id":85671085,
     "wof:placetype":"county",

--- a/data/109/202/412/3/1092024123.geojson
+++ b/data/109/202/412/3/1092024123.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006214,
-    "geom:area_square_m":68421442.154004,
+    "geom:area_square_m":68421442.153983,
     "geom:bbox":"31.28844,27.014443,31.419554,27.152601",
     "geom:latitude":27.064223,
     "geom:longitude":31.343017,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.AT.SS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897498,
-    "wof:geomhash":"55b9fe0c5e8295caa3fafafdfe3f345b",
+    "wof:geomhash":"2e5a25800e6b6646a5945d346014efe5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092024123,
-    "wof:lastmodified":1627522101,
+    "wof:lastmodified":1695886574,
     "wof:name":"Sahel Seleem",
     "wof:parent_id":85671069,
     "wof:placetype":"county",

--- a/data/109/202/416/7/1092024167.geojson
+++ b/data/109/202/416/7/1092024167.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.535927,
-    "geom:area_square_m":5802783692.020785,
+    "geom:area_square_m":5802783692.020847,
     "geom:bbox":"33.661262,28.282908,34.351439,29.405469",
     "geom:latitude":28.877195,
     "geom:longitude":34.025331,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"EG.JS.SK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897500,
-    "wof:geomhash":"aec146d6ebdb93e004a528ca6ad0a69b",
+    "wof:geomhash":"eeaf817e40baa2171a22577ad139247a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1092024167,
-    "wof:lastmodified":1627522101,
+    "wof:lastmodified":1695886574,
     "wof:name":"Saint Cathrine",
     "wof:parent_id":85671089,
     "wof:placetype":"county",

--- a/data/109/202/421/7/1092024217.geojson
+++ b/data/109/202/421/7/1092024217.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032226,
-    "geom:area_square_m":350906073.600751,
+    "geom:area_square_m":350906073.600717,
     "geom:bbox":"30.578893,28.162358,30.773581,28.416431",
     "geom:latitude":28.283177,
     "geom:longitude":30.664059,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MN.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897501,
-    "wof:geomhash":"6c590ebaaa00c73ed7d756f95993df5b",
+    "wof:geomhash":"52e5e47cd48cebc20100d0d0b428f3dd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092024217,
-    "wof:lastmodified":1627522101,
+    "wof:lastmodified":1695886574,
     "wof:name":"Samaloot",
     "wof:parent_id":85671049,
     "wof:placetype":"county",

--- a/data/109/202/425/3/1092024253.geojson
+++ b/data/109/202/425/3/1092024253.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0149,
-    "geom:area_square_m":157992295.071947,
+    "geom:area_square_m":157992295.071984,
     "geom:bbox":"31.159809,30.838966,31.31872,31.063255",
     "geom:latitude":30.962724,
     "geom:longitude":31.241548,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.GH.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897502,
-    "wof:geomhash":"b1ca35270ba78d07bf34c38569d12f32",
+    "wof:geomhash":"0ca0fe16830021ebdbd3133cc45575d5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092024253,
-    "wof:lastmodified":1627522102,
+    "wof:lastmodified":1695886574,
     "wof:name":"Samanoud",
     "wof:parent_id":85670985,
     "wof:placetype":"county",

--- a/data/109/202/429/9/1092024299.geojson
+++ b/data/109/202/429/9/1092024299.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012166,
-    "geom:area_square_m":131653657.301618,
+    "geom:area_square_m":131653657.301603,
     "geom:bbox":"30.775575,28.86653,30.917269,29.017364",
     "geom:latitude":28.939043,
     "geom:longitude":30.850377,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BN.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897504,
-    "wof:geomhash":"51edd732981af8fa638e806562977ff1",
+    "wof:geomhash":"d17066ad8827b456958f8ad30ad6bfb5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092024299,
-    "wof:lastmodified":1627522101,
+    "wof:lastmodified":1695886574,
     "wof:name":"Samasta",
     "wof:parent_id":85671053,
     "wof:placetype":"county",

--- a/data/109/202/437/9/1092024379.geojson
+++ b/data/109/202/437/9/1092024379.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006218,
-    "geom:area_square_m":68701863.244596,
+    "geom:area_square_m":68701863.244613,
     "geom:bbox":"31.568712,26.617783,31.718499,26.748061",
     "geom:latitude":26.680631,
     "geom:longitude":31.648752,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SJ.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897505,
-    "wof:geomhash":"1fd057850b8b26b47d0475dcc3d97df0",
+    "wof:geomhash":"16fa6e8c7246997077ab178de2fe31da",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092024379,
-    "wof:lastmodified":1627522102,
+    "wof:lastmodified":1695886575,
     "wof:name":"Saqaltah",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/202/441/1/1092024411.geojson
+++ b/data/109/202/441/1/1092024411.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00158,
-    "geom:area_square_m":16848246.96998,
+    "geom:area_square_m":16848246.969985,
     "geom:bbox":"30.946161,30.417569,30.996474,30.466827",
     "geom:latitude":30.440833,
     "geom:longitude":30.971455,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MF.SE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897508,
-    "wof:geomhash":"3b6e2b3a42f9e88a2d7a8426c03bab70",
+    "wof:geomhash":"a87fd32e7965de42091027915e35cb7d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092024411,
-    "wof:lastmodified":1627522103,
+    "wof:lastmodified":1695886576,
     "wof:name":"Sars El-Layanah",
     "wof:parent_id":85670995,
     "wof:placetype":"county",

--- a/data/109/202/445/7/1092024457.geojson
+++ b/data/109/202/445/7/1092024457.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021572,
-    "geom:area_square_m":232352203.589984,
+    "geom:area_square_m":232352203.589916,
     "geom:bbox":"30.72427,29.335592,30.931048,29.533316",
     "geom:latitude":29.418256,
     "geom:longitude":30.824495,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.FY.SN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897509,
-    "wof:geomhash":"f9cf6edf72287e5cf4bac0ec0f7f02bb",
+    "wof:geomhash":"ed09f49d76001831b1ff376be90e0f5c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092024457,
-    "wof:lastmodified":1627522102,
+    "wof:lastmodified":1695886575,
     "wof:name":"Senorus",
     "wof:parent_id":85671037,
     "wof:placetype":"county",

--- a/data/109/202/450/5/1092024505.geojson
+++ b/data/109/202/450/5/1092024505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.131502,
-    "geom:area_square_m":1435380657.157191,
+    "geom:area_square_m":1435380657.1572,
     "geom:bbox":"34.037868,27.726487,34.449335,28.282908",
     "geom:latitude":28.024785,
     "geom:longitude":34.250548,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.JS.SS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897511,
-    "wof:geomhash":"eda7ae274d4d9f5d91c543148600ab59",
+    "wof:geomhash":"4eda6ffab546ad7499defeaffd3e2cfd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092024505,
-    "wof:lastmodified":1627522090,
+    "wof:lastmodified":1695886558,
     "wof:name":"Sharm El-Sheikh",
     "wof:parent_id":85671089,
     "wof:placetype":"county",

--- a/data/109/202/454/3/1092024543.geojson
+++ b/data/109/202/454/3/1092024543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017469,
-    "geom:area_square_m":185999239.007233,
+    "geom:area_square_m":185999239.007214,
     "geom:bbox":"30.918793,30.470665,31.084145,30.64811",
     "geom:latitude":30.561717,
     "geom:longitude":31.011242,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MF.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897512,
-    "wof:geomhash":"ddd912ae2668cc11e02f1d4a5dc7d2bb",
+    "wof:geomhash":"291ed4b406b6d9ccc9ea84bfa205a324",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092024543,
-    "wof:lastmodified":1627522102,
+    "wof:lastmodified":1695886575,
     "wof:name":"Shebeen El-Koum",
     "wof:parent_id":85670995,
     "wof:placetype":"county",

--- a/data/109/202/459/3/1092024593.geojson
+++ b/data/109/202/459/3/1092024593.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013446,
-    "geom:area_square_m":143552770.000867,
+    "geom:area_square_m":143552770.000915,
     "geom:bbox":"31.253273,30.182775,31.375956,30.412107",
     "geom:latitude":30.301099,
     "geom:longitude":31.306758,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QL.SK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897514,
-    "wof:geomhash":"8d9140a0d150af137e8b0c847d38d348",
+    "wof:geomhash":"6a2180fc7b0004b19269770a6a4966f2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092024593,
-    "wof:lastmodified":1627522102,
+    "wof:lastmodified":1695886575,
     "wof:name":"Shebeen El-Qanater",
     "wof:parent_id":85671003,
     "wof:placetype":"county",

--- a/data/109/202/475/9/1092024759.geojson
+++ b/data/109/202/475/9/1092024759.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025315,
-    "geom:area_square_m":267588783.788205,
+    "geom:area_square_m":267588783.78825,
     "geom:bbox":"31.452115,31.147338,31.687272,31.364225",
     "geom:latitude":31.25729,
     "geom:longitude":31.552994,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.DQ.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897516,
-    "wof:geomhash":"a26f0ecef6e4e36d64d53721dc188411",
+    "wof:geomhash":"88d763fe69dedb126eed5c053d3a1a5c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092024759,
-    "wof:lastmodified":1627522102,
+    "wof:lastmodified":1695886575,
     "wof:name":"Sherbeen",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/202/480/5/1092024805.geojson
+++ b/data/109/202/480/5/1092024805.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000133,
-    "geom:area_square_m":1418107.501743,
+    "geom:area_square_m":1418107.501742,
     "geom:bbox":"31.245765,30.064222,31.25645,30.082215",
     "geom:latitude":30.073811,
     "geom:longitude":31.250511,
@@ -108,9 +108,10 @@
         "hasc:id":"EG.QH.SH",
         "wd:id":"Q2096164"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897522,
-    "wof:geomhash":"be975b54c2a74d76a8365322122d4409",
+    "wof:geomhash":"9a98b93926ed74575795b2a98cbf277c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1092024805,
-    "wof:lastmodified":1690876045,
+    "wof:lastmodified":1695886296,
     "wof:name":"Shobra",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/484/9/1092024849.geojson
+++ b/data/109/202/484/9/1092024849.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018482,
-    "geom:area_square_m":195899921.644508,
+    "geom:area_square_m":195899921.644464,
     "geom:bbox":"30.570194,30.918535,30.785634,31.081466",
     "geom:latitude":30.998279,
     "geom:longitude":30.679021,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.BH.SK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897524,
-    "wof:geomhash":"4288551234b87686f77c8182391877b5",
+    "wof:geomhash":"ee7e454d3fadc14881b77d944c6f1ed0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092024849,
-    "wof:lastmodified":1627522102,
+    "wof:lastmodified":1695886575,
     "wof:name":"Shobrakheet",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/202/489/9/1092024899.geojson
+++ b/data/109/202/489/9/1092024899.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.889512,
-    "geom:area_square_m":20160900099.219357,
+    "geom:area_square_m":20160900099.219563,
     "geom:bbox":"25.423846,29.108246,26.438979,31.629356",
     "geom:latitude":30.348377,
     "geom:longitude":25.94153,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MT.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897525,
-    "wof:geomhash":"570d1e725a36a86ceef0da25290b1092",
+    "wof:geomhash":"25804ad93d02ad8b889ca763cf9ec5c6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092024899,
-    "wof:lastmodified":1627522102,
+    "wof:lastmodified":1695886575,
     "wof:name":"Sidy Barrany",
     "wof:parent_id":85671031,
     "wof:placetype":"county",

--- a/data/109/202/494/3/1092024943.geojson
+++ b/data/109/202/494/3/1092024943.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001191,
-    "geom:area_square_m":12598568.455636,
+    "geom:area_square_m":12598568.455633,
     "geom:bbox":"29.92255,31.173995,29.9769,31.227073",
     "geom:latitude":31.203111,
     "geom:longitude":29.945223,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.SG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897527,
-    "wof:geomhash":"9cc4c91d65c1439617fc2f3bf4009c45",
+    "wof:geomhash":"54249d047da7aa4f6d603311f5e7bbc6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092024943,
-    "wof:lastmodified":1627522102,
+    "wof:lastmodified":1695886575,
     "wof:name":"Sidy Gaber",
     "wof:parent_id":85671041,
     "wof:placetype":"county",

--- a/data/109/202/497/1/1092024971.geojson
+++ b/data/109/202/497/1/1092024971.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046621,
-    "geom:area_square_m":492370734.929681,
+    "geom:area_square_m":492370734.929709,
     "geom:bbox":"30.562725,31.191675,30.910591,31.53314",
     "geom:latitude":31.33954,
     "geom:longitude":30.74767,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.KS.SS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897528,
-    "wof:geomhash":"f8d2f0d8c33f5da2d2951c165a586565",
+    "wof:geomhash":"52923ff458957acaebbbde9a7110f45d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092024971,
-    "wof:lastmodified":1627522102,
+    "wof:lastmodified":1695886575,
     "wof:name":"Sidy Salem",
     "wof:parent_id":85671057,
     "wof:placetype":"county",

--- a/data/109/202/501/9/1092025019.geojson
+++ b/data/109/202/501/9/1092025019.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.409734,
-    "geom:area_square_m":47934129598.967888,
+    "geom:area_square_m":47934129598.967804,
     "geom:bbox":"24.869994,27.641235,28.86749,29.62",
     "geom:latitude":28.464772,
     "geom:longitude":26.318028,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MT.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897530,
-    "wof:geomhash":"6895f5206bd53a922212d12515d34012",
+    "wof:geomhash":"a76a2f445cf2b1c3b0fe3340b037aaa3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092025019,
-    "wof:lastmodified":1627522103,
+    "wof:lastmodified":1695886576,
     "wof:name":"Siwah",
     "wof:parent_id":85671031,
     "wof:placetype":"county",

--- a/data/109/202/506/3/1092025063.geojson
+++ b/data/109/202/506/3/1092025063.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016089,
-    "geom:area_square_m":177962811.66204,
+    "geom:area_square_m":177962811.662061,
     "geom:bbox":"31.570211,26.443525,31.782216,26.634436",
     "geom:latitude":26.551318,
     "geom:longitude":31.676857,
@@ -180,9 +180,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SJ.SO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897531,
-    "wof:geomhash":"6c1413e01f4bd441ea32ab6befd71c83",
+    "wof:geomhash":"aed60435068f25f0e7b0666faa9ddbed",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -192,7 +193,7 @@
         }
     ],
     "wof:id":1092025063,
-    "wof:lastmodified":1602720868,
+    "wof:lastmodified":1695886296,
     "wof:name":"Sohag",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/202/510/1/1092025101.geojson
+++ b/data/109/202/510/1/1092025101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01468,
-    "geom:area_square_m":162066797.401886,
+    "geom:area_square_m":162066797.401813,
     "geom:bbox":"31.331774,26.7065,31.557581,26.844707",
     "geom:latitude":26.772803,
     "geom:longitude":31.459092,
@@ -110,9 +110,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SJ.TM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897532,
-    "wof:geomhash":"91c15aa5ebc2e476e8cf3e0195b05d6a",
+    "wof:geomhash":"502f5422c10ba7cbca8659c661325f4b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1092025101,
-    "wof:lastmodified":1602720868,
+    "wof:lastmodified":1695886296,
     "wof:name":"Tahta",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/202/514/5/1092025145.geojson
+++ b/data/109/202/514/5/1092025145.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017901,
-    "geom:area_square_m":190366711.796066,
+    "geom:area_square_m":190366711.796039,
     "geom:bbox":"30.793029,30.587833,31.027024,30.747286",
     "geom:latitude":30.680153,
     "geom:longitude":30.921274,
@@ -131,9 +131,10 @@
     "wof:concordances":{
         "hasc:id":"EG.MF.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897534,
-    "wof:geomhash":"d873de4f01653f6bdc236a426293839e",
+    "wof:geomhash":"ea3e32e188b3b70056590e59cac53c68",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":1092025145,
-    "wof:lastmodified":1602720869,
+    "wof:lastmodified":1695886296,
     "wof:name":"Tala",
     "wof:parent_id":85670995,
     "wof:placetype":"county",

--- a/data/109/202/518/9/1092025189.geojson
+++ b/data/109/202/518/9/1092025189.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021594,
-    "geom:area_square_m":228801602.794786,
+    "geom:area_square_m":228801602.794782,
     "geom:bbox":"33.706964,30.921568,33.82434,31.149385",
     "geom:latitude":31.030928,
     "geom:longitude":33.766013,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SS.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897535,
-    "wof:geomhash":"28703f3c230da07d02c45f6049b143ce",
+    "wof:geomhash":"c7ea40f1ead2bc621a00712a3122823a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092025189,
-    "wof:lastmodified":1627522094,
+    "wof:lastmodified":1695886565,
     "wof:name":"Talet El-Areesh",
     "wof:parent_id":85671093,
     "wof:placetype":"county",

--- a/data/109/202/523/1/1092025231.geojson
+++ b/data/109/202/523/1/1092025231.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000964,
-    "geom:area_square_m":10259995.166994,
+    "geom:area_square_m":10259995.166996,
     "geom:bbox":"32.253696,30.595073,32.309621,30.628411",
     "geom:latitude":30.612599,
     "geom:longitude":32.283719,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IS.IT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897537,
-    "wof:geomhash":"bffd169c006d6c4487149a5c8f8cd400",
+    "wof:geomhash":"99534750f6f63a41e04c87e4a494e553",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092025231,
-    "wof:lastmodified":1627522103,
+    "wof:lastmodified":1695886576,
     "wof:name":"Talet El-Esmailiah",
     "wof:parent_id":85670989,
     "wof:placetype":"county",

--- a/data/109/202/526/5/1092025265.geojson
+++ b/data/109/202/526/5/1092025265.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029506,
-    "geom:area_square_m":312313839.468543,
+    "geom:area_square_m":312313839.468564,
     "geom:bbox":"31.219556,31.019702,31.491782,31.21938",
     "geom:latitude":31.127347,
     "geom:longitude":31.343939,
@@ -110,9 +110,10 @@
     "wof:concordances":{
         "hasc:id":"EG.DQ.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897538,
-    "wof:geomhash":"203eff311fd47c8d81b12ac2f9d050f8",
+    "wof:geomhash":"ca37c6294e198989196169b5c644264f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1092025265,
-    "wof:lastmodified":1627522103,
+    "wof:lastmodified":1695886576,
     "wof:name":"Talkha",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/202/532/9/1092025329.geojson
+++ b/data/109/202/532/9/1092025329.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013495,
-    "geom:area_square_m":148868277.672226,
+    "geom:area_square_m":148868277.672227,
     "geom:bbox":"31.330063,26.792985,31.495229,26.936326",
     "geom:latitude":26.856914,
     "geom:longitude":31.415455,
@@ -146,9 +146,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SJ.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897540,
-    "wof:geomhash":"e779f1a3dcbb94c513006ce2d3a026d8",
+    "wof:geomhash":"1d4b52cf65a73f30e0ace8fc5dbedb3e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":1092025329,
-    "wof:lastmodified":1602720869,
+    "wof:lastmodified":1695886296,
     "wof:name":"Tama",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/202/538/1/1092025381.geojson
+++ b/data/109/202/538/1/1092025381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011966,
-    "geom:area_square_m":126891352.749149,
+    "geom:area_square_m":126891352.749172,
     "geom:bbox":"31.475336,30.906017,31.692859,31.004275",
     "geom:latitude":30.954459,
     "geom:longitude":31.594581,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.DQ.TM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897542,
-    "wof:geomhash":"eed59d9f0b74931749f0811517eb1651",
+    "wof:geomhash":"9135788c5edf38b1880b4c6c3cd45215",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092025381,
-    "wof:lastmodified":1627522103,
+    "wof:lastmodified":1695886576,
     "wof:name":"Tamy El-Amdeed",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/202/541/7/1092025417.geojson
+++ b/data/109/202/541/7/1092025417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02828,
-    "geom:area_square_m":304466091.513337,
+    "geom:area_square_m":304466091.513312,
     "geom:bbox":"30.855659,29.368692,31.081624,29.556292",
     "geom:latitude":29.463076,
     "geom:longitude":30.976327,
@@ -82,12 +82,13 @@
     "wof:concordances":{
         "hasc:id":"EG.FY.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897543,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"f4c493b6f5000fbf5a74f88342dc8f01",
+    "wof:geomhash":"be9c17025584030db451de327256097c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1092025417,
-    "wof:lastmodified":1627522103,
+    "wof:lastmodified":1695886576,
     "wof:name":"Tamyah",
     "wof:parent_id":85671037,
     "wof:placetype":"county",

--- a/data/109/202/546/5/1092025465.geojson
+++ b/data/109/202/546/5/1092025465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029866,
-    "geom:area_square_m":317147655.666528,
+    "geom:area_square_m":317147655.666532,
     "geom:bbox":"30.872634,30.702417,31.113131,30.914834",
     "geom:latitude":30.820139,
     "geom:longitude":30.980231,
@@ -203,9 +203,10 @@
     "wof:concordances":{
         "hasc:id":"EG.GH.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897544,
-    "wof:geomhash":"42b74894e12e58446dfd3cb4d28a2f58",
+    "wof:geomhash":"df5fd78993fc2e66650d32048e17fcb2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -215,7 +216,7 @@
         }
     ],
     "wof:id":1092025465,
-    "wof:lastmodified":1602720869,
+    "wof:lastmodified":1695886296,
     "wof:name":"Tanta",
     "wof:parent_id":85670985,
     "wof:placetype":"county",

--- a/data/109/202/551/3/1092025513.geojson
+++ b/data/109/202/551/3/1092025513.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000904,
-    "geom:area_square_m":9941177.088189,
+    "geom:area_square_m":9941177.088192,
     "geom:bbox":"31.145294,27.155371,31.19223,27.193843",
     "geom:latitude":27.170192,
     "geom:longitude":31.170137,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.AT.AF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897546,
-    "wof:geomhash":"dd06e8b09a2eb51dff84d98a8784789d",
+    "wof:geomhash":"ca0a1b5f1465c8c407ae218e31b1e480",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092025513,
-    "wof:lastmodified":1627522089,
+    "wof:lastmodified":1695886557,
     "wof:name":"Tany Asiut",
     "wof:parent_id":85671069,
     "wof:placetype":"county",

--- a/data/109/202/555/3/1092025553.geojson
+++ b/data/109/202/555/3/1092025553.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023887,
-    "geom:area_square_m":253134274.029414,
+    "geom:area_square_m":253134274.029416,
     "geom:bbox":"33.589551,30.914649,33.723274,31.125152",
     "geom:latitude":31.018586,
     "geom:longitude":33.656166,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SS.FO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897547,
-    "wof:geomhash":"c2b0fa07e2abb9107ecaed6c64eab83f",
+    "wof:geomhash":"388c8dc89953bb4b860833d1f78e208f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092025553,
-    "wof:lastmodified":1627522094,
+    "wof:lastmodified":1695886565,
     "wof:name":"Tany El-Areesh",
     "wof:parent_id":85671093,
     "wof:placetype":"county",

--- a/data/109/202/559/1/1092025591.geojson
+++ b/data/109/202/559/1/1092025591.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001886,
-    "geom:area_square_m":20068703.567295,
+    "geom:area_square_m":20068703.567306,
     "geom:bbox":"32.244506,30.58639,32.320217,30.640875",
     "geom:latitude":30.622371,
     "geom:longitude":32.277254,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IS.IS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897549,
-    "wof:geomhash":"4d91c280a1bdf664bd52ce7700e965c4",
+    "wof:geomhash":"58473843de88a0416881416b7385fa98",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092025591,
-    "wof:lastmodified":1627522088,
+    "wof:lastmodified":1695886554,
     "wof:name":"Tany El-Esmailiah",
     "wof:parent_id":85670989,
     "wof:placetype":"county",

--- a/data/109/202/563/7/1092025637.geojson
+++ b/data/109/202/563/7/1092025637.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00107,
-    "geom:area_square_m":11346291.072891,
+    "geom:area_square_m":11346291.072893,
     "geom:bbox":"31.139606,30.973268,31.186225,31.005365",
     "geom:latitude":30.987505,
     "geom:longitude":31.161307,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.GH.MF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897550,
-    "wof:geomhash":"6e7f06176700bafb4935fb5023e484da",
+    "wof:geomhash":"68cb8bfb35c89b4d8dc1d008cae76e77",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092025637,
-    "wof:lastmodified":1627522095,
+    "wof:lastmodified":1695886566,
     "wof:name":"Tany El-Mahallah El-Kobra",
     "wof:parent_id":85670985,
     "wof:placetype":"county",

--- a/data/109/202/568/1/1092025681.geojson
+++ b/data/109/202/568/1/1092025681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002077,
-    "geom:area_square_m":22004414.677527,
+    "geom:area_square_m":22004414.677528,
     "geom:bbox":"31.362386,31.005254,31.441654,31.059465",
     "geom:latitude":31.037224,
     "geom:longitude":31.394983,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.DQ.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897552,
-    "wof:geomhash":"b9a0162dd6b3e97c7b0a57dc8e0f1ebb",
+    "wof:geomhash":"fa2f53ba2570f8be9b19f19e25dca72c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092025681,
-    "wof:lastmodified":1627522099,
+    "wof:lastmodified":1695886572,
     "wof:name":"Tany El-Mansourah",
     "wof:parent_id":85671017,
     "wof:placetype":"county",

--- a/data/109/202/571/3/1092025713.geojson
+++ b/data/109/202/571/3/1092025713.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000408,
-    "geom:area_square_m":4347293.242499,
+    "geom:area_square_m":4347293.2425,
     "geom:bbox":"31.510165,30.585499,31.535141,30.622295",
     "geom:latitude":30.602675,
     "geom:longitude":31.523566,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SQ.ZS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897553,
-    "wof:geomhash":"9741d1ab6939242c0ddaebc6c5057a5f",
+    "wof:geomhash":"460d61a1a20b9c73de3553794a673ae7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092025713,
-    "wof:lastmodified":1627522104,
+    "wof:lastmodified":1695886577,
     "wof:name":"Tany El-Zaqazeeq",
     "wof:parent_id":85671007,
     "wof:placetype":"county",

--- a/data/109/202/576/1/1092025761.geojson
+++ b/data/109/202/576/1/1092025761.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00191,
-    "geom:area_square_m":20441224.550835,
+    "geom:area_square_m":20441224.550833,
     "geom:bbox":"31.280069,30.007293,31.339734,30.079696",
     "geom:latitude":30.046346,
     "geom:longitude":31.313662,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.NS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897554,
-    "wof:geomhash":"1bceee881015e7fc8be95fa6edaa7600",
+    "wof:geomhash":"7cdfbb3e8eeed9718ddac46c8a6bf054",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092025761,
-    "wof:lastmodified":1627522100,
+    "wof:lastmodified":1695886573,
     "wof:name":"Tany Nasr City",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/580/7/1092025807.geojson
+++ b/data/109/202/580/7/1092025807.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001601,
-    "geom:area_square_m":17117986.373702,
+    "geom:area_square_m":17117986.373703,
     "geom:bbox":"31.26066,30.109059,31.312182,30.161813",
     "geom:latitude":30.13822,
     "geom:longitude":31.282289,
@@ -82,12 +82,13 @@
     "wof:concordances":{
         "hasc:id":"EG.QL.SS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897556,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"50a38c8704d5273602b8d7d0f7c39d60",
+    "wof:geomhash":"91029cec9b2b0f87ea09b2bd650b935c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1092025807,
-    "wof:lastmodified":1627522102,
+    "wof:lastmodified":1695886575,
     "wof:name":"Tany Shobra El-Kheimah",
     "wof:parent_id":85671003,
     "wof:placetype":"county",

--- a/data/109/202/585/3/1092025853.geojson
+++ b/data/109/202/585/3/1092025853.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000297,
-    "geom:area_square_m":3283088.869154,
+    "geom:area_square_m":3283088.869153,
     "geom:bbox":"31.680693,26.516058,31.710916,26.533582",
     "geom:latitude":26.524862,
     "geom:longitude":31.695463,
@@ -82,9 +82,10 @@
     "wof:concordances":{
         "hasc:id":"EG.SJ.SS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897557,
-    "wof:geomhash":"677a12010911f8968f24f712eea42fcf",
+    "wof:geomhash":"f6003c16779ed575b465579023d2ddbc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1092025853,
-    "wof:lastmodified":1627522103,
+    "wof:lastmodified":1695886576,
     "wof:name":"Tany Sohag",
     "wof:parent_id":85671079,
     "wof:placetype":"county",

--- a/data/109/202/589/3/1092025893.geojson
+++ b/data/109/202/589/3/1092025893.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001016,
-    "geom:area_square_m":10789944.450608,
+    "geom:area_square_m":10789944.45061,
     "geom:bbox":"30.971336,30.766139,31.029047,30.793851",
     "geom:latitude":30.779407,
     "geom:longitude":30.999012,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.GH.TS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897559,
-    "wof:geomhash":"6e7d1d29fe0a513835994c6762c4bdb9",
+    "wof:geomhash":"52bc8971535508bee76d5a06a965298a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092025893,
-    "wof:lastmodified":1627522103,
+    "wof:lastmodified":1695886577,
     "wof:name":"Tany Tanta",
     "wof:parent_id":85670985,
     "wof:placetype":"county",

--- a/data/109/202/593/9/1092025939.geojson
+++ b/data/109/202/593/9/1092025939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021847,
-    "geom:area_square_m":233145714.223402,
+    "geom:area_square_m":233145714.223408,
     "geom:bbox":"31.058952,30.262158,31.301851,30.418634",
     "geom:latitude":30.341407,
     "geom:longitude":31.195795,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QL.TO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897560,
-    "wof:geomhash":"0fbddaac523468171a50913349f48c85",
+    "wof:geomhash":"05afc382c5db8a2593c1547807e99c2e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092025939,
-    "wof:lastmodified":1627522103,
+    "wof:lastmodified":1695886577,
     "wof:name":"Tookh",
     "wof:parent_id":85671003,
     "wof:placetype":"county",

--- a/data/109/202/598/7/1092025987.geojson
+++ b/data/109/202/598/7/1092025987.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002168,
-    "geom:area_square_m":23230192.556192,
+    "geom:area_square_m":23230192.556191,
     "geom:bbox":"31.266521,29.916435,31.334702,29.961456",
     "geom:latitude":29.940141,
     "geom:longitude":31.303819,
@@ -381,9 +381,10 @@
     "wof:concordances":{
         "hasc:id":"EG.QH.TO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897562,
-    "wof:geomhash":"906a33d4c80919ea6e7c55c829b6d47c",
+    "wof:geomhash":"d4ab5a41f12352c949e14c16affd4ea1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -393,7 +394,7 @@
         }
     ],
     "wof:id":1092025987,
-    "wof:lastmodified":1602720869,
+    "wof:lastmodified":1695886296,
     "wof:name":"Torah",
     "wof:parent_id":85670999,
     "wof:placetype":"county",

--- a/data/109/202/602/3/1092026023.geojson
+++ b/data/109/202/602/3/1092026023.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000924,
-    "geom:area_square_m":9859903.852713,
+    "geom:area_square_m":9859903.852714,
     "geom:bbox":"30.156269,30.29301,30.493508,30.473979",
     "geom:latitude":30.377517,
     "geom:longitude":30.365405,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"EG.IK.UO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897563,
-    "wof:geomhash":"8b01a84b1be8d2be7096160fb3f6a749",
+    "wof:geomhash":"aac03f3805c0b010461014ce7e94922a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092026023,
-    "wof:lastmodified":1627522100,
+    "wof:lastmodified":1695886573,
     "wof:name":"Wady El-Natroon",
     "wof:parent_id":85671035,
     "wof:placetype":"county",

--- a/data/109/202/606/9/1092026069.geojson
+++ b/data/109/202/606/9/1092026069.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021096,
-    "geom:area_square_m":224240549.578326,
+    "geom:area_square_m":224240549.578306,
     "geom:bbox":"31.149961,30.579593,31.281841,30.877445",
     "geom:latitude":30.725228,
     "geom:longitude":31.214578,
@@ -119,9 +119,10 @@
     "wof:concordances":{
         "hasc:id":"EG.GH.ZE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"EG",
     "wof:created":1473897565,
-    "wof:geomhash":"7fdf1d2dba22ef2c83b98c053b961a0a",
+    "wof:geomhash":"03268d70cdf0bbf13c5a2916dea219a5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1092026069,
-    "wof:lastmodified":1627522104,
+    "wof:lastmodified":1695886577,
     "wof:name":"Zefta",
     "wof:parent_id":85670985,
     "wof:placetype":"county",

--- a/data/856/325/81/85632581.geojson
+++ b/data/856/325/81/85632581.geojson
@@ -1301,6 +1301,7 @@
         "hasc:id":"EG",
         "icao:code":"SU",
         "ioc:id":"EGY",
+        "iso:code":"EG",
         "itu:id":"EGY",
         "loc:id":"n80061791",
         "m49:code":"818",
@@ -1315,6 +1316,7 @@
         "wk:page":"Egypt",
         "wmo:id":"EG"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:country_alpha3":"EGY",
     "wof:geom_alt":[
@@ -1338,7 +1340,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694639637,
+    "wof:lastmodified":1695881299,
     "wof:name":"Egypt",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/709/85/85670985.geojson
+++ b/data/856/709/85/85670985.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.189605,
-    "geom:area_square_m":2011953774.025019,
+    "geom:area_square_m":2011953774.024878,
     "geom:bbox":"30.742124,30.579593,31.31872,31.163715",
     "geom:latitude":30.889277,
     "geom:longitude":31.048261,
@@ -368,15 +368,17 @@
         "gn:id":361294,
         "gp:id":2345227,
         "hasc:id":"EG.GH",
+        "iso:code":"EG-GH",
         "iso:id":"EG-GH",
         "qs_pg:id":900673,
         "wd:id":"Q30835"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f580e4cb5f908bea6cb4ec066fef5ccc",
+    "wof:geomhash":"d1e29b5cdd173bebe99dec17768b864f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -391,7 +393,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876033,
+    "wof:lastmodified":1695884927,
     "wof:name":"Al Gharbiyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/709/89/85670989.geojson
+++ b/data/856/709/89/85670989.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.465144,
-    "geom:area_square_m":4953577695.929847,
+    "geom:area_square_m":4953577372.52872,
     "geom:bbox":"31.754936,30.039858,32.776384,31.060552",
     "geom:latitude":30.541752,
     "geom:longitude":32.318856,
@@ -360,15 +360,17 @@
         "gn:id":361056,
         "gp:id":2345229,
         "hasc:id":"EG.IS",
+        "iso:code":"EG-IS",
         "iso:id":"EG-IS",
         "qs_pg:id":890534,
         "wd:id":"Q31067"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e8d1dc8554ca4578ba9ece526af97e53",
+    "wof:geomhash":"6c081c2cc9ae46d0cac4a00280b0cb41",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -383,7 +385,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876032,
+    "wof:lastmodified":1695884927,
     "wof:name":"Al Isma`iliyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/709/95/85670995.geojson
+++ b/data/856/709/95/85670995.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.147315,
-    "geom:area_square_m":1569443350.069794,
+    "geom:area_square_m":1569443350.06971,
     "geom:bbox":"30.788554,30.199385,31.261058,30.747286",
     "geom:latitude":30.504934,
     "geom:longitude":30.998207,
@@ -350,15 +350,17 @@
         "gn:id":360689,
         "gp:id":2345231,
         "hasc:id":"EG.MF",
+        "iso:code":"EG-MNF",
         "iso:id":"EG-MNF",
         "qs_pg:id":890535,
         "wd:id":"Q30786"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f953090aac5fdbe4b7fe7728ccbc3ddf",
+    "wof:geomhash":"0f47d7e543e0d33ac1d5e9e0dc6a52ac",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -373,7 +375,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876032,
+    "wof:lastmodified":1695884927,
     "wof:name":"Al Minufiyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/709/99/85670999.geojson
+++ b/data/856/709/99/85670999.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.67415,
-    "geom:area_square_m":7243333353.152201,
+    "geom:area_square_m":7243333255.768863,
     "geom:bbox":"31.221838,28.993527,31.90529,30.346436",
     "geom:latitude":29.664976,
     "geom:longitude":31.597689,
@@ -391,16 +391,18 @@
         "gn:id":360631,
         "gp:id":2345233,
         "hasc:id":"EG.QH",
+        "iso:code":"EG-C",
         "iso:id":"EG-C",
         "qs_pg:id":1312310,
         "wd:id":"Q30805"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "meso",
         "quattroshapes"
     ],
-    "wof:geomhash":"514ac5e2b9aefbd40cf5fd1c8bbbaa67",
+    "wof:geomhash":"dda276a8b69b0800039d664d46b32d64",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -415,7 +417,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876033,
+    "wof:lastmodified":1695884927,
     "wof:name":"Al Qahirah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/03/85671003.geojson
+++ b/data/856/710/03/85671003.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.10909,
-    "geom:area_square_m":1164574256.552361,
+    "geom:area_square_m":1164574353.080853,
     "geom:bbox":"31.058952,30.102809,31.622314,30.613527",
     "geom:latitude":30.30586,
     "geom:longitude":31.272107,
@@ -348,16 +348,18 @@
         "gn:id":360621,
         "gp:id":2345234,
         "hasc:id":"EG.QL",
+        "iso:code":"EG-KB",
         "iso:id":"EG-KB",
         "qs_pg:id":500332,
         "wd:id":"Q31075"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "meso",
         "quattroshapes"
     ],
-    "wof:geomhash":"95560e5270e159ecb687182bca371855",
+    "wof:geomhash":"af70753152fc2c3e7e05b9bf07e309c2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -372,7 +374,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876035,
+    "wof:lastmodified":1695884927,
     "wof:name":"Al Qalyubiyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/07/85671007.geojson
+++ b/data/856/710/07/85671007.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.483075,
-    "geom:area_square_m":5136632297.995827,
+    "geom:area_square_m":5136632206.351063,
     "geom:bbox":"31.266602,30.223334,32.213823,31.130349",
     "geom:latitude":30.691167,
     "geom:longitude":31.753846,
@@ -355,16 +355,18 @@
         "gn:id":360016,
         "gp:id":2345236,
         "hasc:id":"EG.SQ",
+        "iso:code":"EG-SHR",
         "iso:id":"EG-SHR",
         "qs_pg:id":237283,
         "unlc:id":"EG-SHR",
         "wd:id":"Q31074"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f0ae57d5bbdee701e49e17b69cae72f1",
+    "wof:geomhash":"564a9e85528bb4e97ffb2c66428a2e1a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -379,7 +381,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876038,
+    "wof:lastmodified":1695884928,
     "wof:name":"Ash Sharqiyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/13/85671013.geojson
+++ b/data/856/710/13/85671013.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.86575,
-    "geom:area_square_m":9301744891.18165,
+    "geom:area_square_m":9301744891.071531,
     "geom:bbox":"31.832933,28.976233,32.808671,30.285552",
     "geom:latitude":29.665933,
     "geom:longitude":32.237747,
@@ -354,16 +354,18 @@
         "gn:id":359797,
         "gp:id":2345237,
         "hasc:id":"EG.SW",
+        "iso:code":"EG-SUZ",
         "iso:id":"EG-SUZ",
         "qs_pg:id":237284,
         "unlc:id":"EG-SUZ",
         "wd:id":"Q31070"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"80aa1da92c5daed1d6974fbd917acdf9",
+    "wof:geomhash":"5e7463efd43aaa8799ffb9791281b4c7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -378,7 +380,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876041,
+    "wof:lastmodified":1695884928,
     "wof:name":"As Suways",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/17/85671017.geojson
+++ b/data/856/710/17/85671017.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.329554,
-    "geom:area_square_m":3489138337.321108,
+    "geom:area_square_m":3489138337.321225,
     "geom:bbox":"31.219556,30.589724,32.088591,31.515551",
     "geom:latitude":31.103546,
     "geom:longitude":31.519728,
@@ -360,16 +360,18 @@
         "gn:id":361849,
         "gp:id":2345223,
         "hasc:id":"EG.DQ",
+        "iso:code":"EG-DK",
         "iso:id":"EG-DK",
         "qs_pg:id":900670,
         "unlc:id":"EG-DK",
         "wd:id":"Q31068"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b457319cd9886fbb6d449fce214067fc",
+    "wof:geomhash":"7561323afa2ca98b6cc3e01fad09c22b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -384,7 +386,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876037,
+    "wof:lastmodified":1695884927,
     "wof:name":"Ad Daqahliyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/21/85671021.geojson
+++ b/data/856/710/21/85671021.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.117488,
-    "geom:area_square_m":1243879077.286828,
+    "geom:area_square_m":1243880136.681236,
     "geom:bbox":"32.044398,30.911736,32.592786,31.369647",
     "geom:latitude":31.106682,
     "geom:longitude":32.30583,
@@ -353,16 +353,18 @@
         "gn:id":358617,
         "gp:id":2345241,
         "hasc:id":"EG.BS",
+        "iso:code":"EG-PTS",
         "iso:id":"EG-PTS",
         "qs_pg:id":1087040,
         "unlc:id":"EG-PTS",
         "wd:id":"Q31079"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8b0710b9d465db084990386c0b171e86",
+    "wof:geomhash":"bc39a0755745dd6b8a2de112c38e31d9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -377,7 +379,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876037,
+    "wof:lastmodified":1695884927,
     "wof:name":"Bur Sa`id",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/25/85671025.geojson
+++ b/data/856/710/25/85671025.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.088166,
-    "geom:area_square_m":930676828.462511,
+    "geom:area_square_m":930677328.856441,
     "geom:bbox":"31.483703,31.1673,32.063652,31.535778",
     "geom:latitude":31.385107,
     "geom:longitude":31.769091,
@@ -357,16 +357,18 @@
         "gn:id":358044,
         "gp:id":2345242,
         "hasc:id":"EG.DT",
+        "iso:code":"EG-DT",
         "iso:id":"EG-DT",
         "qs_pg:id":1288982,
         "unlc:id":"EG-DT",
         "wd:id":"Q30644"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5fde8842f610a5d80c29646c4c91c6f9",
+    "wof:geomhash":"37b50ff00715ab8814c4b11b2d58f49a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -381,7 +383,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876042,
+    "wof:lastmodified":1695884928,
     "wof:name":"Dumyat",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/31/85671031.geojson
+++ b/data/856/710/31/85671031.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":14.977033,
-    "geom:area_square_m":160883956246.932983,
+    "geom:area_square_m":160883956246.9328,
     "geom:bbox":"24.692899,27.641235,30.336177,31.670021",
     "geom:latitude":29.672968,
     "geom:longitude":26.983103,
@@ -357,16 +357,18 @@
         "gn:id":352603,
         "gp:id":2345244,
         "hasc:id":"EG.MT",
+        "iso:code":"EG-MT",
         "iso:id":"EG-MT",
         "qs_pg:id":896785,
         "unlc:id":"EG-MT",
         "wd:id":"Q30682"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b99419c005cc0c94b084078f9a9ea5c9",
+    "wof:geomhash":"da1e144f75f9530ee52fac250228f667",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -381,7 +383,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876038,
+    "wof:lastmodified":1695884928,
     "wof:name":"Matruh",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/35/85671035.geojson
+++ b/data/856/710/35/85671035.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.126319,
-    "geom:area_square_m":11986764770.718773,
+    "geom:area_square_m":11986764411.203335,
     "geom:bbox":"29.631109,29.87708,30.872711,31.502089",
     "geom:latitude":30.615159,
     "geom:longitude":30.298099,
@@ -366,15 +366,17 @@
         "gn:id":361370,
         "gp:id":2345225,
         "hasc:id":"EG.BH",
+        "iso:code":"EG-BH",
         "iso:id":"EG-BH",
         "qs_pg:id":900671,
         "wd:id":"Q30630"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"179e26f68b88cefb43066bde5778fa83",
+    "wof:geomhash":"073ebb73c8405f431e350c356e0f16d3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -389,7 +391,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876035,
+    "wof:lastmodified":1695884927,
     "wof:name":"Al Buhayrah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/37/85671037.geojson
+++ b/data/856/710/37/85671037.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.164872,
-    "geom:area_square_m":1777396272.939793,
+    "geom:area_square_m":1777396272.939788,
     "geom:bbox":"30.404651,29.089022,31.081624,29.556292",
     "geom:latitude":29.326791,
     "geom:longitude":30.797677,
@@ -324,16 +324,18 @@
         "gn:id":361323,
         "gp:id":2345226,
         "hasc:id":"EG.FY",
+        "iso:code":"EG-FYM",
         "iso:id":"EG-FYM",
         "qs_pg:id":900672,
         "wd:id":"Q30656"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "meso",
         "quattroshapes"
     ],
-    "wof:geomhash":"bcc7401277b763954860e41319d1d31d",
+    "wof:geomhash":"f9a33100e627750cc29ec9baa157d38e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -348,7 +350,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876039,
+    "wof:lastmodified":1695884928,
     "wof:name":"Al Fayyum",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/41/85671041.geojson
+++ b/data/856/710/41/85671041.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.256166,
-    "geom:area_square_m":2719783584.143685,
+    "geom:area_square_m":2719783584.143626,
     "geom:bbox":"29.356734,30.26259,30.087226,31.329745",
     "geom:latitude":30.837802,
     "geom:longitude":29.742322,
@@ -389,16 +389,18 @@
         "gn:id":361059,
         "gp:id":2345228,
         "hasc:id":"EG.IK",
+        "iso:code":"EG-ALX",
         "iso:id":"EG-ALX",
         "qs_pg:id":206445,
         "wd:id":"Q29943",
         "wk:page":"Alexandria Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cfe521f2a73c1dceb744cc0a78a40a3d",
+    "wof:geomhash":"783a9be106179795da8b3d2e12536fde",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -413,7 +415,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876039,
+    "wof:lastmodified":1695884504,
     "wof:name":"Al Iskandariyah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/47/85671047.geojson
+++ b/data/856/710/47/85671047.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.20584,
-    "geom:area_square_m":34720525326.562546,
+    "geom:area_square_m":34720525571.629028,
     "geom:bbox":"27.41771,27.644231,31.335292,30.342287",
     "geom:latitude":28.842013,
     "geom:longitude":29.409065,
@@ -374,16 +374,18 @@
         "gn:id":360997,
         "gp:id":2345230,
         "hasc:id":"EG.JZ",
+        "iso:code":"EG-GZ",
         "iso:id":"EG-GZ",
         "qs_pg:id":1312303,
         "wd:id":"Q30832"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "meso",
         "quattroshapes"
     ],
-    "wof:geomhash":"f9ec1ce77cfb603eaea3ebcbe8ff99aa",
+    "wof:geomhash":"e07ce5b9b0e327889541674f36707aa0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -398,7 +400,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876041,
+    "wof:lastmodified":1695884928,
     "wof:name":"Al Jizah",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/49/85671049.geojson
+++ b/data/856/710/49/85671049.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.691351,
-    "geom:area_square_m":18443007238.724518,
+    "geom:area_square_m":18443007245.37421,
     "geom:bbox":"28.466408,27.576852,30.903162,28.77903",
     "geom:latitude":28.130037,
     "geom:longitude":30.007302,
@@ -373,15 +373,17 @@
         "gn:id":360688,
         "gp:id":2345232,
         "hasc:id":"EG.MN",
+        "iso:code":"EG-MN",
         "iso:id":"EG-MN",
         "qs_pg:id":1087037,
         "wd:id":"Q30675"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"272f232c851aa138a592a7116581e786",
+    "wof:geomhash":"f9cc07595573cbfeb6c1c1bcb7f79a8e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -396,7 +398,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876041,
+    "wof:lastmodified":1695884928,
     "wof:name":"Al Minya",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/53/85671053.geojson
+++ b/data/856/710/53/85671053.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.395028,
-    "geom:area_square_m":4272762229.615591,
+    "geom:area_square_m":4272762229.615609,
     "geom:bbox":"29.773333,28.698053,31.231901,29.454202",
     "geom:latitude":28.979892,
     "geom:longitude":30.638469,
@@ -412,16 +412,18 @@
         "gn:id":359171,
         "gp:id":2345240,
         "hasc:id":"EG.BN",
+        "iso:code":"EG-BNS",
         "iso:id":"EG-BNS",
         "qs_pg:id":1087039,
         "unlc:id":"EG-BNS",
         "wd:id":"Q30683"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"746e59f1bc0084cf4e22b59f46160e14",
+    "wof:geomhash":"abc644792e7e7f3f16d0aeb9472b8431",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -436,7 +438,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876038,
+    "wof:lastmodified":1695884366,
     "wof:name":"Bani Suwayf",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/57/85671057.geojson
+++ b/data/856/710/57/85671057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.358045,
-    "geom:area_square_m":3781928777.468909,
+    "geom:area_square_m":3781929087.574087,
     "geom:bbox":"30.345215,31.007646,31.370612,31.599093",
     "geom:latitude":31.324842,
     "geom:longitude":30.902975,
@@ -343,16 +343,18 @@
         "gn:id":354500,
         "gp:id":2345243,
         "hasc:id":"EG.KS",
+        "iso:code":"EG-KFS",
         "iso:id":"EG-KFS",
         "qs_pg:id":424966,
         "unlc:id":"EG-KFS",
         "wd:id":"Q30946"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b7a15277f648a5dfaf3385b26b2941cc",
+    "wof:geomhash":"83ef71bb0ca4a58d5d3774b0fc7a690c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -367,7 +369,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876035,
+    "wof:lastmodified":1695884927,
     "wof:name":"Kafr ash Shaykh",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/61/85671061.geojson
+++ b/data/856/710/61/85671061.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.754516,
-    "geom:area_square_m":42608333885.667503,
+    "geom:area_square_m":42608333885.667381,
     "geom:bbox":"31.315317,21.999872,33.466563,25.306825",
     "geom:latitude":23.376013,
     "geom:longitude":32.791903,
@@ -473,16 +473,18 @@
         "gn:id":359787,
         "gp:id":2345238,
         "hasc:id":"EG.AN",
+        "iso:code":"EG-ASN",
         "iso:id":"EG-ASN",
         "qs_pg:id":1312305,
         "unlc:id":"EG-ASN",
         "wd:id":"Q29937"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9d8520d72c571e12f4c8e318b4c96f09",
+    "wof:geomhash":"16c73545cbd1fd60a65381d3ba531d2f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -497,7 +499,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876034,
+    "wof:lastmodified":1695884927,
     "wof:name":"Aswan",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/69/85671069.geojson
+++ b/data/856/710/69/85671069.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.13625,
-    "geom:area_square_m":1498043078.796514,
+    "geom:area_square_m":1498043078.79658,
     "geom:bbox":"30.668685,26.827849,31.509232,27.615094",
     "geom:latitude":27.229453,
     "geom:longitude":31.072969,
@@ -459,16 +459,18 @@
         "gn:id":359781,
         "gp:id":2345239,
         "hasc:id":"EG.AT",
+        "iso:code":"EG-AST",
         "iso:id":"EG-AST",
         "qs_pg:id":1087038,
         "unlc:id":"EG-AST",
         "wd:id":"Q29965"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4ce05b9e6584850fd47fe8a206ba1858",
+    "wof:geomhash":"2adc8bfa1b1056c52a9a3e7f40eb3d85",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -483,7 +485,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876036,
+    "wof:lastmodified":1695884504,
     "wof:name":"Asyut",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/71/85671071.geojson
+++ b/data/856/710/71/85671071.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":39.937156,
-    "geom:area_square_m":448219375812.418091,
+    "geom:area_square_m":448219375812.419189,
     "geom:bbox":"25.0,22.0,32.743283,27.67669",
     "geom:latitude":24.772256,
     "geom:longitude":28.559904,
@@ -348,15 +348,17 @@
         "gn:id":360483,
         "gp:id":2345235,
         "hasc:id":"EG.WJ",
+        "iso:code":"EG-WAD",
         "iso:id":"EG-WAD",
         "qs_pg:id":896788,
         "wd:id":"Q30650"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4b49ff36a31381b11f5c2f5aff7bb41e",
+    "wof:geomhash":"891bc630cc9fb7b3bed1acdc1c5c7ec1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -371,7 +373,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876040,
+    "wof:lastmodified":1695884928,
     "wof:name":"Al Wadi at Jadid",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/75/85671075.geojson
+++ b/data/856/710/75/85671075.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.144673,
-    "geom:area_square_m":1608998672.935899,
+    "geom:area_square_m":1608998672.935831,
     "geom:bbox":"31.982322,25.181794,32.849786,26.20964",
     "geom:latitude":25.915561,
     "geom:longitude":32.487045,
@@ -355,16 +355,18 @@
         "gn:id":350546,
         "gp:id":2345245,
         "hasc:id":"EG.QN",
+        "iso:code":"EG-KN",
         "iso:id":"EG-KN",
         "qs_pg:id":896789,
         "unlc:id":"EG-KN",
         "wd:id":"Q31065"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ed36c24e98c3c0550a18862fee6fd769",
+    "wof:geomhash":"fe56edda5cb8f472de8b21e0f1869624",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -379,7 +381,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876037,
+    "wof:lastmodified":1695884927,
     "wof:name":"Qina",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/79/85671079.geojson
+++ b/data/856/710/79/85671079.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.14834,
-    "geom:area_square_m":1641160003.101382,
+    "geom:area_square_m":1641160003.101404,
     "geom:bbox":"31.330063,26.105413,32.217719,26.936326",
     "geom:latitude":26.525889,
     "geom:longitude":31.704916,
@@ -351,16 +351,18 @@
         "gn:id":347794,
         "gp:id":2345246,
         "hasc:id":"EG.SJ",
+        "iso:code":"EG-SHG",
         "iso:id":"EG-SHG",
         "qs_pg:id":424967,
         "unlc:id":"EG-SHG",
         "wd:id":"Q30669"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7a52f6295f629885bbe609cca14f5dfb",
+    "wof:geomhash":"b472395c2e1bd0ada7c548226b7f087d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -375,7 +377,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876039,
+    "wof:lastmodified":1695884504,
     "wof:name":"Suhaj",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/85/85671085.geojson
+++ b/data/856/710/85/85671085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":15.57328,
-    "geom:area_square_m":173735792830.733429,
+    "geom:area_square_m":173735792824.078796,
     "geom:bbox":"30.733735,21.999539,36.907099,29.313712",
     "geom:latitude":25.466001,
     "geom:longitude":33.51608,
@@ -354,15 +354,17 @@
         "gn:id":361468,
         "gp:id":2345224,
         "hasc:id":"EG.BA",
+        "iso:code":"EG-BA",
         "iso:id":"EG-BA",
         "qs_pg:id":900676,
         "wd:id":"Q30831"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3fcf19b3a27a37b029ca3122ead56426",
+    "wof:geomhash":"c6d8634e27569993b20e0485e78e384c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -377,7 +379,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876040,
+    "wof:lastmodified":1695884928,
     "wof:name":"Al Bahr al Ahmar",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/89/85671089.geojson
+++ b/data/856/710/89/85671089.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.711456,
-    "geom:area_square_m":29316778871.062233,
+    "geom:area_square_m":29316778871.063099,
     "geom:bbox":"32.618492,27.726487,34.906926,29.94119",
     "geom:latitude":29.021,
     "geom:longitude":33.798794,
@@ -361,16 +361,18 @@
         "gn:id":355182,
         "gp:id":2345247,
         "hasc:id":"EG.JS",
+        "iso:code":"EG-JS",
         "iso:id":"EG-JS",
         "qs_pg:id":1312306,
         "unlc:id":"EG-JS",
         "wd:id":"Q30815"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b631dcb2e644211c5aa86db8ba5b623d",
+    "wof:geomhash":"544333e43f154a7167e94451518085e3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -385,7 +387,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876036,
+    "wof:lastmodified":1695884928,
     "wof:name":"Janub Sina'",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/93/85671093.geojson
+++ b/data/856/710/93/85671093.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.645616,
-    "geom:area_square_m":28203277705.933731,
+    "geom:area_square_m":28203277206.669621,
     "geom:bbox":"32.584006,29.509729,34.89731,31.326074",
     "geom:latitude":30.440799,
     "geom:longitude":33.716551,
@@ -351,16 +351,18 @@
         "gn:id":349401,
         "gp:id":2345248,
         "hasc:id":"EG.SS",
+        "iso:code":"EG-SIN",
         "iso:id":"EG-SIN",
         "qs_pg:id":890537,
         "unlc:id":"EG-SIN",
         "wd:id":"Q30662"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bd61cd49547367048617cd4892758552",
+    "wof:geomhash":"86f5e0b65ec3b215ce34d7644e337579",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -375,7 +377,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876036,
+    "wof:lastmodified":1695884928,
     "wof:name":"Shamal Sina'",
     "wof:parent_id":85632581,
     "wof:placetype":"region",

--- a/data/856/710/97/85671097.geojson
+++ b/data/856/710/97/85671097.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021342,
-    "geom:area_square_m":237815754.047008,
+    "geom:area_square_m":237815754.047035,
     "geom:bbox":"32.463708,25.540774,32.737329,25.817437",
     "geom:latitude":25.687654,
     "geom:longitude":32.625967,
@@ -330,16 +330,18 @@
         "gn:id":7603259,
         "gp:id":56120896,
         "hasc:id":"EG.UQ",
+        "iso:code":"EG-LX",
         "iso:id":"EG-LX",
         "qs_pg:id":230277,
         "unlc:id":"EG-LX",
         "wd:id":"Q30797"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"EG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a95bfb4c480c202b55f9cb8ba18af23e",
+    "wof:geomhash":"41036c33e552d9c9c659e493903e7319",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -354,7 +356,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690876039,
+    "wof:lastmodified":1695884928,
     "wof:name":"Luxor",
     "wof:parent_id":85632581,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.